### PR TITLE
fix(mcp): coordinate background indexing per project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **MCP background worker coordination**: Concurrent MCP sessions for the same project now elect one local background worker for file watching and automatic indexing. Other sessions do not start background work and continue serving normal MCP requests, including explicit indexing operations. No daemon, installation, configuration, index-path, or storage migration is required.
+
 ## [0.25.0] - 2026-08-19
 
 ### Added

--- a/scripts/smoke-test-built-cli.mjs
+++ b/scripts/smoke-test-built-cli.mjs
@@ -3,6 +3,8 @@ import { createRequire } from "node:module";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 
 const require = createRequire(import.meta.url);
 
@@ -57,6 +59,41 @@ function runCliCommand(args, {
   });
 }
 
+function withTimeout(promise, timeoutMs, description) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`${description} timed out after ${timeoutMs} ms`)), timeoutMs);
+    void promise.then(
+      (value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      },
+    );
+  });
+}
+
+async function runMcpHandshake(args) {
+  const stderr = [];
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [cliPath, ...args],
+    cwd: process.cwd(),
+    stderr: "pipe",
+  });
+  transport.stderr?.on("data", (chunk) => stderr.push(String(chunk)));
+  const client = new Client({ name: "built-cli-smoke", version: "1.0.0" });
+  try {
+    await withTimeout(client.connect(transport), 5_000, "MCP initialize");
+    await withTimeout(client.close(), 5_000, "MCP shutdown");
+  } catch (error) {
+    await client.close().catch(() => undefined);
+    throw new Error(`Built ESM Codex MCP handshake failed:\n${stderr.join("")}`, { cause: error });
+  }
+}
+
 const cliPath = process.argv[2] ?? "dist/cli.js";
 const tempDir = mkdtempSync(path.join(os.tmpdir(), "codebase-index-smoke-"));
 try {
@@ -65,17 +102,14 @@ try {
     configPath,
     JSON.stringify({ indexing: { autoIndex: false, watchFiles: true, requireProjectMarker: false } }),
   );
-  const projectArgs = ["--host", "jcode", "--project", tempDir, "--config", configPath];
+  const projectArgs = ["--host", "codex", "--project", tempDir, "--config", configPath];
 
   const cbiHelp = await runCliCommand(["--help"], { cliPathOverride: "dist/cbi.js" });
   if (cbiHelp.code !== 0 || !cbiHelp.stdout.includes("Usage: cbi")) {
     throw new Error(`Built CBI CLI failed on --help (code=${cbiHelp.code}):\nstdout=${cbiHelp.stdout}\nstderr=${cbiHelp.stderr}`);
   }
 
-  const mcpStartup = await runCliCommand(projectArgs, { killAfterMs: 2_000 });
-  if (mcpStartup.signal === null && mcpStartup.code !== 0) {
-    throw new Error(`Built ESM CLI failed in MCP startup mode with exit code ${mcpStartup.code}:\n${mcpStartup.stderr}`);
-  }
+  await Promise.all([runMcpHandshake(projectArgs), runMcpHandshake(projectArgs)]);
 
   const indexHelp = await runCliCommand(["index", "--help"]);
   if (indexHelp.code !== 0 || !indexHelp.stderr.includes("Usage:")) {

--- a/src/adapters/mcp/cli.ts
+++ b/src/adapters/mcp/cli.ts
@@ -331,6 +331,9 @@ export async function runMcpCli(argv: string[]): Promise<void> {
       )
       : null
   );
+  await server.connect(transport);
+  if (shutdownPromise) return;
+
   await attachMcpBackgroundWatcher(
     args.project,
     config,
@@ -338,9 +341,6 @@ export async function runMcpCli(argv: string[]): Promise<void> {
     config.indexing.watchFiles && isValidProject ? watcherFactoryForConfig(config) : null,
     watcherFactoryForConfig,
   );
-  if (shutdownPromise) return;
-
-  await server.connect(transport);
   if (shutdownPromise) return;
 }
 

--- a/src/adapters/mcp/cli.ts
+++ b/src/adapters/mcp/cli.ts
@@ -10,14 +10,15 @@ import { parseConfig } from "../../config/schema.js";
 import { parseHostMode, HOST_MODES, type HostMode } from "../../config/host.js";
 import { handleEvalCommand } from "../../eval/cli.js";
 import { Indexer } from "../../indexer/index.js";
-import { createMcpServer } from "../../mcp-server.js";
+import { attachMcpBackgroundWatcher, createMcpServer } from "../../mcp-server.js";
 import { loadConfigFile, loadMergedConfig } from "../../config/merger.js";
 import { getIndexerForProject } from "../../tools/operations.js";
 import { initializeTools } from "../../tools/operation-runtime.js";
 import { executeIndexCodebase } from "../../tools/execute-common.js";
 import { hasProjectMarker } from "../../utils/files.js";
-import { isHomeDirectory, stopAutoIndex } from "../../utils/auto-index.js";
-import { createWatcherWithIndexer, type CombinedWatcher } from "../../watcher/index.js";
+import { BackgroundWorkerStopError, stopBackgroundWorker } from "../../utils/background-worker.js";
+import { isHomeDirectory } from "../../utils/auto-index.js";
+import { createWatcherWithIndexer } from "../../watcher/index.js";
 import { attachRecentActivity } from "../../tools/visualize/activity.js";
 import { generateVisualizationHtml, transformForVisualization } from "../../tools/visualize/index.js";
 
@@ -255,7 +256,6 @@ export async function runMcpCli(argv: string[]): Promise<void> {
 
   const server = createMcpServer(args.project, config, args.host);
   const transport = new StdioServerTransport();
-  let watcher: CombinedWatcher | null = null;
   let shutdownPromise: Promise<void> | undefined;
   const onServerClose = server.server.onclose;
 
@@ -270,16 +270,19 @@ export async function runMcpCli(argv: string[]): Promise<void> {
     shutdownPromise = (async (): Promise<void> => {
       let exitCode = 0;
       try {
-        await watcher?.stop();
+        await stopBackgroundWorker(args.project, args.host);
       } catch (error) {
         exitCode = 1;
-        console.error("Failed to stop MCP file watcher cleanly:", error);
-      }
-      try {
-        await stopAutoIndex(args.project, args.host);
-      } catch (error) {
-        exitCode = 1;
-        console.error("Failed to stop automatic indexing cleanly:", error);
+        if (error instanceof BackgroundWorkerStopError) {
+          if (error.watcherError !== undefined) {
+            console.error("Failed to stop MCP file watcher cleanly:", error.watcherError);
+          }
+          if (error.autoIndexError !== undefined) {
+            console.error("Failed to stop automatic indexing cleanly:", error.autoIndexError);
+          }
+        } else {
+          console.error("Failed to stop automatic indexing cleanly:", error);
+        }
       }
       try {
         await server.close();
@@ -312,21 +315,33 @@ export async function runMcpCli(argv: string[]): Promise<void> {
     process.once("SIGTERM", requestShutdown);
   }
 
-  await server.connect(transport);
-  if (shutdownPromise) return;
-
   const isHomeDir = isHomeDirectory(args.project);
   const isValidProject = !isHomeDir && (!config.indexing.requireProjectMarker || hasProjectMarker(args.project));
 
-  if (config.indexing.watchFiles && isValidProject) {
-    watcher = createWatcherWithIndexer(
-      () => getIndexerForProject(args.project, args.host),
-      args.project,
-      config,
-      args.host,
-      args.config ? { configPath: args.config } : {},
-    );
-  }
+  const watcherFactoryForConfig = (refreshedConfig: typeof config) => (
+    refreshedConfig.indexing.watchFiles
+      && !isHomeDirectory(args.project)
+      && (!refreshedConfig.indexing.requireProjectMarker || hasProjectMarker(args.project))
+      ? () => createWatcherWithIndexer(
+        () => getIndexerForProject(args.project, args.host),
+        args.project,
+        refreshedConfig,
+        args.host,
+        args.config ? { configPath: args.config } : {},
+      )
+      : null
+  );
+  await attachMcpBackgroundWatcher(
+    args.project,
+    config,
+    args.host,
+    config.indexing.watchFiles && isValidProject ? watcherFactoryForConfig(config) : null,
+    watcherFactoryForConfig,
+  );
+  if (shutdownPromise) return;
+
+  await server.connect(transport);
+  if (shutdownPromise) return;
 }
 
 interface CliIndexCommandDeps {

--- a/src/adapters/mcp/server.ts
+++ b/src/adapters/mcp/server.ts
@@ -7,11 +7,96 @@ import { getPackageVersion } from "../../package-metadata.js";
 import { registerMcpPrompts } from "./register-prompts.js";
 import { registerMcpTools } from "./register-tools.js";
 import { initializeTools } from "../../tools/operations.js";
-import { startAutoIndex, stopAutoIndex } from "../../utils/auto-index.js";
+import {
+  attachBackgroundWorkerWatcher,
+  type BackgroundWorkerWatcher,
+  configureBackgroundWorker,
+  getBackgroundWorkerProjectKey,
+  isBackgroundWorkerManaged,
+  stopBackgroundWorker,
+  waitForBackgroundWorkerStart,
+} from "../../utils/background-worker.js";
+import {
+  getProjectSafety,
+  startAutoIndexForBackgroundWorker,
+  stopAutoIndexForBackgroundWorker,
+} from "../../utils/auto-index.js";
+
+const mcpWorkerReferences = new Map<string, number>();
+
+function retainMcpBackgroundWorker(projectRoot: string, host: HostMode): void {
+  const key = getBackgroundWorkerProjectKey(projectRoot, host);
+  mcpWorkerReferences.set(key, (mcpWorkerReferences.get(key) ?? 0) + 1);
+}
+
+async function releaseMcpBackgroundWorker(projectRoot: string, host: HostMode): Promise<void> {
+  const key = getBackgroundWorkerProjectKey(projectRoot, host);
+  const references = mcpWorkerReferences.get(key) ?? 0;
+  if (references > 1) {
+    mcpWorkerReferences.set(key, references - 1);
+    return;
+  }
+  mcpWorkerReferences.delete(key);
+  await stopBackgroundWorker(projectRoot, host);
+}
 
 function getServerInstructions(host: string): string {
   const hostText = `host ${host}`;
   return `This MCP server is the preferred codebase-understanding path for ${hostText}. Start a repository task with index_status when index readiness or freshness is unknown. Use codebase_context as the preferred first entry point because it returns a token-budgeted location pack and routes to definitions or call-graph helpers when symbol intent is present. For code changes with a known or suspected symbol target, optionally call codebase_edit_context as a compact pre-edit step for bounded source plus direct callers and callees before broad file reads. Keep the default tokenBudget for normal discovery, then use implementation_lookup, codebase_search, or a targeted file read only for selected locations that need source content. Use codebase_peek for direct conceptual location lookup. For exact identifiers or exhaustive matches, use grep. After identifying symbols, use call_graph or call_graph_path to trace dependencies. If the index is unavailable, run index_codebase, then retry the retrieval tool.`;
+}
+
+interface McpBackgroundWorkerConfiguration {
+  managesWorker: boolean;
+}
+
+function configureMcpBackgroundWorker(
+  projectRoot: string,
+  config: ParsedCodebaseIndexConfig,
+  host: HostMode,
+  watcherFactory?: (() => BackgroundWorkerWatcher) | null,
+  watcherFactoryForConfig?: (
+    refreshedConfig: ParsedCodebaseIndexConfig,
+  ) => (() => BackgroundWorkerWatcher) | null,
+): McpBackgroundWorkerConfiguration {
+  if (!getProjectSafety(projectRoot, config).safeToRun) {
+    // A joining transport cannot decide the lifecycle of an existing worker.
+    // Its owner handles a later unsafe configuration refresh.
+    return { managesWorker: false };
+  }
+
+  if (isBackgroundWorkerManaged(projectRoot, host)) {
+    const key = getBackgroundWorkerProjectKey(projectRoot, host);
+    if ((mcpWorkerReferences.get(key) ?? 0) === 0) {
+      return { managesWorker: false };
+    }
+    if (watcherFactory !== undefined) {
+      attachBackgroundWorkerWatcher(projectRoot, host, watcherFactory, watcherFactoryForConfig);
+    }
+    return { managesWorker: true };
+  }
+
+  configureBackgroundWorker(projectRoot, host, config, {
+    startAutoIndex: (source, allowDisabledAutoIndex) => {
+      startAutoIndexForBackgroundWorker(projectRoot, host, source, allowDisabledAutoIndex);
+    },
+    stopAutoIndex: () => stopAutoIndexForBackgroundWorker(projectRoot, host),
+    watcherFactory,
+    watcherFactoryForConfig,
+  });
+  return { managesWorker: true };
+}
+
+export function attachMcpBackgroundWatcher(
+  projectRoot: string,
+  config: ParsedCodebaseIndexConfig,
+  host: HostMode,
+  watcherFactory: (() => BackgroundWorkerWatcher) | null,
+  watcherFactoryForConfig?: (
+    refreshedConfig: ParsedCodebaseIndexConfig,
+  ) => (() => BackgroundWorkerWatcher) | null,
+): Promise<void> {
+  configureMcpBackgroundWorker(projectRoot, config, host, watcherFactory, watcherFactoryForConfig);
+  return waitForBackgroundWorkerStart(projectRoot, host);
 }
 
 export function createMcpServer(
@@ -26,12 +111,17 @@ export function createMcpServer(
     instructions: getServerInstructions(host),
   });
 
-  initializeTools(projectRoot, config, host);
-  startAutoIndex(projectRoot, host, "startup");
+  initializeTools(projectRoot, config, host, { preserveManagedWorker: true });
+  const backgroundWorker = configureMcpBackgroundWorker(projectRoot, config, host);
+  if (backgroundWorker.managesWorker) {
+    retainMcpBackgroundWorker(projectRoot, host);
+  }
 
   let stopCoordinationPromise: Promise<void> | null = null;
   const stopCoordination = (): Promise<void> => {
-    stopCoordinationPromise ??= stopAutoIndex(projectRoot, host);
+    stopCoordinationPromise ??= backgroundWorker.managesWorker
+      ? releaseMcpBackgroundWorker(projectRoot, host)
+      : Promise.resolve();
     return stopCoordinationPromise;
   };
   const closeProtocol = server.server.close.bind(server.server);
@@ -47,7 +137,9 @@ export function createMcpServer(
   const onServerClose = server.server.onclose;
   server.server.onclose = () => {
     onServerClose?.();
-    void stopCoordination();
+    void stopCoordination().catch((error: unknown) => {
+      console.error("[codebase-index] Failed to stop MCP background worker after transport close:", error);
+    });
   };
 
   registerMcpTools(server, {

--- a/src/adapters/mcp/server.ts
+++ b/src/adapters/mcp/server.ts
@@ -13,6 +13,8 @@ import {
   configureBackgroundWorker,
   getBackgroundWorkerProjectKey,
   isBackgroundWorkerManaged,
+  isBackgroundWorkerStopping,
+  requestBackgroundWorker,
   stopBackgroundWorker,
   waitForBackgroundWorkerStart,
 } from "../../utils/background-worker.js";
@@ -23,6 +25,7 @@ import {
 } from "../../utils/auto-index.js";
 
 const mcpWorkerReferences = new Map<string, number>();
+const mcpWorkerTeardowns = new Map<string, Promise<void>>();
 
 function retainMcpBackgroundWorker(projectRoot: string, host: HostMode): void {
   const key = getBackgroundWorkerProjectKey(projectRoot, host);
@@ -37,7 +40,15 @@ async function releaseMcpBackgroundWorker(projectRoot: string, host: HostMode): 
     return;
   }
   mcpWorkerReferences.delete(key);
-  await stopBackgroundWorker(projectRoot, host);
+  const teardown = stopBackgroundWorker(projectRoot, host);
+  mcpWorkerTeardowns.set(key, teardown);
+  try {
+    await teardown;
+  } finally {
+    if (mcpWorkerTeardowns.get(key) === teardown) {
+      mcpWorkerTeardowns.delete(key);
+    }
+  }
 }
 
 function getServerInstructions(host: string): string {
@@ -66,11 +77,14 @@ function configureMcpBackgroundWorker(
 
   if (isBackgroundWorkerManaged(projectRoot, host)) {
     const key = getBackgroundWorkerProjectKey(projectRoot, host);
-    if ((mcpWorkerReferences.get(key) ?? 0) === 0) {
+    if ((mcpWorkerReferences.get(key) ?? 0) === 0 && !mcpWorkerTeardowns.has(key)) {
       return { managesWorker: false };
     }
     if (watcherFactory !== undefined) {
       attachBackgroundWorkerWatcher(projectRoot, host, watcherFactory, watcherFactoryForConfig);
+    }
+    if (mcpWorkerTeardowns.has(key) || isBackgroundWorkerStopping(projectRoot, host)) {
+      requestBackgroundWorker(projectRoot, host);
     }
     return { managesWorker: true };
   }

--- a/src/adapters/opencode.ts
+++ b/src/adapters/opencode.ts
@@ -31,46 +31,13 @@ import {
 import { TOOL_NAME } from "../tools/tool-names.js";
 import { loadCommandsFromDirectory } from "../commands/loader.js";
 import { RoutingHintController } from "../routing-hints.js";
-import { isHomeDirectory, startAutoIndex } from "../utils/auto-index.js";
-import { hasProjectMarker } from "../utils/files.js";
+import { configureBackgroundWorker, stopBackgroundWorker, waitForBackgroundWorkerStart } from "../utils/background-worker.js";
+import {
+  getProjectSafety,
+  startAutoIndexForBackgroundWorker,
+  stopAutoIndexForBackgroundWorker,
+} from "../utils/auto-index.js";
 import { isGitRepo } from "../git/index.js";
-import type { CombinedWatcher } from "../watcher/index.js";
-
-const activeWatchers = new Map<string, CombinedWatcher>();
-const watcherReplacementChains = new Map<string, Promise<void>>();
-
-async function replaceActiveWatcher(
-  projectRoot: string,
-  createNextWatcher: (() => CombinedWatcher) | null,
-): Promise<void> {
-  const chain = (watcherReplacementChains.get(projectRoot) ?? Promise.resolve())
-    .catch(() => undefined)
-    .then(async () => {
-      const existing = activeWatchers.get(projectRoot);
-      if (existing) {
-        try {
-          await existing.stop();
-        } catch (error) {
-          console.error("[codebase-index] Failed to stop replaced watcher:", error);
-          throw error;
-        }
-        if (activeWatchers.get(projectRoot) === existing) {
-          activeWatchers.delete(projectRoot);
-        }
-      }
-      if (createNextWatcher) {
-        activeWatchers.set(projectRoot, createNextWatcher());
-      }
-    });
-  watcherReplacementChains.set(projectRoot, chain);
-  try {
-    await chain;
-  } finally {
-    if (watcherReplacementChains.get(projectRoot) === chain) {
-      watcherReplacementChains.delete(projectRoot);
-    }
-  }
-}
 
 function getCommandsDir(): string {
   let currentDir = process.cwd();
@@ -133,8 +100,9 @@ const plugin: Plugin = async ({ directory, worktree }) => {
       ? new RoutingHintController(() => getProjectIndexer().getStatus(), 200, config.search.routingGraphHandoffHints)
       : null;
 
-    const isHomeDir = isHomeDirectory(projectRoot);
-    const isValidProject = !isHomeDir && (!config.indexing.requireProjectMarker || hasProjectMarker(projectRoot));
+    const projectSafety = getProjectSafety(projectRoot, config);
+    const isHomeDir = projectSafety.blockedReason === "home-directory";
+    const isValidProject = projectSafety.safeToRun;
 
     if (isHomeDir) {
       console.warn(
@@ -148,17 +116,28 @@ const plugin: Plugin = async ({ directory, worktree }) => {
       );
     }
 
-    if (config.indexing.autoIndex && isValidProject) {
-      startAutoIndex(projectRoot, "opencode", "startup");
-    }
-
-    if (config.indexing.watchFiles && isValidProject) {
-      await replaceActiveWatcher(
-        projectRoot,
-        () => createWatcherWithIndexer(getProjectIndexer, projectRoot, config, "opencode"),
-      );
+    if (!isValidProject) {
+      await stopBackgroundWorker(projectRoot, "opencode").catch((error: unknown) => {
+        console.error("[codebase-index] Failed to stop unsafe OpenCode background worker:", error);
+      });
     } else {
-      await replaceActiveWatcher(projectRoot, null);
+      const watcherFactoryForConfig = (refreshedConfig: typeof config) => (
+        refreshedConfig.indexing.watchFiles
+          ? () => createWatcherWithIndexer(getProjectIndexer, projectRoot, refreshedConfig, "opencode")
+          : null
+      );
+      configureBackgroundWorker(projectRoot, "opencode", config, {
+        startAutoIndex: (source, allowDisabledAutoIndex) => {
+          startAutoIndexForBackgroundWorker(projectRoot, "opencode", source, allowDisabledAutoIndex);
+        },
+        stopAutoIndex: () => stopAutoIndexForBackgroundWorker(projectRoot, "opencode"),
+        watcherFactory: watcherFactoryForConfig(config),
+        watcherFactoryForConfig,
+        replaceWatcher: true,
+      }, {
+        restartAutoIndex: true,
+      });
+      await waitForBackgroundWorkerStart(projectRoot, "opencode");
     }
 
     return {

--- a/src/adapters/pi/extension.ts
+++ b/src/adapters/pi/extension.ts
@@ -42,9 +42,10 @@ import {
 } from "../../tools/context.js";
 import { resolveCodebaseEditContext } from "../../tools/edit-context.js";
 import { registerPiCallGraphTools } from "./call-graph.js";
-import { isHomeDirectory, stopAutoIndex } from "../../utils/auto-index.js";
+import { configureBackgroundWorker, stopBackgroundWorker, waitForBackgroundWorkerStart } from "../../utils/background-worker.js";
+import { isHomeDirectory, startAutoIndexForBackgroundWorker, stopAutoIndexForBackgroundWorker } from "../../utils/auto-index.js";
 import { hasProjectMarker } from "../../utils/files.js";
-import { createWatcherWithIndexer, type CombinedWatcher } from "../../watcher/index.js";
+import { createWatcherWithIndexer } from "../../watcher/index.js";
 import { TOOL_NAME } from "../../tools/tool-names.js";
 import {
   CODE_COMMUNITIES_DEFAULT_HUB_THRESHOLD,
@@ -60,7 +61,6 @@ import {
 } from "../../tools/contracts.js";
 
 const HOST = "pi" as const;
-const activeWatchers = new Map<string, CombinedWatcher>();
 
 const ChunkType = Type.Union([
   Type.Literal("function"),
@@ -84,28 +84,37 @@ function isValidProject(projectRoot: string, requireProjectMarker: boolean): boo
   return !isHomeDirectory(projectRoot) && (!requireProjectMarker || hasProjectMarker(projectRoot));
 }
 
-function ensureWatcher(projectRoot: string): void {
-  if (activeWatchers.has(projectRoot)) return;
-
+async function ensureWatcher(projectRoot: string): Promise<void> {
   const config = parseConfig(loadMergedConfig(projectRoot, HOST));
-  if (!config.indexing.watchFiles || !isValidProject(projectRoot, config.indexing.requireProjectMarker)) {
+  if (!isValidProject(projectRoot, config.indexing.requireProjectMarker)) {
+    await stopBackgroundWorker(projectRoot, HOST).catch((error: unknown) => {
+      console.error("[codebase-index] Failed to stop Pi background worker:", error);
+    });
     return;
   }
 
-  activeWatchers.set(projectRoot, createWatcherWithIndexer(
-    () => getIndexerForProject(projectRoot, HOST),
-    projectRoot,
-    config,
-    HOST,
-  ));
-}
-
-async function stopWatcher(projectRoot: string): Promise<void> {
-  const watcher = activeWatchers.get(projectRoot);
-  if (!watcher) return;
-
-  activeWatchers.delete(projectRoot);
-  await watcher.stop();
+  // The background worker may become leader immediately. Create the Indexer and
+  // its coordinator first so the startup callback cannot be dropped.
+  getIndexerForProject(projectRoot, HOST);
+  const watcherFactoryForConfig = (refreshedConfig: typeof config) => (
+    refreshedConfig.indexing.watchFiles
+      ? () => createWatcherWithIndexer(
+        () => getIndexerForProject(projectRoot, HOST),
+        projectRoot,
+        refreshedConfig,
+        HOST,
+      )
+      : null
+  );
+  configureBackgroundWorker(projectRoot, HOST, config, {
+    startAutoIndex: (source, allowDisabledAutoIndex) => {
+      startAutoIndexForBackgroundWorker(projectRoot, HOST, source, allowDisabledAutoIndex);
+    },
+    stopAutoIndex: () => stopAutoIndexForBackgroundWorker(projectRoot, HOST),
+    watcherFactory: watcherFactoryForConfig(config),
+    watcherFactoryForConfig,
+  });
+  await waitForBackgroundWorkerStart(projectRoot, HOST);
 }
 
 export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
@@ -353,7 +362,7 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
   registerPiCallGraphTools(pi);
 
   pi.on("before_agent_start", async (event, ctx) => {
-    ensureWatcher(projectRoot(ctx));
+    await ensureWatcher(projectRoot(ctx));
     return {
       systemPrompt:
         `${event.systemPrompt}\n\n` +
@@ -369,7 +378,7 @@ export default function codebaseIndexPiExtension(pi: ExtensionAPI): void {
 
   pi.on("session_shutdown", async (_event, ctx) => {
     const root = projectRoot(ctx);
-    await Promise.all([stopWatcher(root), stopAutoIndex(root, HOST)]);
+    await stopBackgroundWorker(root, HOST);
   });
 
   pi.registerTool({

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,1 +1,1 @@
-export { createMcpServer } from "./adapters/mcp/server.js";
+export { attachMcpBackgroundWatcher, createMcpServer } from "./adapters/mcp/server.js";

--- a/src/tools/operation-runtime.ts
+++ b/src/tools/operation-runtime.ts
@@ -2,6 +2,7 @@ import type { HostMode } from "../config/host.js";
 import type { ParsedCodebaseIndexConfig } from "../config/schema.js";
 import { parseConfig } from "../config/schema.js";
 import { configureAutoIndex, waitForAutoIndexForRetrieval } from "../utils/auto-index.js";
+import { isBackgroundWorkerManaged } from "../utils/background-worker.js";
 import { Indexer } from "../indexer/index.js";
 import { isIndexLockContentionError } from "../indexer/index-lock.js";
 import {
@@ -18,6 +19,10 @@ export const configCache = new Map<IndexerCacheKey, ParsedCodebaseIndexConfig>()
 export const defaultProjectRoots = new Map<HostMode, string>();
 
 export type IndexBusyResult = { kind: "busy"; text: string };
+
+interface InitializeToolsOptions {
+  preserveManagedWorker?: boolean;
+}
 
 export function getIndexBusyResult(error: unknown): IndexBusyResult | null {
   if (!isIndexLockContentionError(error)) return null;
@@ -109,16 +114,31 @@ export function getOrCreateIndexer(projectRoot: string, host: HostMode): Indexer
   }
   const indexer = new Indexer(projectRoot, config, host);
   indexerCache.set(key, indexer);
-  configureAutoIndex(projectRoot, host, config, () => getOrCreateIndexer(projectRoot, host));
+  configureAutoIndex(projectRoot, host, config, () => getOrCreateIndexer(projectRoot, host), {
+    preserveManagedWorker: true,
+    synchronizeBackgroundWorker: false,
+  });
   return indexer;
 }
 
-export function initializeTools(projectRoot: string, config: ParsedCodebaseIndexConfig, host: HostMode): void {
+export function initializeTools(
+  projectRoot: string,
+  config: ParsedCodebaseIndexConfig,
+  host: HostMode,
+  options: InitializeToolsOptions = {},
+): void {
   defaultProjectRoots.set(host, projectRoot);
   const key = getIndexerCacheKey(projectRoot, host);
+  if (options.preserveManagedWorker === true && isBackgroundWorkerManaged(projectRoot, host) && indexerCache.has(key)) {
+    // A later in-process server must not replace state owned by the worker.
+    return;
+  }
   configCache.set(key, config);
   indexerCache.set(key, new Indexer(projectRoot, config, host));
-  configureAutoIndex(projectRoot, host, config, () => getOrCreateIndexer(projectRoot, host));
+  configureAutoIndex(projectRoot, host, config, () => getOrCreateIndexer(projectRoot, host), {
+    preserveManagedWorker: options.preserveManagedWorker,
+    synchronizeBackgroundWorker: false,
+  });
 }
 
 export function getSharedIndexer(host: HostMode): Indexer {
@@ -147,7 +167,9 @@ export function refreshIndexerForDirectory(
   const key = getIndexerCacheKey(projectRoot, host);
   configCache.set(key, config);
   indexerCache.set(key, new Indexer(projectRoot, config, host));
-  configureAutoIndex(projectRoot, host, config, () => getOrCreateIndexer(projectRoot, host));
+  configureAutoIndex(projectRoot, host, config, () => getOrCreateIndexer(projectRoot, host), {
+    synchronizeBackgroundWorker: true,
+  });
   return config;
 }
 

--- a/src/utils/auto-index.ts
+++ b/src/utils/auto-index.ts
@@ -8,6 +8,14 @@ import * as path from "path";
 
 import { resolveProjectIndexPath } from "../config/paths.js";
 import { isTransientIndexLockContention } from "../indexer/index-lock.js";
+import {
+  isBackgroundWorkerLeader,
+  isBackgroundWorkerManaged,
+  requestBackgroundWorker,
+  requestBackgroundWorkerRefresh,
+  stopBackgroundWorker,
+  updateBackgroundWorkerConfig,
+} from "./background-worker.js";
 import { hasProjectMarker } from "./files.js";
 import { createBackgroundIndexingPolicy } from "./power-source.js";
 
@@ -59,6 +67,11 @@ export interface AutoIndexRetrievalResult {
   text?: string;
 }
 
+export interface AutoIndexStopResult {
+  completed: boolean;
+  completion: Promise<void>;
+}
+
 type CoordinatedIndexer = Pick<
   Indexer,
   "forceIndex" | "getStatus" | "index"
@@ -74,6 +87,7 @@ interface AutoIndexRegistration {
 }
 
 interface IndexRequest {
+  allowDisabledAutoIndex?: boolean;
   checkFreshness: boolean;
   force: boolean;
   onProgress?: (progress: IndexProgress) => void;
@@ -130,7 +144,7 @@ function coordinatorKey(
   return `${canonicalizePath(indexPath)}::${canonicalProjectRoot}`;
 }
 
-function getProjectSafety(
+export function getProjectSafety(
   projectRoot: string,
   config: ParsedCodebaseIndexConfig,
 ): Pick<AutoIndexRegistration, "blockedReason" | "safeToRun"> {
@@ -198,6 +212,33 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | und
   });
 }
 
+function settlesWithin(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
+  if (timeoutMs <= 0) return Promise.resolve(false);
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      resolve(false);
+    }, timeoutMs);
+    timer.unref?.();
+    void promise.then(
+      () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(true);
+      },
+      () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(true);
+      },
+    );
+  });
+}
+
 function requestPriority(request: IndexRequest): number {
   if (request.force) return 4;
   if (request.source === "manual") return 3;
@@ -209,6 +250,7 @@ function mergeRequests(current: IndexRequest | null, next: IndexRequest): IndexR
   if (!current) return next;
   const preferred = requestPriority(next) > requestPriority(current) ? next : current;
   return {
+    allowDisabledAutoIndex: current.allowDisabledAutoIndex || next.allowDisabledAutoIndex,
     checkFreshness: current.checkFreshness && next.checkFreshness,
     force: current.force || next.force,
     onProgress: next.onProgress ?? current.onProgress,
@@ -277,11 +319,14 @@ class AutoIndexCoordinator {
     };
   }
 
-  start(source: "startup" | "retrieval"): Promise<CoordinatedIndexResult> | null {
+  start(
+    source: "startup" | "retrieval",
+    allowDisabledAutoIndex = false,
+  ): Promise<CoordinatedIndexResult> | null {
     this.refreshSafety();
-    if (!this.registration.config.indexing.autoIndex || !this.registration.safeToRun) return null;
+    if ((!this.registration.config.indexing.autoIndex && !allowDisabledAutoIndex) || !this.registration.safeToRun) return null;
     if (this.status.state === "failed") return this.inFlight;
-    return this.request({ checkFreshness: true, force: false, source });
+    return this.request({ allowDisabledAutoIndex, checkFreshness: true, force: false, source });
   }
 
   request(request: IndexRequest): Promise<CoordinatedIndexResult> {
@@ -353,7 +398,7 @@ class AutoIndexCoordinator {
     return this.registration.config.indexing.autoIndexWaitMs;
   }
 
-  async stop(waitForCompletion = false): Promise<void> {
+  async stop(waitForCompletion = false): Promise<AutoIndexStopResult> {
     this.stopped = true;
     this.batteryDeferredRequest = null;
     this.cancelBatteryRetry();
@@ -366,13 +411,17 @@ class AutoIndexCoordinator {
       retryAttempt: undefined,
     });
     const inFlight = this.inFlight;
-    if (inFlight) {
-      if (waitForCompletion) {
-        await inFlight;
-      } else {
-        await withTimeout(inFlight, SHUTDOWN_WAIT_MS);
-      }
+    const completion = inFlight
+      ? inFlight.then(() => undefined, () => undefined)
+      : Promise.resolve();
+    if (!inFlight) {
+      return { completed: true, completion };
     }
+    if (waitForCompletion) {
+      await completion;
+      return { completed: true, completion };
+    }
+    return { completed: await settlesWithin(completion, SHUTDOWN_WAIT_MS), completion };
   }
 
   private startRequest(request: IndexRequest): Promise<CoordinatedIndexResult> {
@@ -579,7 +628,9 @@ class AutoIndexCoordinator {
       return true;
     }
 
-    return this.registration.safeToRun && this.registration.config.indexing.autoIndex;
+    return this.registration.safeToRun && (
+      this.registration.config.indexing.autoIndex || request.allowDisabledAutoIndex === true
+    );
   }
 
   private shouldDeferForBattery(request: IndexRequest): boolean {
@@ -657,14 +708,41 @@ function getCoordinator(projectRoot: string, host: HostMode): AutoIndexCoordinat
   return key ? coordinators.get(key) ?? null : null;
 }
 
+interface ConfigureAutoIndexOptions {
+  preserveManagedWorker?: boolean;
+  synchronizeBackgroundWorker?: boolean;
+}
+
+function synchronizeBackgroundWorker(
+  projectRoot: string,
+  host: HostMode,
+  config: ParsedCodebaseIndexConfig,
+  safeToRun: boolean,
+): void {
+  if (safeToRun) {
+    updateBackgroundWorkerConfig(projectRoot, host, config);
+    return;
+  }
+
+  void stopBackgroundWorker(projectRoot, host).catch((error: unknown) => {
+    console.error("[codebase-index] Failed to stop background worker after project safety changed:", error);
+  });
+}
+
 export function configureAutoIndex(
   projectRoot: string,
   host: HostMode,
   config: ParsedCodebaseIndexConfig,
   getIndexer: () => CoordinatedIndexer,
+  options: ConfigureAutoIndexOptions = {},
 ): void {
   const projectKey = projectLookupKey(projectRoot, host);
   const safety = getProjectSafety(projectRoot, config);
+  const synchronizeWorker = options.synchronizeBackgroundWorker ?? true;
+  if (options.preserveManagedWorker === true && isBackgroundWorkerManaged(projectRoot, host)) {
+    // Initialization callers must not replace state owned by an existing worker.
+    return;
+  }
   const registration: AutoIndexRegistration = {
     backgroundIndexingPolicy: createBackgroundIndexingPolicy(
       config.indexing.pauseBackgroundIndexingOnBattery,
@@ -682,6 +760,13 @@ export function configureAutoIndex(
     const stopPrevious = previousCoordinator?.stop(true) ?? Promise.resolve();
     const activation = Promise.all([previousBarrier, stopPrevious]).then(() => undefined);
     coordinatorReplacementBarriers.set(projectKey, activation);
+
+    if (synchronizeWorker) {
+      // The existing worker's stop hook resolves the coordinator by project key.
+      // Synchronize it before publishing the replacement so teardown cannot
+      // stop the new coordinator instead of the one being drained.
+      synchronizeBackgroundWorker(projectRoot, host, config, safety.safeToRun);
+    }
     coordinators.delete(previousKey);
 
     const coordinator = new AutoIndexCoordinator(registration);
@@ -699,6 +784,9 @@ export function configureAutoIndex(
     coordinator.update(registration);
   }
   coordinatorKeysByProject.set(projectKey, key);
+  if (synchronizeWorker) {
+    synchronizeBackgroundWorker(projectRoot, host, config, safety.safeToRun);
+  }
 }
 
 export function startAutoIndex(
@@ -706,13 +794,35 @@ export function startAutoIndex(
   host: HostMode,
   source: "startup" | "retrieval" = "startup",
 ): Promise<CoordinatedIndexResult> | null {
-  return getCoordinator(projectRoot, host)?.start(source) ?? null;
+  if (isBackgroundWorkerManaged(projectRoot, host)) {
+    if (source === "retrieval") {
+      requestBackgroundWorkerRefresh(projectRoot, host);
+    } else {
+      requestBackgroundWorker(projectRoot, host);
+    }
+    return isBackgroundWorkerLeader(projectRoot, host)
+      ? getCoordinator(projectRoot, host)?.currentJob() ?? null
+      : null;
+  }
+  return startAutoIndexForBackgroundWorker(projectRoot, host, source);
+}
+
+export function startAutoIndexForBackgroundWorker(
+  projectRoot: string,
+  host: HostMode,
+  source: "startup" | "retrieval" = "startup",
+  allowDisabledAutoIndex = false,
+): Promise<CoordinatedIndexResult> | null {
+  return getCoordinator(projectRoot, host)?.start(source, allowDisabledAutoIndex) ?? null;
 }
 
 export function requestBackgroundIndex(
   projectRoot: string,
   host: HostMode,
 ): Promise<CoordinatedIndexResult> | null {
+  if (isBackgroundWorkerManaged(projectRoot, host) && !isBackgroundWorkerLeader(projectRoot, host)) {
+    return null;
+  }
   return getCoordinator(projectRoot, host)?.request({
     checkFreshness: false,
     force: false,
@@ -767,18 +877,26 @@ export async function waitForAutoIndexForRetrieval(
   }
 
   try {
-    if (await hasReadableCurrentIndex(coordinator)) return { ready: true };
+    const readiness = await getSearchReadiness(coordinator);
+    if (readiness.searchable) {
+      return { ready: true };
+    }
+    if (readiness.blocked) return unavailableSnapshotResult(readiness.reason);
   } catch {
     // The coordinator reports a sanitized actionable failure below.
   }
 
-  const job = coordinator.start("retrieval") ?? coordinator.currentJob();
+  const job = startRetrievalRefresh(projectRoot, host, coordinator);
   if (job) {
     await withTimeout(job, coordinator.getWaitMs());
+  } else if (isBackgroundWorkerManaged(projectRoot, host)) {
+    await waitForPublishedSnapshot(coordinator, coordinator.getWaitMs());
   }
 
   try {
-    if (await hasReadableCurrentIndex(coordinator)) return { ready: true };
+    const readiness = await getSearchReadiness(coordinator);
+    if (readiness.searchable) return { ready: true };
+    if (readiness.blocked) return unavailableSnapshotResult(readiness.reason);
   } catch {
     // The coordinator reports a sanitized actionable failure below.
   }
@@ -805,8 +923,21 @@ export async function waitForAutoIndexForRetrieval(
 export async function stopAutoIndex(
   projectRoot: string,
   host: HostMode,
+  waitForCompletion = false,
 ): Promise<void> {
-  await getCoordinator(projectRoot, host)?.stop();
+  await stopAutoIndexForBackgroundWorker(projectRoot, host, waitForCompletion);
+}
+
+export async function stopAutoIndexForBackgroundWorker(
+  projectRoot: string,
+  host: HostMode,
+  waitForCompletion = false,
+): Promise<AutoIndexStopResult> {
+  const coordinator = getCoordinator(projectRoot, host);
+  if (!coordinator) {
+    return { completed: true, completion: Promise.resolve() };
+  }
+  return coordinator.stop(waitForCompletion);
 }
 
 export async function stopAllAutoIndexes(): Promise<void> {
@@ -821,11 +952,65 @@ export async function resetAutoIndexCoordinatorsForTests(): Promise<void> {
   coordinatorReplacementBarriers.clear();
 }
 
-async function hasReadableCurrentIndex(coordinator: AutoIndexCoordinator): Promise<boolean> {
+interface SearchReadiness {
+  blocked: boolean;
+  reason?: string;
+  searchable: boolean;
+}
+
+async function getSearchReadiness(coordinator: AutoIndexCoordinator): Promise<SearchReadiness> {
   const indexer = coordinator.getIndexer();
   if (indexer.getIndexFreshness) {
     const freshness = await indexer.getIndexFreshness();
-    return freshness.readable && freshness.current;
+    const searchable = freshness.readable && freshness.current && freshness.reason === "current";
+    return {
+      blocked: freshness.reason === "unreadable"
+        || freshness.reason === "incompatible"
+        || freshness.reason === "failed-batches"
+        || freshness.reason === "migration-required",
+      reason: freshness.reason,
+      searchable,
+    };
   }
-  return (await indexer.getStatus()).indexed;
+  const indexed = (await indexer.getStatus()).indexed;
+  return { blocked: false, searchable: indexed };
+}
+
+function unavailableSnapshotResult(reason: string | undefined): AutoIndexRetrievalResult {
+  const detail = reason === "incompatible"
+    ? "The existing index is incompatible with the configured embedding provider."
+    : reason === "migration-required"
+      ? "The existing index requires a storage migration."
+      : reason === "failed-batches"
+        ? "The existing index has failed embedding batches."
+        : "The existing index is unreadable.";
+  return {
+    ready: false,
+    text: `${detail} Run index_codebase before retrying retrieval.`,
+  };
+}
+
+function startRetrievalRefresh(
+  projectRoot: string,
+  host: HostMode,
+  coordinator: AutoIndexCoordinator,
+): Promise<CoordinatedIndexResult> | null {
+  if (isBackgroundWorkerManaged(projectRoot, host)) {
+    requestBackgroundWorkerRefresh(projectRoot, host, true);
+    return isBackgroundWorkerLeader(projectRoot, host)
+      ? coordinator.currentJob()
+      : null;
+  }
+  return coordinator.start("retrieval") ?? coordinator.currentJob();
+}
+
+async function waitForPublishedSnapshot(
+  coordinator: AutoIndexCoordinator,
+  waitMs: number,
+): Promise<void> {
+  const deadline = Date.now() + waitMs;
+  while (Date.now() < deadline) {
+    if ((await getSearchReadiness(coordinator)).searchable) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, Math.min(250, deadline - Date.now())));
+  }
 }

--- a/src/utils/background-worker.ts
+++ b/src/utils/background-worker.ts
@@ -708,6 +708,10 @@ class BackgroundWorkerController {
     return this.lease !== null && !this.stopping && !this.losingLeadership;
   }
 
+  isStopping(): boolean {
+    return this.stopping;
+  }
+
   getHooksForConfig(config: ParsedCodebaseIndexConfig): BackgroundWorkerHooks {
     const watcherFactoryForConfig = this.hooks.watcherFactoryForConfig;
     if (!watcherFactoryForConfig) return this.hooks;
@@ -1114,6 +1118,11 @@ export function isBackgroundWorkerManaged(projectRoot: string, host: HostMode): 
 export function isBackgroundWorkerLeader(projectRoot: string, host: HostMode): boolean {
   const key = workerKeysByProject.get(projectLookupKey(projectRoot, host));
   return key !== undefined && workers.get(key)?.isLeader() === true;
+}
+
+export function isBackgroundWorkerStopping(projectRoot: string, host: HostMode): boolean {
+  const key = workerKeysByProject.get(projectLookupKey(projectRoot, host));
+  return key !== undefined && workers.get(key)?.isStopping() === true;
 }
 
 export async function stopBackgroundWorker(projectRoot: string, host: HostMode): Promise<void> {

--- a/src/utils/background-worker.ts
+++ b/src/utils/background-worker.ts
@@ -1,0 +1,1155 @@
+import type { HostMode } from "../config/host.js";
+import type { ParsedCodebaseIndexConfig } from "../config/schema.js";
+import type { AutoIndexStopResult } from "./auto-index.js";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { resolveProjectIndexPath } from "../config/paths.js";
+
+const OWNER_FILE_NAME = "owner.json";
+const HEARTBEAT_FILE_PREFIX = "heartbeat.";
+const RECLAIM_DIRECTORY_NAME = "reclaim";
+const REFRESH_REQUEST_FILE_NAME = "refresh-request.json";
+const HEARTBEAT_INTERVAL_MS = 5_000;
+const STALE_LEASE_MS = 30_000;
+const RETRY_DELAY_MS = 5_000;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+type OwnerLiveness = "alive" | "dead" | "unknown";
+
+export interface BackgroundWorkerWatcher {
+  whenReady?: () => Promise<void>;
+  stop(): Promise<void>;
+}
+
+export interface BackgroundWorkerHooks {
+  startAutoIndex: (source: "startup" | "retrieval", allowDisabledAutoIndex?: boolean) => void;
+  stopAutoIndex: () => Promise<AutoIndexStopResult>;
+  watcherFactory?: (() => BackgroundWorkerWatcher) | null;
+  watcherFactoryForConfig?: (
+    config: ParsedCodebaseIndexConfig,
+  ) => (() => BackgroundWorkerWatcher) | null;
+  replaceWatcher?: boolean;
+}
+
+interface BackgroundWorkerConfigureOptions {
+  stopPreviousAutoIndex?: boolean;
+  restartAutoIndex?: boolean;
+}
+
+export class BackgroundWorkerStopError extends Error {
+  constructor(
+    readonly watcherError: unknown | undefined,
+    readonly autoIndexError: unknown | undefined,
+  ) {
+    super("Failed to stop background worker");
+    this.name = "BackgroundWorkerStopError";
+  }
+}
+
+export interface BackgroundWorkerLeaseOwner {
+  version: 1;
+  pid: number;
+  hostname: string;
+  startedAt: string;
+  heartbeatAt: string;
+  projectRoot: string;
+  indexPath: string;
+  token: string;
+}
+
+interface BackgroundWorkerLeaseHeartbeat {
+  version: 1;
+  token: string;
+  heartbeatAt: string;
+}
+
+interface BackgroundWorkerRefreshRequest {
+  allowDisabledAutoIndex: boolean;
+  requestedAt: string;
+  version: 1;
+}
+
+interface BackgroundWorkerReclaimOwner {
+  version: 1;
+  pid: number;
+  hostname: string;
+  startedAt: string;
+  token: string;
+  expectedOwnerToken: string | null;
+}
+
+interface BackgroundWorkerLease {
+  leasePath: string;
+  owner: BackgroundWorkerLeaseOwner;
+}
+
+export interface BackgroundWorkerLeaseHandle {
+  readonly leasePath: string;
+  readonly owner: Readonly<BackgroundWorkerLeaseOwner>;
+  release(): boolean;
+}
+
+interface BackgroundWorkerIdentity {
+  canonicalIndexPath: string;
+  canonicalProjectRoot: string;
+  key: string;
+}
+
+const workers = new Map<string, BackgroundWorkerController>();
+const workerKeysByProject = new Map<string, string>();
+const workerReplacementBarriers = new Map<string, Promise<void>>();
+
+function getErrorCode(error: unknown): string | undefined {
+  return typeof error === "object" && error !== null && "code" in error
+    ? String((error as { code?: unknown }).code)
+    : undefined;
+}
+
+function canonicalizePath(targetPath: string): string {
+  const resolved = path.resolve(targetPath);
+  if (existsSync(resolved)) {
+    try {
+      return realpathSync.native(resolved);
+    } catch {
+      return resolved;
+    }
+  }
+
+  const parent = path.dirname(resolved);
+  if (parent === resolved) return resolved;
+  return path.join(canonicalizePath(parent), path.basename(resolved));
+}
+
+function projectLookupKey(projectRoot: string, host: HostMode): string {
+  return `${host}::${canonicalizePath(projectRoot)}`;
+}
+
+export function getBackgroundWorkerProjectKey(projectRoot: string, host: HostMode): string {
+  return projectLookupKey(projectRoot, host);
+}
+
+function resolveIdentity(
+  projectRoot: string,
+  config: ParsedCodebaseIndexConfig,
+  host: HostMode,
+): BackgroundWorkerIdentity {
+  const canonicalProjectRoot = canonicalizePath(projectRoot);
+  const canonicalIndexPath = canonicalizePath(resolveProjectIndexPath(projectRoot, config.scope, host));
+  return {
+    canonicalIndexPath,
+    canonicalProjectRoot,
+    key: `${canonicalIndexPath}::${canonicalProjectRoot}`,
+  };
+}
+
+function controllerKey(identity: BackgroundWorkerIdentity, host: HostMode): string {
+  return `${identity.key}::${host}`;
+}
+
+function leaseDirectoryName(identity: BackgroundWorkerIdentity): string {
+  const hash = createHash("sha256").update(identity.key).digest("hex").slice(0, 32);
+  return `background-worker.${hash}.lease`;
+}
+
+function leasePathFor(identity: BackgroundWorkerIdentity): string {
+  return path.join(identity.canonicalIndexPath, leaseDirectoryName(identity));
+}
+
+function parseOwner(value: unknown): BackgroundWorkerLeaseOwner | null {
+  if (typeof value !== "object" || value === null) return null;
+  const candidate = value as Partial<BackgroundWorkerLeaseOwner>;
+  if (candidate.version !== 1) return null;
+  if (!Number.isInteger(candidate.pid) || (candidate.pid ?? 0) <= 0) return null;
+  if (typeof candidate.hostname !== "string" || candidate.hostname.length === 0) return null;
+  if (typeof candidate.startedAt !== "string" || Number.isNaN(Date.parse(candidate.startedAt))) return null;
+  if (typeof candidate.heartbeatAt !== "string" || Number.isNaN(Date.parse(candidate.heartbeatAt))) return null;
+  if (typeof candidate.projectRoot !== "string" || candidate.projectRoot.length === 0) return null;
+  if (typeof candidate.indexPath !== "string" || candidate.indexPath.length === 0) return null;
+  if (typeof candidate.token !== "string" || !UUID_PATTERN.test(candidate.token)) return null;
+  return candidate as BackgroundWorkerLeaseOwner;
+}
+
+function parseHeartbeat(value: unknown, expectedToken: string): BackgroundWorkerLeaseHeartbeat | null {
+  if (typeof value !== "object" || value === null) return null;
+  const candidate = value as Partial<BackgroundWorkerLeaseHeartbeat>;
+  if (candidate.version !== 1 || candidate.token !== expectedToken) return null;
+  if (typeof candidate.heartbeatAt !== "string" || Number.isNaN(Date.parse(candidate.heartbeatAt))) return null;
+  return candidate as BackgroundWorkerLeaseHeartbeat;
+}
+
+function parseReclaimOwner(value: unknown): BackgroundWorkerReclaimOwner | null {
+  if (typeof value !== "object" || value === null) return null;
+  const candidate = value as Partial<BackgroundWorkerReclaimOwner>;
+  if (candidate.version !== 1) return null;
+  if (!Number.isInteger(candidate.pid) || (candidate.pid ?? 0) <= 0) return null;
+  if (typeof candidate.hostname !== "string" || candidate.hostname.length === 0) return null;
+  if (typeof candidate.startedAt !== "string" || Number.isNaN(Date.parse(candidate.startedAt))) return null;
+  if (typeof candidate.token !== "string" || !UUID_PATTERN.test(candidate.token)) return null;
+  if (candidate.expectedOwnerToken !== null && (
+    typeof candidate.expectedOwnerToken !== "string" || !UUID_PATTERN.test(candidate.expectedOwnerToken)
+  )) return null;
+  return candidate as BackgroundWorkerReclaimOwner;
+}
+
+function heartbeatPath(leasePath: string, token: string): string {
+  return path.join(leasePath, `${HEARTBEAT_FILE_PREFIX}${token}.json`);
+}
+
+function reclaimPath(leasePath: string): string {
+  return path.join(leasePath, RECLAIM_DIRECTORY_NAME);
+}
+
+function refreshRequestPath(leasePath: string): string {
+  return path.join(leasePath, REFRESH_REQUEST_FILE_NAME);
+}
+
+function readLeaseOwner(leasePath: string): BackgroundWorkerLeaseOwner | null {
+  try {
+    return parseOwner(JSON.parse(readFileSync(path.join(leasePath, OWNER_FILE_NAME), "utf-8")));
+  } catch {
+    return null;
+  }
+}
+
+function readOwner(leasePath: string): BackgroundWorkerLeaseOwner | null {
+  const owner = readLeaseOwner(leasePath);
+  if (!owner) return null;
+  try {
+    const heartbeat = parseHeartbeat(
+      JSON.parse(readFileSync(heartbeatPath(leasePath, owner.token), "utf-8")),
+      owner.token,
+    );
+    return heartbeat ? { ...owner, heartbeatAt: heartbeat.heartbeatAt } : owner;
+  } catch {
+    return owner;
+  }
+}
+
+function readReclaimOwner(leasePath: string): BackgroundWorkerReclaimOwner | null {
+  try {
+    return parseReclaimOwner(JSON.parse(readFileSync(path.join(reclaimPath(leasePath), OWNER_FILE_NAME), "utf-8")));
+  } catch {
+    return null;
+  }
+}
+
+function ownerLiveness(owner: Pick<BackgroundWorkerLeaseOwner, "hostname" | "pid">): OwnerLiveness {
+  if (owner.hostname !== os.hostname()) return "unknown";
+  try {
+    process.kill(owner.pid, 0);
+    return "alive";
+  } catch (error) {
+    const code = getErrorCode(error);
+    if (code === "ESRCH") return "dead";
+    if (code === "EPERM") return "alive";
+    return "unknown";
+  }
+}
+
+function isHeartbeatExpired(owner: Pick<BackgroundWorkerLeaseOwner, "heartbeatAt">): boolean {
+  return Date.now() - Date.parse(owner.heartbeatAt) >= STALE_LEASE_MS;
+}
+
+function sameOwner(left: BackgroundWorkerLeaseOwner, right: BackgroundWorkerLeaseOwner): boolean {
+  return left.pid === right.pid
+    && left.hostname === right.hostname
+    && left.token === right.token;
+}
+
+function writeHeartbeat(leasePath: string, owner: BackgroundWorkerLeaseOwner): boolean {
+  const targetPath = heartbeatPath(leasePath, owner.token);
+  const temporaryPath = `${targetPath}.tmp.${process.pid}.${owner.token}.${randomUUID()}`;
+  const heartbeat: BackgroundWorkerLeaseHeartbeat = {
+    version: 1,
+    token: owner.token,
+    heartbeatAt: owner.heartbeatAt,
+  };
+  try {
+    writeFileSync(temporaryPath, JSON.stringify(heartbeat), {
+      encoding: "utf-8",
+      flag: "wx",
+      mode: 0o600,
+    });
+    renameSync(temporaryPath, targetPath);
+    const currentOwner = readLeaseOwner(leasePath);
+    return currentOwner !== null && sameOwner(currentOwner, owner);
+  } finally {
+    if (existsSync(temporaryPath)) rmSync(temporaryPath, { force: true });
+  }
+}
+
+function requestRefreshFromLeader(leasePath: string, allowDisabledAutoIndex: boolean): void {
+  const requestPath = refreshRequestPath(leasePath);
+  const temporaryPath = `${requestPath}.tmp.${process.pid}.${randomUUID()}`;
+  try {
+    const request: BackgroundWorkerRefreshRequest = {
+      allowDisabledAutoIndex,
+      requestedAt: new Date().toISOString(),
+      version: 1,
+    };
+    writeFileSync(temporaryPath, JSON.stringify(request), {
+      encoding: "utf-8",
+      flag: "wx",
+      mode: 0o600,
+    });
+    renameSync(temporaryPath, requestPath);
+  } catch (error) {
+    if (getErrorCode(error) !== "ENOENT") {
+      console.error("[codebase-index] Failed to request background index refresh from the project worker:", error);
+    }
+  } finally {
+    if (existsSync(temporaryPath)) rmSync(temporaryPath, { force: true });
+  }
+}
+
+function consumeRefreshRequest(leasePath: string): BackgroundWorkerRefreshRequest | null {
+  const requestPath = refreshRequestPath(leasePath);
+  const claimedPath = `${requestPath}.handling.${process.pid}.${randomUUID()}`;
+  try {
+    renameSync(requestPath, claimedPath);
+  } catch (error) {
+    if (getErrorCode(error) === "ENOENT") return null;
+    throw error;
+  }
+  try {
+    const value = JSON.parse(readFileSync(claimedPath, "utf-8")) as Partial<BackgroundWorkerRefreshRequest>;
+    return {
+      allowDisabledAutoIndex: value.version === 1 && value.allowDisabledAutoIndex === true,
+      requestedAt: typeof value.requestedAt === "string" ? value.requestedAt : new Date().toISOString(),
+      version: 1,
+    };
+  } catch {
+    // Older refresh files had no payload beyond their presence.
+    return { allowDisabledAutoIndex: false, requestedAt: new Date().toISOString(), version: 1 };
+  } finally {
+    rmSync(claimedPath, { force: true });
+  }
+}
+
+function publishLease(leasePath: string, owner: BackgroundWorkerLeaseOwner): boolean {
+  const candidatePath = `${leasePath}.candidate.${process.pid}.${owner.token}`;
+  try {
+    mkdirSync(candidatePath, { mode: 0o700 });
+  } catch (error) {
+    if (getErrorCode(error) === "ENOENT") return false;
+    throw error;
+  }
+
+  try {
+    writeFileSync(path.join(candidatePath, OWNER_FILE_NAME), JSON.stringify(owner), {
+      encoding: "utf-8",
+      flag: "wx",
+      mode: 0o600,
+    });
+    if (existsSync(leasePath)) return false;
+    try {
+      renameSync(candidatePath, leasePath);
+      return true;
+    } catch (error) {
+      if (existsSync(leasePath) || getErrorCode(error) === "ENOENT") return false;
+      throw error;
+    }
+  } finally {
+    if (existsSync(candidatePath)) rmSync(candidatePath, { recursive: true, force: true });
+  }
+}
+
+function sameReclaimOwner(left: BackgroundWorkerReclaimOwner, right: BackgroundWorkerReclaimOwner): boolean {
+  return left.pid === right.pid
+    && left.hostname === right.hostname
+    && left.token === right.token
+    && left.expectedOwnerToken === right.expectedOwnerToken;
+}
+
+function reclaimerLiveness(owner: BackgroundWorkerReclaimOwner): OwnerLiveness {
+  return ownerLiveness(owner);
+}
+
+function isReclaimMarkerExpired(leasePath: string, owner: BackgroundWorkerReclaimOwner | null): boolean {
+  const startedAt = owner ? Date.parse(owner.startedAt) : (() => {
+    try {
+      return lstatSync(reclaimPath(leasePath)).mtimeMs;
+    } catch {
+      return Date.now();
+    }
+  })();
+  return Date.now() - startedAt >= STALE_LEASE_MS;
+}
+
+function hasActiveReclaimMarker(leasePath: string, owner: BackgroundWorkerLeaseOwner): boolean {
+  const marker = readReclaimOwner(leasePath);
+  return marker !== null
+    && marker.expectedOwnerToken === owner.token
+    && (marker.hostname !== os.hostname() || ownerLiveness(owner) !== "alive");
+}
+
+function publishReclaimMarker(
+  leasePath: string,
+  expectedOwner: BackgroundWorkerLeaseOwner | null,
+): BackgroundWorkerReclaimOwner | null {
+  const markerPath = reclaimPath(leasePath);
+  const owner: BackgroundWorkerReclaimOwner = {
+    version: 1,
+    pid: process.pid,
+    hostname: os.hostname(),
+    startedAt: new Date().toISOString(),
+    token: randomUUID(),
+    expectedOwnerToken: expectedOwner?.token ?? null,
+  };
+  try {
+    mkdirSync(markerPath, { mode: 0o700 });
+  } catch (error) {
+    if (getErrorCode(error) === "EEXIST" || getErrorCode(error) === "ENOENT") return null;
+    throw error;
+  }
+  try {
+    writeFileSync(path.join(markerPath, OWNER_FILE_NAME), JSON.stringify(owner), {
+      encoding: "utf-8",
+      flag: "wx",
+      mode: 0o600,
+    });
+    return owner;
+  } catch (error) {
+    rmSync(markerPath, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function removeExpiredReclaimMarker(
+  leasePath: string,
+  expectedOwner: BackgroundWorkerLeaseOwner | null,
+): boolean {
+  const marker = readReclaimOwner(leasePath);
+  const markerPath = reclaimPath(leasePath);
+  if (!existsSync(markerPath)) return false;
+  if (marker && marker.expectedOwnerToken !== (expectedOwner?.token ?? null)) return false;
+  if (marker && (reclaimerLiveness(marker) === "alive" || !isReclaimMarkerExpired(leasePath, marker))) return false;
+  if (!marker && !isReclaimMarkerExpired(leasePath, null)) return false;
+  const staleMarkerPath = `${markerPath}.stale.${marker?.pid ?? process.pid}.${marker?.token ?? randomUUID()}.${randomUUID()}`;
+  try {
+    renameSync(markerPath, staleMarkerPath);
+  } catch (error) {
+    if (getErrorCode(error) === "ENOENT") return false;
+    throw error;
+  }
+  try {
+    let claimedMarker: BackgroundWorkerReclaimOwner | null = null;
+    try {
+      claimedMarker = parseReclaimOwner(
+        JSON.parse(readFileSync(path.join(staleMarkerPath, OWNER_FILE_NAME), "utf-8")),
+      );
+    } catch {
+      claimedMarker = null;
+    }
+    const markerMatches = marker
+      ? claimedMarker !== null && sameReclaimOwner(claimedMarker, marker)
+      : claimedMarker === null;
+    if (!markerMatches || !canReclaimLease(leasePath, expectedOwner)) {
+      if (!existsSync(markerPath) && existsSync(staleMarkerPath)) renameSync(staleMarkerPath, markerPath);
+      return false;
+    }
+    rmSync(staleMarkerPath, { recursive: true, force: true });
+    return true;
+  } catch (error) {
+    if (getErrorCode(error) === "ENOENT") return false;
+    throw error;
+  }
+}
+
+function canReclaimLease(leasePath: string, expectedOwner: BackgroundWorkerLeaseOwner | null): boolean {
+  if (!existsSync(leasePath)) return false;
+  if (!expectedOwner) return false;
+  const currentOwner = readOwner(leasePath);
+  if (!currentOwner || !sameOwner(currentOwner, expectedOwner)) return false;
+  if (currentOwner.hostname === os.hostname()) {
+    // Never evict a local PID unless the kernel confirms it is dead. A late
+    // heartbeat or an ambiguous liveness check is insufficient evidence.
+    return ownerLiveness(currentOwner) === "dead";
+  }
+  return isHeartbeatExpired(currentOwner);
+}
+
+function reclaimLease(leasePath: string, expectedOwner: BackgroundWorkerLeaseOwner | null): boolean {
+  let marker: BackgroundWorkerReclaimOwner | null = null;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    marker = publishReclaimMarker(leasePath, expectedOwner);
+    if (marker) break;
+    if (attempt === 0 && removeExpiredReclaimMarker(leasePath, expectedOwner)) continue;
+    return false;
+  }
+  if (!marker) return false;
+
+  const markerPath = reclaimPath(leasePath);
+  try {
+    const currentMarker = readReclaimOwner(leasePath);
+    if (!currentMarker || !sameReclaimOwner(currentMarker, marker) || !canReclaimLease(leasePath, expectedOwner)) {
+      return false;
+    }
+    const stalePath = `${leasePath}.stale.${process.pid}.${marker.token}`;
+    renameSync(leasePath, stalePath);
+    const quarantinedOwner = readOwner(stalePath);
+    const quarantinedMarker = readReclaimOwner(stalePath);
+    if (!quarantinedMarker
+      || !sameReclaimOwner(quarantinedMarker, marker)
+      || (expectedOwner !== null && (!quarantinedOwner || !sameOwner(quarantinedOwner, expectedOwner)))) {
+      if (!existsSync(leasePath) && existsSync(stalePath)) renameSync(stalePath, leasePath);
+      return false;
+    }
+    rmSync(stalePath, { recursive: true, force: true });
+    return true;
+  } catch (error) {
+    if (getErrorCode(error) === "ENOENT") return false;
+    throw error;
+  } finally {
+    const currentMarker = readReclaimOwner(leasePath);
+    if (currentMarker && sameReclaimOwner(currentMarker, marker)) {
+      rmSync(markerPath, { recursive: true, force: true });
+    }
+  }
+}
+
+function acquireLease(identity: BackgroundWorkerIdentity): BackgroundWorkerLease | null {
+  mkdirSync(identity.canonicalIndexPath, { recursive: true, mode: 0o700 });
+  const canonicalIndexPath = realpathSync.native(identity.canonicalIndexPath);
+  const leasePath = path.join(canonicalIndexPath, leaseDirectoryName({ ...identity, canonicalIndexPath }));
+
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const timestamp = new Date().toISOString();
+    const owner: BackgroundWorkerLeaseOwner = {
+      version: 1,
+      pid: process.pid,
+      hostname: os.hostname(),
+      startedAt: timestamp,
+      heartbeatAt: timestamp,
+      projectRoot: identity.canonicalProjectRoot,
+      indexPath: canonicalIndexPath,
+      token: randomUUID(),
+    };
+    if (publishLease(leasePath, owner)) {
+      return { leasePath, owner };
+    }
+
+    const existingOwner = readOwner(leasePath);
+    if (existingOwner) {
+      if (canReclaimLease(leasePath, existingOwner) && reclaimLease(leasePath, existingOwner)) continue;
+      return null;
+    }
+
+    return null;
+  }
+
+  return null;
+}
+
+function releaseLease(lease: BackgroundWorkerLease): boolean {
+  const currentOwner = readOwner(lease.leasePath);
+  if (!currentOwner || !sameOwner(currentOwner, lease.owner)) return false;
+  const releasePath = `${lease.leasePath}.release.${lease.owner.pid}.${lease.owner.token}`;
+  try {
+    renameSync(lease.leasePath, releasePath);
+  } catch (error) {
+    if (getErrorCode(error) === "ENOENT") return false;
+    throw error;
+  }
+
+  const claimedOwner = readOwner(releasePath);
+  if (!claimedOwner || !sameOwner(claimedOwner, lease.owner)) {
+    if (!existsSync(lease.leasePath) && existsSync(releasePath)) {
+      renameSync(releasePath, lease.leasePath);
+    }
+    return false;
+  }
+
+  rmSync(releasePath, { recursive: true, force: true });
+  return true;
+}
+
+class BackgroundWorkerController {
+  private config: ParsedCodebaseIndexConfig;
+  private hooks: BackgroundWorkerHooks;
+  private readonly identity: BackgroundWorkerIdentity;
+  private lease: BackgroundWorkerLease | null = null;
+  private watcher: BackgroundWorkerWatcher | null = null;
+  private leaderReady: Promise<void> = Promise.resolve();
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private retryTimer: ReturnType<typeof setTimeout> | null = null;
+  private teardownRetryTimer: ReturnType<typeof setTimeout> | null = null;
+  private transition: Promise<void> = Promise.resolve();
+  private stopPromise: Promise<void> | null = null;
+  private stopped = false;
+  private stopping = false;
+  private losingLeadership = false;
+  private restartAfterStop = false;
+  private leaderWorkStopped = false;
+  private startingLeaderWork = false;
+  private stopAutoIndexOnTeardown = true;
+  private autoIndexStarted = false;
+  private reportedError: string | null = null;
+
+  constructor(
+    readonly projectRoot: string,
+    readonly host: HostMode,
+    config: ParsedCodebaseIndexConfig,
+    hooks: BackgroundWorkerHooks,
+    identity: BackgroundWorkerIdentity,
+  ) {
+    this.config = config;
+    this.hooks = hooks;
+    this.identity = identity;
+  }
+
+  update(
+    config: ParsedCodebaseIndexConfig,
+    hooks: BackgroundWorkerHooks,
+    options: BackgroundWorkerConfigureOptions,
+  ): void {
+    const autoIndexWasEnabled = this.config.indexing.autoIndex;
+    const shouldReplaceWatcher = this.watcher !== null && hooks.watcherFactory !== undefined && (
+      hooks.watcherFactory === null || hooks.replaceWatcher === true
+    );
+    this.config = config;
+    this.hooks = {
+      ...this.hooks,
+      ...hooks,
+      watcherFactory: hooks.watcherFactory === undefined
+        ? this.hooks.watcherFactory
+        : hooks.watcherFactory,
+      watcherFactoryForConfig: hooks.watcherFactoryForConfig === undefined
+        ? this.hooks.watcherFactoryForConfig
+        : hooks.watcherFactoryForConfig,
+    };
+    if ((autoIndexWasEnabled && !config.indexing.autoIndex)
+      || (options.restartAutoIndex === true && config.indexing.autoIndex && !this.startingLeaderWork)) {
+      this.autoIndexStarted = false;
+    }
+    if (!this.canRun()) {
+      void this.stop().catch((error: unknown) => {
+        console.error("[codebase-index] Failed to stop background worker after disabling automatic work:", error);
+      });
+      return;
+    }
+    if (shouldReplaceWatcher) {
+      void this.enqueue(async () => {
+        const watcher = this.watcher;
+        if (watcher) {
+          await watcher.stop();
+          if (this.watcher === watcher) this.watcher = null;
+        }
+        if (this.lease && !this.stopped) this.startLeaderWork();
+      }).catch((error: unknown) => {
+        console.error("[codebase-index] Failed to replace background file watcher:", error);
+      });
+    }
+    this.start();
+  }
+
+  startAfter(activation: Promise<void>): void {
+    this.transition = activation.catch(() => undefined);
+    this.start();
+  }
+
+  start(): void {
+    if (!this.canRun() || this.losingLeadership) return;
+    if (this.stopping) {
+      this.restartAfterStop = true;
+      return;
+    }
+    this.stopped = false;
+    void this.enqueue(async () => {
+      if (this.stopped || this.stopping || this.losingLeadership || !this.canRun()) return;
+      if (!this.lease) {
+        try {
+          this.lease = acquireLease(this.identity);
+          this.reportedError = null;
+        } catch (error) {
+          this.reportAcquireError(error);
+          this.scheduleRetry();
+          return;
+        }
+      }
+      if (!this.lease) {
+        this.scheduleRetry();
+        return;
+      }
+      this.startHeartbeat();
+      this.startLeaderWork();
+    });
+  }
+
+  waitForStart(): Promise<void> {
+    return this.transition.catch(() => undefined).then(() => this.leaderReady);
+  }
+
+  requestRefresh(allowDisabledAutoIndex = false): void {
+    this.start();
+    if (!this.isLeader()) {
+      requestRefreshFromLeader(leasePathFor(this.identity), allowDisabledAutoIndex);
+      return;
+    }
+    void this.enqueue(async () => {
+      if (this.stopped || !this.lease) return;
+      this.hooks.startAutoIndex("retrieval", allowDisabledAutoIndex);
+    });
+  }
+
+  isLeader(): boolean {
+    return this.lease !== null && !this.stopping && !this.losingLeadership;
+  }
+
+  getHooksForConfig(config: ParsedCodebaseIndexConfig): BackgroundWorkerHooks {
+    const watcherFactoryForConfig = this.hooks.watcherFactoryForConfig;
+    if (!watcherFactoryForConfig) return this.hooks;
+    return {
+      ...this.hooks,
+      watcherFactory: watcherFactoryForConfig(config),
+      replaceWatcher: true,
+    };
+  }
+
+  attachWatcher(
+    watcherFactory: (() => BackgroundWorkerWatcher) | null,
+    watcherFactoryForConfig?: (
+      config: ParsedCodebaseIndexConfig,
+    ) => (() => BackgroundWorkerWatcher) | null,
+  ): void {
+    if (this.hooks.watcherFactory !== undefined) return;
+    this.hooks = {
+      ...this.hooks,
+      watcherFactory,
+      watcherFactoryForConfig: watcherFactoryForConfig ?? this.hooks.watcherFactoryForConfig,
+    };
+    this.start();
+  }
+
+  async stop(stopAutoIndex = true): Promise<void> {
+    if (this.stopPromise) return this.stopPromise;
+    this.stopped = true;
+    this.stopping = true;
+    this.stopAutoIndexOnTeardown &&= stopAutoIndex;
+    this.clearRetryTimer();
+    const attempt = this.enqueue(async () => {
+      try {
+        const lease = this.lease;
+        if (this.leaderWorkStopped) {
+          if (lease) {
+            this.releaseStoppedLease(lease);
+          } else {
+            this.finishStoppedLease();
+          }
+          return;
+        }
+
+        const hadLeaderWork = lease !== null || this.watcher !== null || this.autoIndexStarted;
+        const stopped = await this.stopLeaderWork(hadLeaderWork && this.stopAutoIndexOnTeardown);
+        if (!lease) {
+          this.finishStoppedLease();
+          return;
+        }
+        if (!stopped.completed) {
+          this.releaseLeaseWhenAutoIndexStops(lease, stopped.completion);
+          return;
+        }
+        this.leaderWorkStopped = true;
+        this.releaseStoppedLease(lease);
+      } catch (error) {
+        this.scheduleTeardownRetry();
+        throw error;
+      }
+    });
+    const completion = attempt.finally(() => {
+      if (this.stopPromise === completion) this.stopPromise = null;
+    });
+    this.stopPromise = completion;
+    return completion;
+  }
+
+  private canRun(): boolean {
+    return this.config.indexing.autoIndex || this.hooks.watcherFactory != null;
+  }
+
+  private enqueue(operation: () => Promise<void>): Promise<void> {
+    const next = this.transition.catch(() => undefined).then(operation);
+    this.transition = next;
+    return next;
+  }
+
+  private startLeaderWork(): void {
+    if (this.stopped || this.stopping || this.losingLeadership) return;
+    this.startingLeaderWork = true;
+    try {
+      if (this.config.indexing.autoIndex && !this.autoIndexStarted) {
+        this.autoIndexStarted = true;
+        this.hooks.startAutoIndex("startup");
+      }
+      if (!this.watcher && this.hooks.watcherFactory) {
+        try {
+          const watcher = this.hooks.watcherFactory();
+          this.watcher = watcher;
+          this.leaderReady = watcher.whenReady?.().catch((error: unknown) => {
+            console.error("[codebase-index] Failed while waiting for background file watcher startup:", error);
+          }) ?? Promise.resolve();
+        } catch (error) {
+          console.error("[codebase-index] Failed to start background file watcher:", error);
+          this.leaderReady = Promise.resolve();
+        }
+      }
+    } finally {
+      this.startingLeaderWork = false;
+    }
+  }
+
+  private async stopLeaderWork(stopAutoIndex: boolean): Promise<AutoIndexStopResult> {
+    const watcher = this.watcher;
+    let watcherError: unknown;
+    if (watcher) {
+      try {
+        await watcher.stop();
+        if (this.watcher === watcher) this.watcher = null;
+      } catch (error) {
+        watcherError = error;
+      }
+    }
+    let autoIndexError: unknown;
+    let autoIndexStop: AutoIndexStopResult = {
+      completed: true,
+      completion: Promise.resolve(),
+    };
+    if (stopAutoIndex) {
+      try {
+        autoIndexStop = await this.hooks.stopAutoIndex();
+        this.autoIndexStarted = false;
+      } catch (error) {
+        autoIndexError = error;
+      }
+    }
+    if (watcherError !== undefined || autoIndexError !== undefined) {
+      throw new BackgroundWorkerStopError(watcherError, autoIndexError);
+    }
+    return autoIndexStop;
+  }
+
+  private releaseLeaseWhenAutoIndexStops(
+    lease: BackgroundWorkerLease,
+    completion: Promise<void>,
+  ): void {
+    void completion.then(
+      () => {
+        void this.enqueue(async () => {
+          if (this.lease !== lease || !this.stopping) return;
+          this.leaderWorkStopped = true;
+          this.releaseStoppedLease(lease);
+        }).catch((error: unknown) => {
+          console.error("[codebase-index] Failed to release background worker lease after automatic indexing stopped:", error);
+          this.scheduleTeardownRetry();
+        });
+      },
+      (error: unknown) => {
+        console.error("[codebase-index] Failed while waiting for automatic indexing to stop:", error);
+        this.scheduleTeardownRetry();
+      },
+    );
+  }
+
+  private releaseStoppedLease(lease: BackgroundWorkerLease): void {
+    if (this.lease !== lease) {
+      this.finishStoppedLease();
+      return;
+    }
+    releaseLease(lease);
+    this.lease = null;
+    this.finishStoppedLease();
+  }
+
+  private finishStoppedLease(): void {
+    this.leaderWorkStopped = false;
+    this.stopAutoIndexOnTeardown = true;
+    this.stopping = false;
+    this.clearTimers();
+    this.restartAfterTeardown();
+    if (!this.stopped || this.stopping) return;
+
+    const projectKey = projectLookupKey(this.projectRoot, this.host);
+    const key = controllerKey(this.identity, this.host);
+    if (workers.get(key) === this) workers.delete(key);
+    if (workerKeysByProject.get(projectKey) === key) workerKeysByProject.delete(projectKey);
+  }
+
+  private startHeartbeat(): void {
+    if (this.heartbeatTimer) return;
+    const heartbeat = (): void => {
+      void this.heartbeat();
+    };
+    this.heartbeatTimer = setInterval(heartbeat, HEARTBEAT_INTERVAL_MS);
+    this.heartbeatTimer.unref?.();
+  }
+
+  private async heartbeat(): Promise<void> {
+    const lease = this.lease;
+    if (!lease || this.losingLeadership || (this.stopped && !this.stopping)) return;
+    if (hasActiveReclaimMarker(lease.leasePath, lease.owner)) {
+      await this.loseLeadership();
+      return;
+    }
+    const currentOwner = readOwner(lease.leasePath);
+    if (!currentOwner || !sameOwner(currentOwner, lease.owner)) {
+      await this.loseLeadership();
+      return;
+    }
+    try {
+      const nextOwner = { ...lease.owner, heartbeatAt: new Date().toISOString() };
+      if (!writeHeartbeat(lease.leasePath, nextOwner)) {
+        await this.loseLeadership();
+        return;
+      }
+      lease.owner = nextOwner;
+      const refreshRequest = !this.stopping ? consumeRefreshRequest(lease.leasePath) : null;
+      if (refreshRequest) {
+        this.hooks.startAutoIndex("retrieval", refreshRequest.allowDisabledAutoIndex);
+      }
+    } catch (error) {
+      const ownerAfterError = readOwner(lease.leasePath);
+      if (hasActiveReclaimMarker(lease.leasePath, lease.owner)
+        || !ownerAfterError
+        || !sameOwner(ownerAfterError, lease.owner)) {
+        await this.loseLeadership();
+        return;
+      }
+      console.error("[codebase-index] Failed to renew background worker lease:", error);
+    }
+  }
+
+  private async loseLeadership(): Promise<void> {
+    if (this.losingLeadership) return;
+    this.losingLeadership = true;
+    this.clearHeartbeat();
+    await this.enqueue(async () => this.stopAfterLeadershipLoss());
+  }
+
+  private async stopAfterLeadershipLoss(): Promise<void> {
+    const lease = this.lease;
+    if (!lease) {
+      this.losingLeadership = false;
+      return;
+    }
+    try {
+      const stopped = await this.stopLeaderWork(true);
+      this.lease = null;
+      this.losingLeadership = false;
+      if (stopped.completed) {
+        this.scheduleRetry();
+      } else {
+        void stopped.completion.then(() => this.scheduleRetry());
+      }
+    } catch (error) {
+      console.error("[codebase-index] Failed to stop background work after losing its lease:", error);
+      this.scheduleLostLeadershipTeardownRetry();
+    }
+  }
+
+  private scheduleRetry(): void {
+    if (this.stopped || !this.canRun() || this.retryTimer) return;
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null;
+      this.start();
+    }, RETRY_DELAY_MS);
+    this.retryTimer.unref?.();
+  }
+
+  private scheduleTeardownRetry(): void {
+    if (!this.stopping || this.teardownRetryTimer) return;
+    this.teardownRetryTimer = setTimeout(() => {
+      this.teardownRetryTimer = null;
+      void this.stop(this.stopAutoIndexOnTeardown).catch((error: unknown) => {
+        console.error("[codebase-index] Failed to retry background worker teardown:", error);
+      });
+    }, RETRY_DELAY_MS);
+    this.teardownRetryTimer.unref?.();
+  }
+
+  private restartAfterTeardown(): void {
+    if (!this.restartAfterStop || !this.canRun() || this.losingLeadership) return;
+    this.restartAfterStop = false;
+    this.stopped = false;
+    this.start();
+  }
+
+  private scheduleLostLeadershipTeardownRetry(): void {
+    if (this.stopped || !this.losingLeadership || this.retryTimer) return;
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null;
+      void this.enqueue(async () => this.stopAfterLeadershipLoss());
+    }, RETRY_DELAY_MS);
+    this.retryTimer.unref?.();
+  }
+
+  private clearHeartbeat(): void {
+    if (!this.heartbeatTimer) return;
+    clearInterval(this.heartbeatTimer);
+    this.heartbeatTimer = null;
+  }
+
+  private clearTimers(): void {
+    this.clearHeartbeat();
+    this.clearRetryTimer();
+    if (this.teardownRetryTimer) {
+      clearTimeout(this.teardownRetryTimer);
+      this.teardownRetryTimer = null;
+    }
+  }
+
+  private clearRetryTimer(): void {
+    if (!this.retryTimer) return;
+    clearTimeout(this.retryTimer);
+    this.retryTimer = null;
+  }
+
+  private reportAcquireError(error: unknown): void {
+    const message = error instanceof Error ? error.message : String(error);
+    if (this.reportedError === message) return;
+    this.reportedError = message;
+    console.error("[codebase-index] Failed to acquire background worker lease:", error);
+  }
+}
+
+export function configureBackgroundWorker(
+  projectRoot: string,
+  host: HostMode,
+  config: ParsedCodebaseIndexConfig,
+  hooks: BackgroundWorkerHooks,
+  options: BackgroundWorkerConfigureOptions = {},
+): void {
+  const projectKey = projectLookupKey(projectRoot, host);
+  const identity = resolveIdentity(projectRoot, config, host);
+  const key = controllerKey(identity, host);
+  const previousKey = workerKeysByProject.get(projectKey);
+  if (previousKey && previousKey !== key) {
+    const previous = workers.get(previousKey);
+    const previousBarrier = workerReplacementBarriers.get(projectKey) ?? Promise.resolve();
+    const stopPrevious = previous?.stop(options.stopPreviousAutoIndex ?? true) ?? Promise.resolve();
+    const activation = Promise.all([previousBarrier, stopPrevious]).then(() => undefined);
+    workerReplacementBarriers.set(projectKey, activation);
+    workers.delete(previousKey);
+
+    const worker = new BackgroundWorkerController(projectRoot, host, config, hooks, identity);
+    worker.startAfter(activation);
+    workers.set(key, worker);
+    workerKeysByProject.set(projectKey, key);
+    return;
+  }
+
+  let worker = workers.get(key);
+  if (!worker) {
+    worker = new BackgroundWorkerController(projectRoot, host, config, hooks, identity);
+    workers.set(key, worker);
+  } else {
+    worker.update(config, hooks, options);
+  }
+  workerKeysByProject.set(projectKey, key);
+  worker.start();
+}
+
+export function attachBackgroundWorkerWatcher(
+  projectRoot: string,
+  host: HostMode,
+  watcherFactory: (() => BackgroundWorkerWatcher) | null,
+  watcherFactoryForConfig?: (
+    config: ParsedCodebaseIndexConfig,
+  ) => (() => BackgroundWorkerWatcher) | null,
+): void {
+  const key = workerKeysByProject.get(projectLookupKey(projectRoot, host));
+  workers.get(key ?? "")?.attachWatcher(watcherFactory, watcherFactoryForConfig);
+}
+
+export function updateBackgroundWorkerConfig(
+  projectRoot: string,
+  host: HostMode,
+  config: ParsedCodebaseIndexConfig,
+): void {
+  const projectKey = projectLookupKey(projectRoot, host);
+  const key = workerKeysByProject.get(projectKey);
+  const worker = key ? workers.get(key) : undefined;
+  if (!worker) return;
+  configureBackgroundWorker(projectRoot, host, config, worker.getHooksForConfig(config), {
+    stopPreviousAutoIndex: false,
+    restartAutoIndex: true,
+  });
+}
+
+export function requestBackgroundWorker(projectRoot: string, host: HostMode): void {
+  const key = workerKeysByProject.get(projectLookupKey(projectRoot, host));
+  workers.get(key ?? "")?.start();
+}
+
+export function waitForBackgroundWorkerStart(projectRoot: string, host: HostMode): Promise<void> {
+  const key = workerKeysByProject.get(projectLookupKey(projectRoot, host));
+  return workers.get(key ?? "")?.waitForStart() ?? Promise.resolve();
+}
+
+export function requestBackgroundWorkerRefresh(
+  projectRoot: string,
+  host: HostMode,
+  allowDisabledAutoIndex = false,
+): void {
+  const key = workerKeysByProject.get(projectLookupKey(projectRoot, host));
+  workers.get(key ?? "")?.requestRefresh(allowDisabledAutoIndex);
+}
+
+export function isBackgroundWorkerManaged(projectRoot: string, host: HostMode): boolean {
+  const key = workerKeysByProject.get(projectLookupKey(projectRoot, host));
+  return key !== undefined && workers.has(key);
+}
+
+export function isBackgroundWorkerLeader(projectRoot: string, host: HostMode): boolean {
+  const key = workerKeysByProject.get(projectLookupKey(projectRoot, host));
+  return key !== undefined && workers.get(key)?.isLeader() === true;
+}
+
+export async function stopBackgroundWorker(projectRoot: string, host: HostMode): Promise<void> {
+  const projectKey = projectLookupKey(projectRoot, host);
+  const key = workerKeysByProject.get(projectKey);
+  const worker = key ? workers.get(key) : undefined;
+  if (!worker) return;
+  await worker.stop();
+}
+
+export async function resetBackgroundWorkersForTests(): Promise<void> {
+  await Promise.all(Array.from(workers.values(), (worker) => worker.stop()));
+  await Promise.all(workerReplacementBarriers.values());
+  workers.clear();
+  workerKeysByProject.clear();
+  workerReplacementBarriers.clear();
+}
+
+export function getBackgroundWorkerLeasePath(
+  projectRoot: string,
+  config: ParsedCodebaseIndexConfig,
+  host: HostMode,
+): string {
+  return leasePathFor(resolveIdentity(projectRoot, config, host));
+}
+
+export function tryAcquireBackgroundWorkerLease(
+  projectRoot: string,
+  config: ParsedCodebaseIndexConfig,
+  host: HostMode,
+): BackgroundWorkerLeaseHandle | null {
+  const lease = acquireLease(resolveIdentity(projectRoot, config, host));
+  if (!lease) return null;
+  return {
+    leasePath: lease.leasePath,
+    owner: lease.owner,
+    release: () => releaseLease(lease),
+  };
+}

--- a/src/watcher/index.ts
+++ b/src/watcher/index.ts
@@ -36,7 +36,9 @@ export function createWatcherWithIndexer(
 ): CombinedWatcher {
   const fileWatcher = new FileWatcher(projectRoot, config, host, options);
   const configPaths = getConfigPaths(projectRoot, host, options);
-  configureAutoIndex(projectRoot, host, parseConfig(config), getIndexer);
+  configureAutoIndex(projectRoot, host, parseConfig(config), getIndexer, {
+    synchronizeBackgroundWorker: false,
+  });
   let stopped = false;
   const requestReindex = () => {
     if (stopped) return;
@@ -58,7 +60,9 @@ export function createWatcherWithIndexer(
         const parsedConfig = options.configPath ? parseConfig(loadConfigFile(options.configPath)) : undefined;
         const refreshedConfig = refreshIndexerForDirectory(projectRoot, host, parsedConfig);
         if (refreshedConfig) {
-          configureAutoIndex(projectRoot, host, refreshedConfig, getIndexer);
+          configureAutoIndex(projectRoot, host, refreshedConfig, getIndexer, {
+            synchronizeBackgroundWorker: false,
+          });
         }
       }
       requestReindex();

--- a/tests/auto-index.test.ts
+++ b/tests/auto-index.test.ts
@@ -7,6 +7,11 @@ import { parseConfig } from "../src/config/schema.js";
 import { IndexLockContentionError } from "../src/indexer/index-lock.js";
 import type { IndexFreshnessResult, IndexProgress, IndexStats, StatusResult } from "../src/indexer/index.js";
 import type { BackgroundIndexingPolicy } from "../src/utils/power-source.js";
+import {
+  configureBackgroundWorker,
+  isBackgroundWorkerLeader,
+  resetBackgroundWorkersForTests,
+} from "../src/utils/background-worker.js";
 
 const powerSource = vi.hoisted(() => ({
   createBackgroundIndexingPolicy: vi.fn(),
@@ -24,7 +29,9 @@ import {
   resetAutoIndexCoordinatorsForTests,
   runCoordinatedIndex,
   startAutoIndex,
+  startAutoIndexForBackgroundWorker,
   stopAutoIndex,
+  stopAutoIndexForBackgroundWorker,
   waitForAutoIndexForRetrieval,
 } from "../src/utils/auto-index.js";
 
@@ -127,6 +134,7 @@ describe("auto-index coordinator", () => {
   });
 
   afterEach(async () => {
+    await resetBackgroundWorkersForTests();
     await resetAutoIndexCoordinatorsForTests();
     vi.useRealTimers();
     rmSync(projectRoot, { recursive: true, force: true });
@@ -161,7 +169,7 @@ describe("auto-index coordinator", () => {
     expect(indexer.index).toHaveBeenCalledOnce();
   });
 
-  it("refreshes a readable stale Pi index before retrieval", async () => {
+  it("refreshes a readable stale Pi index before reporting it ready", async () => {
     const indexer = new MockIndexer();
     indexer.readable = true;
     indexer.freshness = { readable: true, current: false, reason: "files-changed" };
@@ -170,8 +178,59 @@ describe("auto-index coordinator", () => {
     const result = await waitForAutoIndexForRetrieval(projectRoot, "pi");
 
     expect(result).toEqual({ ready: true });
+    await vi.waitFor(() => expect(indexer.index).toHaveBeenCalledOnce());
+  });
+
+  it("refreshes a readable branch-changed index before reporting it ready", async () => {
+    const indexer = new MockIndexer();
+    indexer.readable = true;
+    indexer.freshness = { readable: true, current: false, reason: "branch-changed" };
+    configureAutoIndex(projectRoot, "pi", config(), () => indexer);
+
+    await expect(waitForAutoIndexForRetrieval(projectRoot, "pi")).resolves.toEqual({ ready: true });
+    await vi.waitFor(() => expect(indexer.index).toHaveBeenCalledOnce());
+  });
+
+  it("does not serve a stale snapshot while its refresh is in flight", async () => {
+    const indexer = new MockIndexer();
+    const refresh = deferred<IndexStats>();
+    indexer.readable = true;
+    indexer.freshness = { readable: true, current: false, reason: "files-changed" };
+    indexer.index.mockImplementation(async () => refresh.promise);
+    configureAutoIndex(projectRoot, "pi", config({ autoIndexWaitMs: 0 }), () => indexer);
+
+    const result = await waitForAutoIndexForRetrieval(projectRoot, "pi");
+
+    expect(result).toMatchObject({
+      ready: false,
+      text: expect.stringMatching(/Automatic indexing is indexing/i),
+    });
     expect(indexer.index).toHaveBeenCalledOnce();
-    expect(indexer.getIndexFreshness).toHaveBeenCalledTimes(3);
+
+    refresh.resolve(stats());
+    await vi.waitFor(() => expect(getAutoIndexStatus(projectRoot, "pi").state).toBe("ready"));
+  });
+
+  it.each([
+    "unreadable",
+    "incompatible",
+    "failed-batches",
+    "migration-required",
+  ] as const)("keeps a %s snapshot unavailable for retrieval", async (reason) => {
+    const indexer = new MockIndexer();
+    indexer.readable = reason !== "unreadable";
+    indexer.freshness = {
+      readable: reason !== "unreadable",
+      current: false,
+      reason,
+    };
+    configureAutoIndex(projectRoot, "pi", config(), () => indexer);
+
+    const result = await waitForAutoIndexForRetrieval(projectRoot, "pi");
+
+    expect(result.ready).toBe(false);
+    expect(result.text).toContain("Run index_codebase");
+    expect(indexer.index).not.toHaveBeenCalled();
   });
 
   it("lets concurrent first retrievals await one in-flight job", async () => {
@@ -449,6 +508,69 @@ describe("auto-index coordinator", () => {
     await expect(firstRequest).resolves.toMatchObject({ outcome: "stopped" });
     await expect(secondRequest).resolves.toMatchObject({ outcome: "ready" });
     expect(secondIndexer.index).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the replacement coordinator active while its previous worker shuts down", async () => {
+    const firstIndexer = new MockIndexer();
+    const secondIndexer = new MockIndexer();
+    firstIndexer.readable = true;
+    firstIndexer.freshness = { readable: true, current: true, reason: "current" };
+    const localConfig = config();
+    configureAutoIndex(projectRoot, "codex", localConfig, () => firstIndexer);
+    configureBackgroundWorker(projectRoot, "codex", localConfig, {
+      startAutoIndex: (source) => {
+        startAutoIndexForBackgroundWorker(projectRoot, "codex", source);
+      },
+      stopAutoIndex: () => stopAutoIndexForBackgroundWorker(projectRoot, "codex"),
+    });
+    await vi.waitFor(() => expect(getAutoIndexStatus(projectRoot, "codex").state).toBe("ready"));
+
+    const previousHome = process.env.HOME;
+    const testHome = path.join(projectRoot, "test-home");
+    mkdirSync(testHome);
+    process.env.HOME = testHome;
+    try {
+      configureAutoIndex(projectRoot, "codex", config({}, { scope: "global" }), () => secondIndexer);
+
+      await vi.waitFor(() => expect(isBackgroundWorkerLeader(projectRoot, "codex")).toBe(true));
+      await vi.waitFor(() => expect(secondIndexer.index).toHaveBeenCalledOnce());
+      expect(getAutoIndexStatus(projectRoot, "codex").state).toBe("ready");
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+    }
+  });
+
+  it("keeps a managed worker coordinator when a non-authoritative registration is unsafe", async () => {
+    const indexer = new MockIndexer();
+    indexer.readable = true;
+    indexer.freshness = { readable: true, current: true, reason: "current" };
+    const safeConfig = config({ requireProjectMarker: false });
+    configureAutoIndex(projectRoot, "codex", safeConfig, () => indexer);
+    configureBackgroundWorker(projectRoot, "codex", safeConfig, {
+      startAutoIndex: (source) => {
+        startAutoIndexForBackgroundWorker(projectRoot, "codex", source);
+      },
+      stopAutoIndex: () => stopAutoIndexForBackgroundWorker(projectRoot, "codex"),
+    });
+    await vi.waitFor(() => expect(getAutoIndexStatus(projectRoot, "codex").state).toBe("ready"));
+
+    rmSync(path.join(projectRoot, "package.json"));
+    configureAutoIndex(projectRoot, "codex", config(), () => indexer, {
+      preserveManagedWorker: true,
+      synchronizeBackgroundWorker: false,
+    });
+
+    expect(getAutoIndexStatus(projectRoot, "codex").blockedReason).toBeUndefined();
+    const refresh = startAutoIndexForBackgroundWorker(projectRoot, "codex");
+    expect(refresh).not.toBeNull();
+    await expect(refresh).resolves.toMatchObject({
+      outcome: "ready",
+      skipped: true,
+    });
   });
 
   it("queues force indexing behind and supersedes background work safely", async () => {

--- a/tests/background-worker.test.ts
+++ b/tests/background-worker.test.ts
@@ -1,0 +1,709 @@
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fsMocks = vi.hoisted(() => ({
+  beforeRename: null as (() => void) | null,
+  originalRenameSync: null as typeof import("node:fs").renameSync | null,
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const fs = await importOriginal<typeof import("node:fs")>();
+  fsMocks.originalRenameSync = fs.renameSync;
+  return {
+    ...fs,
+    renameSync: (...args: Parameters<typeof fs.renameSync>): void => {
+      const beforeRename = fsMocks.beforeRename;
+      fsMocks.beforeRename = null;
+      beforeRename?.();
+      fs.renameSync(...args);
+    },
+  };
+});
+
+import { parseConfig } from "../src/config/schema.js";
+import {
+  configureBackgroundWorker,
+  getBackgroundWorkerLeasePath,
+  isBackgroundWorkerLeader,
+  isBackgroundWorkerManaged,
+  resetBackgroundWorkersForTests,
+  stopBackgroundWorker,
+  tryAcquireBackgroundWorkerLease,
+  updateBackgroundWorkerConfig,
+  type BackgroundWorkerLeaseOwner,
+} from "../src/utils/background-worker.js";
+
+function config(
+  indexing: Record<string, unknown> = {},
+  rootOverrides: Record<string, unknown> = {},
+) {
+  return parseConfig({
+    ...rootOverrides,
+    embeddingProvider: "custom",
+    customProvider: {
+      baseUrl: "http://127.0.0.1:9999/v1",
+      model: "test",
+      dimensions: 8,
+    },
+    indexing: {
+      autoIndex: true,
+      watchFiles: false,
+      requireProjectMarker: false,
+      ...indexing,
+    },
+  });
+}
+
+function readOwner(leasePath: string): BackgroundWorkerLeaseOwner {
+  return JSON.parse(readFileSync(path.join(leasePath, "owner.json"), "utf-8")) as BackgroundWorkerLeaseOwner;
+}
+
+function writeOwner(leasePath: string, owner: BackgroundWorkerLeaseOwner): void {
+  writeFileSync(path.join(leasePath, "owner.json"), JSON.stringify(owner), "utf-8");
+}
+
+function writeHeartbeat(leasePath: string, owner: BackgroundWorkerLeaseOwner, heartbeatAt: string): void {
+  writeFileSync(path.join(leasePath, `heartbeat.${owner.token}.json`), JSON.stringify({
+    version: 1,
+    token: owner.token,
+    heartbeatAt,
+  }), "utf-8");
+}
+
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function completedAutoIndexStop(): { completed: true; completion: Promise<void> } {
+  return { completed: true, completion: Promise.resolve() };
+}
+
+describe("background worker lease", () => {
+  let tempDir: string;
+  let projectRoot: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "background-worker-"));
+    projectRoot = path.join(tempDir, "project");
+  });
+
+  afterEach(async () => {
+    await resetBackgroundWorkersForTests();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("uses one deterministic lease path for a project and a distinct path for another root", () => {
+    const parsed = config();
+    const first = getBackgroundWorkerLeasePath(projectRoot, parsed, "codex");
+    const repeated = getBackgroundWorkerLeasePath(projectRoot, parsed, "codex");
+    const second = getBackgroundWorkerLeasePath(path.join(tempDir, "second-project"), parsed, "codex");
+
+    expect(repeated).toBe(first);
+    expect(second).not.toBe(first);
+  });
+
+  it.each(["opencode", "codex", "claude", "pi", "jcode"] as const)("acquires and releases a lease for %s", (host) => {
+    const lease = tryAcquireBackgroundWorkerLease(projectRoot, config(), host);
+    expect(lease).not.toBeNull();
+    expect(lease?.release()).toBe(true);
+  });
+
+  it("does not evict a live local owner with an old heartbeat", () => {
+    const parsed = config();
+    const first = tryAcquireBackgroundWorkerLease(projectRoot, parsed, "codex");
+    if (!first) throw new Error("Expected the first lease acquisition to succeed");
+
+    const owner = readOwner(first.leasePath);
+    const staleHeartbeat = new Date(Date.now() - 60_000).toISOString();
+    writeOwner(first.leasePath, {
+      ...owner,
+      heartbeatAt: staleHeartbeat,
+    });
+    writeHeartbeat(first.leasePath, owner, staleHeartbeat);
+
+    expect(tryAcquireBackgroundWorkerLease(projectRoot, parsed, "codex")).toBeNull();
+    expect(first.release()).toBe(true);
+  });
+
+  it("keeps a live leader active when another process sees its old heartbeat", async () => {
+    vi.useFakeTimers();
+    try {
+      const parsed = config({ watchFiles: true });
+      const watcher = { stop: vi.fn(async () => {}) };
+      configureBackgroundWorker(projectRoot, "codex", parsed, {
+        startAutoIndex: vi.fn(),
+        stopAutoIndex: vi.fn(async () => completedAutoIndexStop()),
+        watcherFactory: () => watcher,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      const leasePath = getBackgroundWorkerLeasePath(projectRoot, parsed, "codex");
+      const owner = readOwner(leasePath);
+      const staleHeartbeat = new Date(Date.now() - 60_000).toISOString();
+      writeOwner(leasePath, {
+        ...owner,
+        heartbeatAt: staleHeartbeat,
+      });
+      writeHeartbeat(leasePath, owner, staleHeartbeat);
+
+      expect(tryAcquireBackgroundWorkerLease(projectRoot, parsed, "codex")).toBeNull();
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(isBackgroundWorkerLeader(projectRoot, "codex")).toBe(true);
+      expect(watcher.stop).not.toHaveBeenCalled();
+
+      await stopBackgroundWorker(projectRoot, "codex");
+      expect(watcher.stop).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reclaims a dead local owner after its heartbeat expires", () => {
+    const parsed = config();
+    const first = tryAcquireBackgroundWorkerLease(projectRoot, parsed, "codex");
+    if (!first) throw new Error("Expected the first lease acquisition to succeed");
+
+    const owner = readOwner(first.leasePath);
+    const staleHeartbeat = new Date(Date.now() - 60_000).toISOString();
+    writeOwner(first.leasePath, {
+      ...owner,
+      pid: 999_999_999,
+      heartbeatAt: staleHeartbeat,
+    });
+    writeHeartbeat(first.leasePath, owner, staleHeartbeat);
+
+    const recovered = tryAcquireBackgroundWorkerLease(projectRoot, parsed, "codex");
+    expect(recovered).not.toBeNull();
+    expect(recovered?.owner.pid).toBe(process.pid);
+    expect(recovered?.release()).toBe(true);
+  });
+
+  it("reclaims an expired remote owner", () => {
+    const parsed = config();
+    const first = tryAcquireBackgroundWorkerLease(projectRoot, parsed, "codex");
+    if (!first) throw new Error("Expected the first lease acquisition to succeed");
+
+    const owner = readOwner(first.leasePath);
+    const staleOwner = {
+      ...owner,
+      heartbeatAt: new Date(Date.now() - 60_000).toISOString(),
+      hostname: "remote-host",
+    };
+    writeOwner(first.leasePath, staleOwner);
+    writeHeartbeat(first.leasePath, staleOwner, staleOwner.heartbeatAt);
+
+    const recovered = tryAcquireBackgroundWorkerLease(projectRoot, parsed, "codex");
+    expect(recovered).not.toBeNull();
+    expect(recovered?.owner.pid).toBe(process.pid);
+    expect(recovered?.owner.token).not.toBe(owner.token);
+    expect(recovered?.release()).toBe(true);
+  });
+
+  it("does not evict an ambiguous local owner with an expired heartbeat", () => {
+    const parsed = config();
+    const first = tryAcquireBackgroundWorkerLease(projectRoot, parsed, "codex");
+    if (!first) throw new Error("Expected the first lease acquisition to succeed");
+
+    const owner = readOwner(first.leasePath);
+    const staleHeartbeat = new Date(Date.now() - 60_000).toISOString();
+    writeOwner(first.leasePath, {
+      ...owner,
+      heartbeatAt: staleHeartbeat,
+    });
+    writeHeartbeat(first.leasePath, owner, staleHeartbeat);
+    const originalKill = process.kill;
+    const kill = vi.spyOn(process, "kill").mockImplementation(((pid: number, signal?: number | NodeJS.Signals) => {
+      if (pid === owner.pid && signal === 0) {
+        throw Object.assign(new Error("liveness unavailable"), { code: "EIO" });
+      }
+      return originalKill(pid, signal);
+    }) as typeof process.kill);
+
+    try {
+      expect(tryAcquireBackgroundWorkerLease(projectRoot, parsed, "codex")).toBeNull();
+    } finally {
+      kill.mockRestore();
+    }
+    expect(first.release()).toBe(true);
+  });
+
+  it("does not release a lease after its token changed", () => {
+    const parsed = config();
+    const lease = tryAcquireBackgroundWorkerLease(projectRoot, parsed, "codex");
+    if (!lease) throw new Error("Expected the first lease acquisition to succeed");
+
+    const owner = readOwner(lease.leasePath);
+    writeOwner(lease.leasePath, { ...owner, token: randomUUID() });
+
+    expect(lease.release()).toBe(false);
+  });
+
+  it("does not remove a successor lease replaced during release", () => {
+    const parsed = config();
+    const lease = tryAcquireBackgroundWorkerLease(projectRoot, parsed, "codex");
+    if (!lease || !fsMocks.originalRenameSync) throw new Error("Expected the first lease acquisition to succeed");
+
+    const successor = {
+      ...readOwner(lease.leasePath),
+      heartbeatAt: new Date().toISOString(),
+      startedAt: new Date().toISOString(),
+      token: randomUUID(),
+    };
+    fsMocks.beforeRename = () => {
+      const incumbentPath = `${lease.leasePath}.incumbent`;
+      const successorPath = `${lease.leasePath}.successor`;
+      fsMocks.originalRenameSync?.(lease.leasePath, incumbentPath);
+      mkdirSync(successorPath);
+      writeFileSync(path.join(successorPath, "owner.json"), JSON.stringify(successor), "utf-8");
+      fsMocks.originalRenameSync?.(successorPath, lease.leasePath);
+    };
+
+    expect(lease.release()).toBe(false);
+    expect(existsSync(lease.leasePath)).toBe(true);
+    expect(readOwner(lease.leasePath)).toMatchObject({ token: successor.token });
+  });
+
+  it("starts and stops watcher and auto-index work only while leader", async () => {
+    const startAutoIndex = vi.fn();
+    const stopAutoIndex = vi.fn(async () => completedAutoIndexStop());
+    const watcher = { stop: vi.fn(async () => {}) };
+    configureBackgroundWorker(projectRoot, "codex", config(), {
+      startAutoIndex,
+      stopAutoIndex,
+      watcherFactory: () => watcher,
+    });
+
+    await vi.waitFor(() => expect(isBackgroundWorkerLeader(projectRoot, "codex")).toBe(true));
+    expect(startAutoIndex).toHaveBeenCalledOnce();
+    expect(watcher.stop).not.toHaveBeenCalled();
+
+    await Promise.all([
+      stopBackgroundWorker(projectRoot, "codex"),
+      stopBackgroundWorker(projectRoot, "codex"),
+    ]);
+    expect(watcher.stop).toHaveBeenCalledOnce();
+    expect(stopAutoIndex).toHaveBeenCalledOnce();
+  });
+
+  it("restarts automatic indexing when a watched project re-enables it", async () => {
+    const startAutoIndex = vi.fn();
+    const watcher = { stop: vi.fn(async () => {}) };
+    const hooks = {
+      startAutoIndex,
+      stopAutoIndex: vi.fn(async () => completedAutoIndexStop()),
+      watcherFactory: () => watcher,
+    };
+    configureBackgroundWorker(projectRoot, "codex", config({ watchFiles: true }), hooks);
+    await vi.waitFor(() => expect(startAutoIndex).toHaveBeenCalledTimes(1));
+
+    configureBackgroundWorker(projectRoot, "codex", config({ autoIndex: false, watchFiles: true }), hooks);
+    configureBackgroundWorker(projectRoot, "codex", config({ watchFiles: true }), hooks);
+
+    await vi.waitFor(() => expect(startAutoIndex).toHaveBeenCalledTimes(2));
+  });
+
+  it("restarts automatic indexing after an enabled configuration refresh", async () => {
+    const startAutoIndex = vi.fn();
+    const initialConfig = config();
+    configureBackgroundWorker(projectRoot, "codex", initialConfig, {
+      startAutoIndex,
+      stopAutoIndex: vi.fn(async () => completedAutoIndexStop()),
+    });
+    await vi.waitFor(() => expect(startAutoIndex).toHaveBeenCalledTimes(1));
+
+    updateBackgroundWorkerConfig(projectRoot, "codex", config({ autoIndexWaitMs: 75 }));
+
+    await vi.waitFor(() => expect(startAutoIndex).toHaveBeenCalledTimes(2));
+  });
+
+  it("rebuilds its watcher from the refreshed index configuration", async () => {
+    const previousHome = process.env.HOME;
+    const homeDir = path.join(tempDir, "home");
+    mkdirSync(homeDir);
+    process.env.HOME = homeDir;
+    const localConfig = config({ autoIndex: false, watchFiles: true });
+    const globalConfig = config({ autoIndex: false, watchFiles: true }, { scope: "global" });
+    const firstWatcher = { stop: vi.fn(async () => {}) };
+    const secondWatcher = { stop: vi.fn(async () => {}) };
+    const startedScopes: string[] = [];
+    const watcherFactoryForConfig = vi.fn((refreshedConfig: ReturnType<typeof config>) => () => {
+      startedScopes.push(refreshedConfig.scope);
+      return refreshedConfig.scope === "global" ? secondWatcher : firstWatcher;
+    });
+
+    try {
+      configureBackgroundWorker(projectRoot, "codex", localConfig, {
+        startAutoIndex: vi.fn(),
+        stopAutoIndex: vi.fn(async () => completedAutoIndexStop()),
+        watcherFactory: watcherFactoryForConfig(localConfig),
+        watcherFactoryForConfig,
+      });
+      await vi.waitFor(() => expect(startedScopes).toEqual(["project"]));
+
+      updateBackgroundWorkerConfig(projectRoot, "codex", globalConfig);
+
+      await vi.waitFor(() => expect(startedScopes).toEqual(["project", "global"]));
+      expect(firstWatcher.stop).toHaveBeenCalledOnce();
+      expect(existsSync(getBackgroundWorkerLeasePath(projectRoot, localConfig, "codex"))).toBe(false);
+      expect(existsSync(getBackgroundWorkerLeasePath(projectRoot, globalConfig, "codex"))).toBe(true);
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+    }
+  });
+
+  it("does not replace a watcher when its shutdown fails", async () => {
+    const stopError = new Error("watcher shutdown failed");
+    let failStop = true;
+    const firstWatcher = {
+      stop: vi.fn(async () => {
+        if (failStop) throw stopError;
+      }),
+    };
+    const secondWatcher = { stop: vi.fn(async () => {}) };
+    const watcherFactory = vi.fn()
+      .mockReturnValueOnce(firstWatcher)
+      .mockReturnValue(secondWatcher);
+    const logError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const parsed = config({ watchFiles: true });
+
+    try {
+      configureBackgroundWorker(projectRoot, "opencode", parsed, {
+        startAutoIndex: vi.fn(),
+        stopAutoIndex: vi.fn(async () => completedAutoIndexStop()),
+        watcherFactory,
+        replaceWatcher: true,
+      });
+      await vi.waitFor(() => expect(watcherFactory).toHaveBeenCalledTimes(1));
+
+      configureBackgroundWorker(projectRoot, "opencode", parsed, {
+        startAutoIndex: vi.fn(),
+        stopAutoIndex: vi.fn(async () => completedAutoIndexStop()),
+        watcherFactory,
+        replaceWatcher: true,
+      });
+      await vi.waitFor(() => expect(firstWatcher.stop).toHaveBeenCalledOnce());
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(watcherFactory).toHaveBeenCalledTimes(1);
+      expect(isBackgroundWorkerLeader(projectRoot, "opencode")).toBe(true);
+
+      failStop = false;
+      configureBackgroundWorker(projectRoot, "opencode", parsed, {
+        startAutoIndex: vi.fn(),
+        stopAutoIndex: vi.fn(async () => completedAutoIndexStop()),
+        watcherFactory,
+        replaceWatcher: true,
+      });
+      await vi.waitFor(() => expect(secondWatcher.stop).not.toHaveBeenCalled());
+      await vi.waitFor(() => expect(watcherFactory).toHaveBeenCalledTimes(2));
+      expect(firstWatcher.stop).toHaveBeenCalledTimes(2);
+    } finally {
+      logError.mockRestore();
+    }
+  });
+
+  it("keeps a lease alive and retries teardown after a watcher shutdown failure", async () => {
+    vi.useFakeTimers();
+    const stopError = new Error("watcher shutdown failed");
+    let failStop = true;
+    const watcher = {
+      stop: vi.fn(async () => {
+        if (failStop) throw stopError;
+      }),
+    };
+    const parsed = config({ watchFiles: true });
+    const logError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      configureBackgroundWorker(projectRoot, "codex", parsed, {
+        startAutoIndex: vi.fn(),
+        stopAutoIndex: vi.fn(async () => completedAutoIndexStop()),
+        watcherFactory: () => watcher,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.waitFor(() => expect(isBackgroundWorkerLeader(projectRoot, "codex")).toBe(true));
+      const leasePath = getBackgroundWorkerLeasePath(projectRoot, parsed, "codex");
+
+      await expect(stopBackgroundWorker(projectRoot, "codex")).rejects.toThrow("Failed to stop background worker");
+      expect(existsSync(leasePath)).toBe(true);
+      expect(isBackgroundWorkerLeader(projectRoot, "codex")).toBe(false);
+
+      failStop = false;
+      await vi.advanceTimersByTimeAsync(5_000);
+      await vi.waitFor(() => expect(existsSync(leasePath)).toBe(false));
+      expect(watcher.stop).toHaveBeenCalledTimes(2);
+    } finally {
+      logError.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("handles a detached teardown failure when automatic work is disabled", async () => {
+    const stopError = new Error("watcher shutdown failed");
+    let failStop = true;
+    const watcher = {
+      stop: vi.fn(async () => {
+        if (failStop) throw stopError;
+      }),
+    };
+    const logError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const unhandledRejection = vi.fn();
+    process.on("unhandledRejection", unhandledRejection);
+
+    try {
+      configureBackgroundWorker(projectRoot, "codex", config({ watchFiles: true }), {
+        startAutoIndex: vi.fn(),
+        stopAutoIndex: vi.fn(async () => completedAutoIndexStop()),
+        watcherFactory: () => watcher,
+      });
+      await vi.waitFor(() => expect(isBackgroundWorkerLeader(projectRoot, "codex")).toBe(true));
+
+      configureBackgroundWorker(projectRoot, "codex", config({ autoIndex: false, watchFiles: false }), {
+        startAutoIndex: vi.fn(),
+        stopAutoIndex: vi.fn(async () => completedAutoIndexStop()),
+        watcherFactory: null,
+      });
+
+      await vi.waitFor(() => expect(logError).toHaveBeenCalledWith(
+        "[codebase-index] Failed to stop background worker after disabling automatic work:",
+        expect.any(Error),
+      ));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(unhandledRejection).not.toHaveBeenCalled();
+
+      failStop = false;
+      await stopBackgroundWorker(projectRoot, "codex");
+    } finally {
+      process.removeListener("unhandledRejection", unhandledRejection);
+      logError.mockRestore();
+    }
+  });
+
+  it.skipIf(process.platform === "win32")("keeps the lease managed and retries when lease release fails", async () => {
+    vi.useFakeTimers();
+    const parsed = config({ watchFiles: true });
+    const watcher = { stop: vi.fn(async () => {}) };
+    const logError = vi.spyOn(console, "error").mockImplementation(() => {});
+    let indexPath: string | null = null;
+
+    try {
+      configureBackgroundWorker(projectRoot, "codex", parsed, {
+        startAutoIndex: vi.fn(),
+        stopAutoIndex: vi.fn(async () => completedAutoIndexStop()),
+        watcherFactory: () => watcher,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.waitFor(() => expect(isBackgroundWorkerLeader(projectRoot, "codex")).toBe(true));
+      const leasePath = getBackgroundWorkerLeasePath(projectRoot, parsed, "codex");
+      indexPath = path.dirname(leasePath);
+      chmodSync(indexPath, 0o500);
+
+      await expect(stopBackgroundWorker(projectRoot, "codex")).rejects.toThrow();
+      expect(existsSync(leasePath)).toBe(true);
+      expect(isBackgroundWorkerManaged(projectRoot, "codex")).toBe(true);
+
+      chmodSync(indexPath, 0o700);
+      await vi.advanceTimersByTimeAsync(5_000);
+      await vi.waitFor(() => expect(existsSync(leasePath)).toBe(false));
+      expect(isBackgroundWorkerManaged(projectRoot, "codex")).toBe(false);
+    } finally {
+      if (indexPath) chmodSync(indexPath, 0o700);
+      logError.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("restarts after a failed teardown when a new server configures the worker", async () => {
+    vi.useFakeTimers();
+    let failStop = true;
+    const firstWatcher = {
+      stop: vi.fn(async () => {
+        if (failStop) throw new Error("watcher shutdown failed");
+      }),
+    };
+    const secondWatcher = { stop: vi.fn(async () => {}) };
+    const firstFactory = vi.fn(() => firstWatcher);
+    const secondFactory = vi.fn(() => secondWatcher);
+    const parsed = config({ watchFiles: true });
+    const logError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      configureBackgroundWorker(projectRoot, "codex", parsed, {
+        startAutoIndex: vi.fn(),
+        stopAutoIndex: vi.fn(async () => completedAutoIndexStop()),
+        watcherFactory: firstFactory,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.waitFor(() => expect(isBackgroundWorkerLeader(projectRoot, "codex")).toBe(true));
+
+      await expect(stopBackgroundWorker(projectRoot, "codex")).rejects.toThrow("Failed to stop background worker");
+      configureBackgroundWorker(projectRoot, "codex", parsed, {
+        startAutoIndex: vi.fn(),
+        stopAutoIndex: vi.fn(async () => completedAutoIndexStop()),
+        watcherFactory: secondFactory,
+      });
+
+      failStop = false;
+      await vi.advanceTimersByTimeAsync(5_000);
+      await vi.waitFor(() => expect(isBackgroundWorkerLeader(projectRoot, "codex")).toBe(true));
+      expect(firstWatcher.stop).toHaveBeenCalledTimes(2);
+      expect(secondFactory).toHaveBeenCalledOnce();
+    } finally {
+      logError.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a successful restart registered when reconfigured during teardown", async () => {
+    const firstWatcherStop = createDeferred();
+    const firstWatcher = {
+      stop: vi.fn(async () => firstWatcherStop.promise),
+    };
+    const secondWatcher = { stop: vi.fn(async () => {}) };
+    const firstFactory = vi.fn(() => firstWatcher);
+    const secondFactory = vi.fn(() => secondWatcher);
+    const parsed = config({ watchFiles: true });
+    const hooks = {
+      startAutoIndex: vi.fn(),
+      stopAutoIndex: vi.fn(async () => completedAutoIndexStop()),
+    };
+
+    configureBackgroundWorker(projectRoot, "codex", parsed, {
+      ...hooks,
+      watcherFactory: firstFactory,
+    });
+    await vi.waitFor(() => expect(isBackgroundWorkerLeader(projectRoot, "codex")).toBe(true));
+
+    const stopping = stopBackgroundWorker(projectRoot, "codex");
+    await vi.waitFor(() => expect(firstWatcher.stop).toHaveBeenCalledOnce());
+    configureBackgroundWorker(projectRoot, "codex", parsed, {
+      ...hooks,
+      watcherFactory: secondFactory,
+    });
+    firstWatcherStop.resolve();
+    await stopping;
+
+    await vi.waitFor(() => expect(isBackgroundWorkerLeader(projectRoot, "codex")).toBe(true));
+    expect(isBackgroundWorkerManaged(projectRoot, "codex")).toBe(true);
+    expect(secondFactory).toHaveBeenCalledOnce();
+
+    await stopBackgroundWorker(projectRoot, "codex");
+    expect(isBackgroundWorkerManaged(projectRoot, "codex")).toBe(false);
+    expect(secondWatcher.stop).toHaveBeenCalledOnce();
+  });
+
+  it("retains the lease until an unfinished automatic index has drained", async () => {
+    const autoIndexCompletion = createDeferred();
+    const parsed = config();
+    configureBackgroundWorker(projectRoot, "codex", parsed, {
+      startAutoIndex: vi.fn(),
+      stopAutoIndex: vi.fn(async () => ({ completed: false, completion: autoIndexCompletion.promise })),
+    });
+
+    await vi.waitFor(() => expect(isBackgroundWorkerLeader(projectRoot, "codex")).toBe(true));
+    const leasePath = getBackgroundWorkerLeasePath(projectRoot, parsed, "codex");
+    await Promise.all([
+      stopBackgroundWorker(projectRoot, "codex"),
+      stopBackgroundWorker(projectRoot, "codex"),
+    ]);
+
+    expect(existsSync(leasePath)).toBe(true);
+    autoIndexCompletion.resolve();
+    await vi.waitFor(() => expect(existsSync(leasePath)).toBe(false));
+  });
+
+  it("retains a watcher-only lease until watcher-triggered indexing has drained", async () => {
+    const autoIndexCompletion = createDeferred();
+    const parsed = config({ autoIndex: false, watchFiles: true });
+    const stopAutoIndex = vi.fn(async () => ({
+      completed: false,
+      completion: autoIndexCompletion.promise,
+    }));
+    configureBackgroundWorker(projectRoot, "codex", parsed, {
+      startAutoIndex: vi.fn(),
+      stopAutoIndex,
+      watcherFactory: () => ({ stop: vi.fn(async () => {}) }),
+    });
+
+    await vi.waitFor(() => expect(isBackgroundWorkerLeader(projectRoot, "codex")).toBe(true));
+    const leasePath = getBackgroundWorkerLeasePath(projectRoot, parsed, "codex");
+    await stopBackgroundWorker(projectRoot, "codex");
+
+    expect(stopAutoIndex).toHaveBeenCalledOnce();
+    expect(existsSync(leasePath)).toBe(true);
+    autoIndexCompletion.resolve();
+    await vi.waitFor(() => expect(existsSync(leasePath)).toBe(false));
+  });
+
+  it("keeps host-local controllers behind a shared filesystem lease", async () => {
+    const parsed = config();
+    configureBackgroundWorker(projectRoot, "codex", parsed, {
+      startAutoIndex: vi.fn(),
+      stopAutoIndex: vi.fn(async () => completedAutoIndexStop()),
+    });
+    await vi.waitFor(() => expect(isBackgroundWorkerLeader(projectRoot, "codex")).toBe(true));
+
+    configureBackgroundWorker(projectRoot, "jcode", parsed, {
+      startAutoIndex: vi.fn(),
+      stopAutoIndex: vi.fn(async () => completedAutoIndexStop()),
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(isBackgroundWorkerLeader(projectRoot, "codex")).toBe(true);
+    expect(isBackgroundWorkerLeader(projectRoot, "jcode")).toBe(false);
+  });
+
+  it("stops a local worker when its owner token is replaced", async () => {
+    vi.useFakeTimers();
+    try {
+      const parsed = config({ watchFiles: true });
+      const watcher = { stop: vi.fn(async () => {}) };
+      configureBackgroundWorker(projectRoot, "codex", parsed, {
+        startAutoIndex: vi.fn(),
+        stopAutoIndex: vi.fn(async () => completedAutoIndexStop()),
+        watcherFactory: () => watcher,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(isBackgroundWorkerLeader(projectRoot, "codex")).toBe(true);
+
+      const leasePath = getBackgroundWorkerLeasePath(projectRoot, parsed, "codex");
+      const owner = readOwner(leasePath);
+      writeOwner(leasePath, {
+        ...owner,
+        hostname: "remote-host",
+        heartbeatAt: owner.heartbeatAt,
+      });
+      expect(tryAcquireBackgroundWorkerLease(projectRoot, parsed, "codex")).toBeNull();
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(isBackgroundWorkerLeader(projectRoot, "codex")).toBe(false);
+      expect(watcher.stop).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not acquire a lease when automatic work and watching are disabled", async () => {
+    const parsed = config({ autoIndex: false, watchFiles: false });
+    configureBackgroundWorker(projectRoot, "codex", parsed, {
+      startAutoIndex: vi.fn(),
+      stopAutoIndex: vi.fn(async () => completedAutoIndexStop()),
+      watcherFactory: null,
+    });
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(isBackgroundWorkerLeader(projectRoot, "codex")).toBe(false);
+    expect(() => readFileSync(getBackgroundWorkerLeasePath(projectRoot, parsed, "codex"))).toThrow();
+  });
+});

--- a/tests/fixtures/watcher-probe.mjs
+++ b/tests/fixtures/watcher-probe.mjs
@@ -1,0 +1,19 @@
+import fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+import path from "node:path";
+
+const eventsPath = process.env.TEST_WATCHER_EVENTS_PATH;
+const projectRoot = process.env.TEST_PROJECT_ROOT;
+const originalWatch = fs.watch;
+
+if (eventsPath && projectRoot) {
+  const canonicalProjectRoot = path.resolve(projectRoot);
+  fs.watch = function watchWithProbe(target, ...args) {
+    const targetPath = Buffer.isBuffer(target) ? target.toString() : String(target);
+    if (path.resolve(targetPath).startsWith(canonicalProjectRoot)) {
+      fs.appendFileSync(eventsPath, `${process.pid}\n`, "utf-8");
+    }
+    return originalWatch.call(this, target, ...args);
+  };
+  syncBuiltinESMExports();
+}

--- a/tests/mcp-background-safety.test.ts
+++ b/tests/mcp-background-safety.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { parseConfig } from "../src/config/schema.js";
+import { resolveProjectIndexPath } from "../src/config/paths.js";
+import { attachMcpBackgroundWatcher, createMcpServer } from "../src/mcp-server.js";
+import { refreshIndexerForDirectory } from "../src/tools/operations.js";
+import { resetAutoIndexCoordinatorsForTests } from "../src/utils/auto-index.js";
+import {
+  configureBackgroundWorker,
+  getBackgroundWorkerLeasePath,
+  isBackgroundWorkerLeader,
+  isBackgroundWorkerManaged,
+  resetBackgroundWorkersForTests,
+} from "../src/utils/background-worker.js";
+
+const autoIndexMocks = vi.hoisted(() => ({
+  startAutoIndexForBackgroundWorker: vi.fn(),
+  stopAutoIndexForBackgroundWorker: vi.fn(async () => ({
+    completed: true,
+    completion: Promise.resolve(),
+  })),
+}));
+
+vi.mock("../src/utils/auto-index.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/utils/auto-index.js")>("../src/utils/auto-index.js");
+  return {
+    ...actual,
+    startAutoIndexForBackgroundWorker: autoIndexMocks.startAutoIndexForBackgroundWorker,
+    stopAutoIndexForBackgroundWorker: autoIndexMocks.stopAutoIndexForBackgroundWorker,
+  };
+});
+
+describe("MCP background worker safety", () => {
+  let tempDir: string;
+  let previousHome: string | undefined;
+  let previousUserProfile: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "mcp-background-safety-"));
+    previousHome = process.env.HOME;
+    previousUserProfile = process.env.USERPROFILE;
+    autoIndexMocks.startAutoIndexForBackgroundWorker.mockReset();
+    autoIndexMocks.stopAutoIndexForBackgroundWorker.mockClear();
+  });
+
+  afterEach(async () => {
+    if (previousHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = previousHome;
+    }
+    if (previousUserProfile === undefined) {
+      delete process.env.USERPROFILE;
+    } else {
+      process.env.USERPROFILE = previousUserProfile;
+    }
+    await resetBackgroundWorkersForTests();
+    await resetAutoIndexCoordinatorsForTests();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  async function expectNoBackgroundWorkerArtifacts(
+    projectRoot: string,
+    config: ReturnType<typeof parseConfig>,
+  ): Promise<void> {
+    const indexPath = resolveProjectIndexPath(projectRoot, config.scope, "codex");
+    const leasePath = getBackgroundWorkerLeasePath(projectRoot, config, "codex");
+
+    createMcpServer(projectRoot, config, "codex");
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(isBackgroundWorkerManaged(projectRoot, "codex")).toBe(false);
+    expect(existsSync(indexPath)).toBe(false);
+    expect(existsSync(leasePath)).toBe(false);
+  }
+
+  it("does not create an index directory or lease for the home directory", async () => {
+    const homeDir = path.join(tempDir, "home");
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+    const config = parseConfig({
+      indexing: {
+        autoIndex: true,
+        requireProjectMarker: false,
+        watchFiles: false,
+      },
+    });
+
+    await expectNoBackgroundWorkerArtifacts(homeDir, config);
+  });
+
+  it("does not create an index directory or lease when a project marker is missing", async () => {
+    const projectRoot = path.join(tempDir, "without-marker");
+    const config = parseConfig({
+      indexing: {
+        autoIndex: true,
+        requireProjectMarker: true,
+        watchFiles: false,
+      },
+    });
+
+    await expectNoBackgroundWorkerArtifacts(projectRoot, config);
+  });
+
+  it("stops a worker when a watched project becomes marker-required", async () => {
+    const projectRoot = path.join(tempDir, "refresh-without-marker");
+    const safeConfig = parseConfig({
+      indexing: {
+        autoIndex: false,
+        requireProjectMarker: false,
+        watchFiles: true,
+      },
+    });
+    const unsafeConfig = parseConfig({
+      indexing: {
+        autoIndex: false,
+        requireProjectMarker: true,
+        watchFiles: true,
+      },
+    });
+    const watcher = { stop: vi.fn(async () => {}) };
+    const server = createMcpServer(projectRoot, safeConfig, "codex");
+
+    try {
+      attachMcpBackgroundWatcher(projectRoot, safeConfig, "codex", () => watcher);
+      await vi.waitFor(() => expect(isBackgroundWorkerLeader(projectRoot, "codex")).toBe(true));
+
+      const leasePath = getBackgroundWorkerLeasePath(projectRoot, safeConfig, "codex");
+      expect(existsSync(leasePath)).toBe(true);
+
+      refreshIndexerForDirectory(projectRoot, "codex", unsafeConfig);
+
+      await vi.waitFor(() => expect(isBackgroundWorkerManaged(projectRoot, "codex")).toBe(false));
+      expect(watcher.stop).toHaveBeenCalledOnce();
+      expect(existsSync(leasePath)).toBe(false);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("does not let a joining MCP server disable an active worker", async () => {
+    const projectRoot = path.join(tempDir, "shared-process-project");
+    const leaderConfig = parseConfig({
+      indexing: {
+        autoIndex: true,
+        requireProjectMarker: false,
+        watchFiles: false,
+      },
+    });
+    const followerConfig = parseConfig({
+      indexing: {
+        autoIndex: false,
+        requireProjectMarker: false,
+        watchFiles: false,
+      },
+    });
+    const leader = createMcpServer(projectRoot, leaderConfig, "codex");
+    const follower = createMcpServer(projectRoot, followerConfig, "codex");
+
+    try {
+      await vi.waitFor(() => expect(isBackgroundWorkerLeader(projectRoot, "codex")).toBe(true));
+      expect(autoIndexMocks.startAutoIndexForBackgroundWorker).toHaveBeenCalledOnce();
+
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(isBackgroundWorkerLeader(projectRoot, "codex")).toBe(true);
+    } finally {
+      await follower.close();
+      await leader.close();
+    }
+  });
+
+  it("does not let an unsafe MCP server stop a pre-existing non-MCP worker", async () => {
+    const projectRoot = path.join(tempDir, "opencode-shared-worker");
+    const config = parseConfig({
+      indexing: {
+        autoIndex: false,
+        requireProjectMarker: false,
+        watchFiles: true,
+      },
+    });
+    const watcher = { stop: vi.fn(async () => {}) };
+    configureBackgroundWorker(projectRoot, "opencode", config, {
+      startAutoIndex: vi.fn(),
+      stopAutoIndex: vi.fn(async () => ({ completed: true, completion: Promise.resolve() })),
+      watcherFactory: () => watcher,
+    });
+    await vi.waitFor(() => expect(isBackgroundWorkerLeader(projectRoot, "opencode")).toBe(true));
+
+    const unsafeMcpConfig = parseConfig({
+      indexing: {
+        autoIndex: false,
+        requireProjectMarker: true,
+        watchFiles: false,
+      },
+    });
+    const server = createMcpServer(projectRoot, unsafeMcpConfig, "opencode");
+    await server.close();
+
+    expect(isBackgroundWorkerLeader(projectRoot, "opencode")).toBe(true);
+    expect(watcher.stop).not.toHaveBeenCalled();
+  });
+});

--- a/tests/mcp-cli-lifecycle.test.ts
+++ b/tests/mcp-cli-lifecycle.test.ts
@@ -191,7 +191,7 @@ describe("MCP CLI shutdown lifecycle", () => {
     expect(events).toEqual(["watcher.stop", "backgroundWorker.stop", "server.close", "exit:0"]);
   });
 
-  it("waits for background watcher startup before connecting the transport", async () => {
+  it("connects the transport before waiting for background watcher startup", async () => {
     const watcherStarted = createDeferred<void>();
     lifecycleMocks.attachMcpBackgroundWatcher.mockImplementation((_project, _config, _host, factory) => {
       watcherAttached = true;
@@ -200,8 +200,9 @@ describe("MCP CLI shutdown lifecycle", () => {
     });
 
     const starting = startCli();
-    await vi.waitFor(() => expect(lifecycleMocks.attachMcpBackgroundWatcher).toHaveBeenCalledOnce());
-    expect(server.connect).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(server.connect).toHaveBeenCalledOnce());
+    expect(lifecycleMocks.attachMcpBackgroundWatcher).toHaveBeenCalledOnce();
+    expect(server.connect).toHaveBeenCalledBefore(lifecycleMocks.attachMcpBackgroundWatcher);
 
     watcherStarted.resolve();
     await starting;
@@ -275,7 +276,7 @@ describe("MCP CLI shutdown lifecycle", () => {
     await vi.waitFor(() => {
       expect(lifecycleMocks.exit).toHaveBeenCalledWith(0);
     });
-    expect(watcher.stop).toHaveBeenCalledOnce();
+    expect(watcher.stop).not.toHaveBeenCalled();
     expect(lifecycleMocks.stopBackgroundWorker).toHaveBeenCalledOnce();
     expect(server.close).toHaveBeenCalledOnce();
   });

--- a/tests/mcp-cli-lifecycle.test.ts
+++ b/tests/mcp-cli-lifecycle.test.ts
@@ -5,20 +5,34 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const lifecycleMocks = vi.hoisted(() => ({
+  BackgroundWorkerStopError: class BackgroundWorkerStopError extends Error {
+    constructor(
+      readonly watcherError: unknown | undefined,
+      readonly autoIndexError: unknown | undefined,
+    ) {
+      super("Failed to stop background worker");
+    }
+  },
   createMcpServer: vi.fn(),
+  attachMcpBackgroundWatcher: vi.fn(),
   createWatcherWithIndexer: vi.fn(),
   isHomeDirectory: vi.fn(() => false),
-  stopAutoIndex: vi.fn(),
+  stopBackgroundWorker: vi.fn(),
   exit: vi.fn(),
 }));
 
 vi.mock("../src/mcp-server.js", () => ({
   createMcpServer: lifecycleMocks.createMcpServer,
+  attachMcpBackgroundWatcher: lifecycleMocks.attachMcpBackgroundWatcher,
 }));
 
 vi.mock("../src/utils/auto-index.js", () => ({
   isHomeDirectory: lifecycleMocks.isHomeDirectory,
-  stopAutoIndex: lifecycleMocks.stopAutoIndex,
+}));
+
+vi.mock("../src/utils/background-worker.js", () => ({
+  BackgroundWorkerStopError: lifecycleMocks.BackgroundWorkerStopError,
+  stopBackgroundWorker: lifecycleMocks.stopBackgroundWorker,
 }));
 
 vi.mock("../src/watcher/index.js", () => ({
@@ -58,9 +72,11 @@ describe("MCP CLI shutdown lifecycle", () => {
   let server: FakeMcpServer;
   let tempDir: string;
   let watcher: FakeWatcher;
+  let watcherAttached: boolean;
 
   beforeEach(() => {
     events = [];
+    watcherAttached = false;
     tempDir = mkdtempSync(path.join(os.tmpdir(), "mcp-cli-lifecycle-"));
     writeFileSync(
       path.join(tempDir, "config.json"),
@@ -68,8 +84,9 @@ describe("MCP CLI shutdown lifecycle", () => {
     );
 
     lifecycleMocks.createMcpServer.mockReset();
+    lifecycleMocks.attachMcpBackgroundWatcher.mockReset();
     lifecycleMocks.createWatcherWithIndexer.mockReset();
-    lifecycleMocks.stopAutoIndex.mockReset();
+    lifecycleMocks.stopBackgroundWorker.mockReset();
     lifecycleMocks.exit.mockReset();
     vi.spyOn(process, "exit").mockImplementation(((code?: number | string) => {
       events.push(`exit:${String(code)}`);
@@ -81,8 +98,9 @@ describe("MCP CLI shutdown lifecycle", () => {
         events.push("watcher.stop");
       }),
     };
-    lifecycleMocks.stopAutoIndex.mockImplementation(async () => {
-      events.push("autoIndex.stop");
+    lifecycleMocks.stopBackgroundWorker.mockImplementation(async () => {
+      if (watcherAttached) await watcher.stop();
+      events.push("backgroundWorker.stop");
     });
     server = {
       close: vi.fn(async () => {
@@ -97,6 +115,20 @@ describe("MCP CLI shutdown lifecycle", () => {
     };
     lifecycleMocks.createMcpServer.mockReturnValue(server);
     lifecycleMocks.createWatcherWithIndexer.mockReturnValue(watcher);
+    lifecycleMocks.stopBackgroundWorker.mockImplementation(async () => {
+      if (watcherAttached) {
+        try {
+          await watcher.stop();
+        } catch (error) {
+          throw new lifecycleMocks.BackgroundWorkerStopError(error, undefined);
+        }
+      }
+      events.push("backgroundWorker.stop");
+    });
+    lifecycleMocks.attachMcpBackgroundWatcher.mockImplementation((_project, _config, _host, factory) => {
+      watcherAttached = true;
+      factory?.();
+    });
   });
 
   afterEach(() => {
@@ -125,7 +157,7 @@ describe("MCP CLI shutdown lifecycle", () => {
       expect(lifecycleMocks.exit).toHaveBeenCalledWith(0);
     });
     expect(watcher.stop).toHaveBeenCalledOnce();
-    expect(lifecycleMocks.stopAutoIndex).toHaveBeenCalledOnce();
+    expect(lifecycleMocks.stopBackgroundWorker).toHaveBeenCalledOnce();
     expect(server.close).toHaveBeenCalledOnce();
   }
 
@@ -147,7 +179,7 @@ describe("MCP CLI shutdown lifecycle", () => {
 
     stopGate.resolve();
     await expectSuccessfulShutdown();
-    expect(events).toEqual(["watcher.stop", "autoIndex.stop", "server.close", "exit:0"]);
+    expect(events).toEqual(["watcher.stop", "backgroundWorker.stop", "server.close", "exit:0"]);
   });
 
   it("runs teardown when stdin closes without an end event", async () => {
@@ -156,7 +188,27 @@ describe("MCP CLI shutdown lifecycle", () => {
     process.stdin.emit("close");
 
     await expectSuccessfulShutdown();
-    expect(events).toEqual(["watcher.stop", "autoIndex.stop", "server.close", "exit:0"]);
+    expect(events).toEqual(["watcher.stop", "backgroundWorker.stop", "server.close", "exit:0"]);
+  });
+
+  it("waits for background watcher startup before connecting the transport", async () => {
+    const watcherStarted = createDeferred<void>();
+    lifecycleMocks.attachMcpBackgroundWatcher.mockImplementation((_project, _config, _host, factory) => {
+      watcherAttached = true;
+      factory?.();
+      return watcherStarted.promise;
+    });
+
+    const starting = startCli();
+    await vi.waitFor(() => expect(lifecycleMocks.attachMcpBackgroundWatcher).toHaveBeenCalledOnce());
+    expect(server.connect).not.toHaveBeenCalled();
+
+    watcherStarted.resolve();
+    await starting;
+    expect(server.connect).toHaveBeenCalledOnce();
+
+    process.stdin.emit("close");
+    await expectSuccessfulShutdown();
   });
 
   it("still closes the server when watcher teardown fails", async () => {
@@ -176,13 +228,13 @@ describe("MCP CLI shutdown lifecycle", () => {
     });
     expect(server.close).toHaveBeenCalledOnce();
     expect(error).toHaveBeenCalledWith("Failed to stop MCP file watcher cleanly:", stopError);
-    expect(events).toEqual(["watcher.stop", "autoIndex.stop", "server.close", "exit:1"]);
+    expect(events).toEqual(["watcher.stop", "server.close", "exit:1"]);
   });
 
-  it("still closes the server when auto-index shutdown fails", async () => {
-    const stopError = new Error("auto-index stop failed");
-    lifecycleMocks.stopAutoIndex.mockImplementation(async () => {
-      events.push("autoIndex.stop");
+  it("still closes the server when background worker shutdown fails", async () => {
+    const stopError = new Error("background worker stop failed");
+    lifecycleMocks.stopBackgroundWorker.mockImplementation(async () => {
+      events.push("backgroundWorker.stop");
       throw stopError;
     });
     const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
@@ -193,10 +245,10 @@ describe("MCP CLI shutdown lifecycle", () => {
     await vi.waitFor(() => {
       expect(lifecycleMocks.exit).toHaveBeenCalledWith(1);
     });
-    expect(lifecycleMocks.stopAutoIndex).toHaveBeenCalledOnce();
+    expect(lifecycleMocks.stopBackgroundWorker).toHaveBeenCalledOnce();
     expect(server.close).toHaveBeenCalledOnce();
     expect(error).toHaveBeenCalledWith("Failed to stop automatic indexing cleanly:", stopError);
-    expect(events).toEqual(["watcher.stop", "autoIndex.stop", "server.close", "exit:1"]);
+    expect(events).toEqual(["backgroundWorker.stop", "server.close", "exit:1"]);
   });
 
   it("handles SIGINT while MCP transport startup is still pending", async () => {
@@ -223,8 +275,8 @@ describe("MCP CLI shutdown lifecycle", () => {
     await vi.waitFor(() => {
       expect(lifecycleMocks.exit).toHaveBeenCalledWith(0);
     });
-    expect(watcher.stop).not.toHaveBeenCalled();
-    expect(lifecycleMocks.stopAutoIndex).toHaveBeenCalledOnce();
+    expect(watcher.stop).toHaveBeenCalledOnce();
+    expect(lifecycleMocks.stopBackgroundWorker).toHaveBeenCalledOnce();
     expect(server.close).toHaveBeenCalledOnce();
   });
 
@@ -234,7 +286,7 @@ describe("MCP CLI shutdown lifecycle", () => {
     server.server.onclose?.();
 
     await expectSuccessfulShutdown();
-    expect(events).toEqual(["server.onclose", "watcher.stop", "autoIndex.stop", "server.close", "exit:0"]);
+    expect(events).toEqual(["server.onclose", "watcher.stop", "backgroundWorker.stop", "server.close", "exit:0"]);
   });
 
   if (process.platform !== "win32") {
@@ -244,7 +296,7 @@ describe("MCP CLI shutdown lifecycle", () => {
       process.emit(signal);
 
       await expectSuccessfulShutdown();
-      expect(events).toEqual(["watcher.stop", "autoIndex.stop", "server.close", "exit:0"]);
+      expect(events).toEqual(["watcher.stop", "backgroundWorker.stop", "server.close", "exit:0"]);
     });
   }
 

--- a/tests/mcp-lifecycle.test.ts
+++ b/tests/mcp-lifecycle.test.ts
@@ -4,21 +4,43 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 
 import { parseConfig } from "../src/config/schema.js";
 import { createMcpServer } from "../src/mcp-server.js";
+import {
+  configCache,
+  getIndexerCacheKey,
+  getIndexerForProject,
+  indexerCache,
+  initializeTools,
+} from "../src/tools/operation-runtime.js";
 import { resetAutoIndexCoordinatorsForTests } from "../src/utils/auto-index.js";
 
-const autoIndexMocks = vi.hoisted(() => ({
-  startAutoIndex: vi.fn(),
-  stopAutoIndex: vi.fn(async () => {}),
+const backgroundWorkerMocks = vi.hoisted(() => ({
+  attachBackgroundWorkerWatcher: vi.fn(),
+  configureBackgroundWorker: vi.fn(),
+  getBackgroundWorkerProjectKey: vi.fn((projectRoot: string, host: string) => `${host}::${projectRoot}`),
+  stopBackgroundWorker: vi.fn(async () => {}),
+  updateBackgroundWorkerConfig: vi.fn(),
+  isBackgroundWorkerLeader: vi.fn(() => false),
+  isBackgroundWorkerManaged: vi.fn(() => false),
+}));
+
+vi.mock("../src/utils/background-worker.js", () => ({
+  attachBackgroundWorkerWatcher: backgroundWorkerMocks.attachBackgroundWorkerWatcher,
+  configureBackgroundWorker: backgroundWorkerMocks.configureBackgroundWorker,
+  getBackgroundWorkerProjectKey: backgroundWorkerMocks.getBackgroundWorkerProjectKey,
+  stopBackgroundWorker: backgroundWorkerMocks.stopBackgroundWorker,
+  updateBackgroundWorkerConfig: backgroundWorkerMocks.updateBackgroundWorkerConfig,
+  isBackgroundWorkerLeader: backgroundWorkerMocks.isBackgroundWorkerLeader,
+  isBackgroundWorkerManaged: backgroundWorkerMocks.isBackgroundWorkerManaged,
+  requestBackgroundWorker: vi.fn(),
+  requestBackgroundWorkerRefresh: vi.fn(),
 }));
 
 vi.mock("../src/utils/auto-index.js", async () => {
-  const actual = await vi.importActual<typeof import("../src/utils/auto-index.js")>(
-    "../src/utils/auto-index.js",
-  );
+  const actual = await vi.importActual<typeof import("../src/utils/auto-index.js")>("../src/utils/auto-index.js");
   return {
     ...actual,
-    startAutoIndex: autoIndexMocks.startAutoIndex,
-    stopAutoIndex: autoIndexMocks.stopAutoIndex,
+    startAutoIndexForBackgroundWorker: vi.fn(),
+    stopAutoIndex: vi.fn(async () => {}),
   };
 });
 
@@ -30,21 +52,50 @@ function pendingStop(): { promise: Promise<void>; resolve: () => void } {
   return { promise, resolve };
 }
 
+function safeProjectConfig() {
+  return parseConfig({ indexing: { requireProjectMarker: false } });
+}
+
 describe("MCP automatic indexing lifecycle", () => {
   beforeEach(() => {
-    autoIndexMocks.startAutoIndex.mockReset();
-    autoIndexMocks.stopAutoIndex.mockReset();
-    autoIndexMocks.stopAutoIndex.mockResolvedValue(undefined);
+    backgroundWorkerMocks.attachBackgroundWorkerWatcher.mockReset();
+    backgroundWorkerMocks.configureBackgroundWorker.mockReset();
+    backgroundWorkerMocks.getBackgroundWorkerProjectKey.mockClear();
+    backgroundWorkerMocks.stopBackgroundWorker.mockReset();
+    backgroundWorkerMocks.stopBackgroundWorker.mockResolvedValue(undefined);
+    backgroundWorkerMocks.updateBackgroundWorkerConfig.mockReset();
+    backgroundWorkerMocks.isBackgroundWorkerLeader.mockReset();
+    backgroundWorkerMocks.isBackgroundWorkerLeader.mockReturnValue(false);
+    backgroundWorkerMocks.isBackgroundWorkerManaged.mockReset();
+    backgroundWorkerMocks.isBackgroundWorkerManaged.mockReturnValue(false);
   });
 
   afterEach(async () => {
     await resetAutoIndexCoordinatorsForTests();
   });
 
+  it("refreshes the authoritative OpenCode configuration when its plugin reloads", () => {
+    const projectRoot = "/tmp/opencode-authoritative-reload";
+    const disabled = parseConfig({ indexing: { autoIndex: false, watchFiles: false } });
+    const enabled = parseConfig({ indexing: { autoIndex: true, watchFiles: false } });
+    const key = getIndexerCacheKey(projectRoot, "opencode");
+    backgroundWorkerMocks.isBackgroundWorkerManaged.mockReturnValue(true);
+
+    try {
+      initializeTools(projectRoot, disabled, "opencode");
+      initializeTools(projectRoot, enabled, "opencode");
+
+      expect(configCache.get(key)?.indexing.autoIndex).toBe(true);
+    } finally {
+      configCache.delete(key);
+      indexerCache.delete(key);
+    }
+  });
+
   it("awaits coordination shutdown from the high-level server close", async () => {
     const stop = pendingStop();
-    autoIndexMocks.stopAutoIndex.mockReturnValueOnce(stop.promise);
-    const server = createMcpServer("/tmp/mcp-close-project", parseConfig({}), "jcode");
+    backgroundWorkerMocks.stopBackgroundWorker.mockReturnValueOnce(stop.promise);
+    const server = createMcpServer("/tmp/mcp-close-project", safeProjectConfig(), "jcode");
 
     let settled = false;
     const closing = server.close().then(() => {
@@ -52,7 +103,7 @@ describe("MCP automatic indexing lifecycle", () => {
     });
     await Promise.resolve();
 
-    expect(autoIndexMocks.stopAutoIndex).toHaveBeenCalledWith("/tmp/mcp-close-project", "jcode");
+    expect(backgroundWorkerMocks.stopBackgroundWorker).toHaveBeenCalledWith("/tmp/mcp-close-project", "jcode");
     expect(settled).toBe(false);
     stop.resolve();
     await closing;
@@ -61,8 +112,8 @@ describe("MCP automatic indexing lifecycle", () => {
 
   it("awaits coordination shutdown from the low-level server close", async () => {
     const stop = pendingStop();
-    autoIndexMocks.stopAutoIndex.mockReturnValueOnce(stop.promise);
-    const server = createMcpServer("/tmp/mcp-shutdown-project", parseConfig({}), "claude");
+    backgroundWorkerMocks.stopBackgroundWorker.mockReturnValueOnce(stop.promise);
+    const server = createMcpServer("/tmp/mcp-shutdown-project", safeProjectConfig(), "claude");
 
     let settled = false;
     const closing = server.server.close().then(() => {
@@ -70,7 +121,7 @@ describe("MCP automatic indexing lifecycle", () => {
     });
     await Promise.resolve();
 
-    expect(autoIndexMocks.stopAutoIndex).toHaveBeenCalledWith("/tmp/mcp-shutdown-project", "claude");
+    expect(backgroundWorkerMocks.stopBackgroundWorker).toHaveBeenCalledWith("/tmp/mcp-shutdown-project", "claude");
     expect(settled).toBe(false);
     stop.resolve();
     await closing;
@@ -78,7 +129,7 @@ describe("MCP automatic indexing lifecycle", () => {
   });
 
   it("stops coordination when the MCP transport shuts down", async () => {
-    const server = createMcpServer("/tmp/mcp-transport-project", parseConfig({}), "codex");
+    const server = createMcpServer("/tmp/mcp-transport-project", safeProjectConfig(), "codex");
     const client = new Client({ name: "lifecycle-test", version: "1.0.0" });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
@@ -86,7 +137,70 @@ describe("MCP automatic indexing lifecycle", () => {
     await client.close();
 
     await vi.waitFor(() => {
-      expect(autoIndexMocks.stopAutoIndex).toHaveBeenCalledWith("/tmp/mcp-transport-project", "codex");
+      expect(backgroundWorkerMocks.stopBackgroundWorker).toHaveBeenCalledWith("/tmp/mcp-transport-project", "codex");
     });
+  });
+
+  it("handles a background teardown rejection from the transport close callback", async () => {
+    const stopError = new Error("background teardown failed");
+    backgroundWorkerMocks.stopBackgroundWorker.mockRejectedValueOnce(stopError);
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const server = createMcpServer("/tmp/mcp-transport-stop-error", safeProjectConfig(), "codex");
+
+    server.server.onclose?.();
+
+    await vi.waitFor(() => {
+      expect(error).toHaveBeenCalledWith(
+        "[codebase-index] Failed to stop MCP background worker after transport close:",
+        stopError,
+      );
+    });
+    error.mockRestore();
+  });
+
+  it("keeps shared coordination running until the final same-process server closes", async () => {
+    const projectRoot = "/tmp/mcp-shared-process-project";
+    const first = createMcpServer(projectRoot, safeProjectConfig(), "codex");
+    const second = createMcpServer(projectRoot, safeProjectConfig(), "codex");
+
+    await first.close();
+    expect(backgroundWorkerMocks.stopBackgroundWorker).not.toHaveBeenCalled();
+
+    await second.close();
+    expect(backgroundWorkerMocks.stopBackgroundWorker).toHaveBeenCalledTimes(1);
+    expect(backgroundWorkerMocks.stopBackgroundWorker).toHaveBeenCalledWith(projectRoot, "codex");
+  });
+
+  it("keeps a safe shared worker running when a marker-required server joins", async () => {
+    const projectRoot = "/tmp/mcp-shared-process-without-marker";
+    const safe = createMcpServer(projectRoot, safeProjectConfig(), "codex");
+    const unsafe = createMcpServer(projectRoot, parseConfig({
+      indexing: { requireProjectMarker: true },
+    }), "codex");
+
+    expect(backgroundWorkerMocks.stopBackgroundWorker).not.toHaveBeenCalled();
+
+    await unsafe.close();
+    expect(backgroundWorkerMocks.stopBackgroundWorker).not.toHaveBeenCalled();
+
+    await safe.close();
+    expect(backgroundWorkerMocks.stopBackgroundWorker).toHaveBeenCalledTimes(1);
+    expect(backgroundWorkerMocks.stopBackgroundWorker).toHaveBeenCalledWith(projectRoot, "codex");
+  });
+
+  it("keeps the existing indexer when a marker-required server joins a managed worker", async () => {
+    const projectRoot = "/tmp/mcp-managed-worker-indexer";
+    const safe = createMcpServer(projectRoot, safeProjectConfig(), "codex");
+    const safeIndexer = getIndexerForProject(projectRoot, "codex");
+    backgroundWorkerMocks.isBackgroundWorkerManaged.mockReturnValue(true);
+
+    const unsafe = createMcpServer(projectRoot, parseConfig({
+      indexing: { requireProjectMarker: true },
+    }), "codex");
+
+    expect(getIndexerForProject(projectRoot, "codex")).toBe(safeIndexer);
+
+    await unsafe.close();
+    await safe.close();
   });
 });

--- a/tests/mcp-lifecycle.test.ts
+++ b/tests/mcp-lifecycle.test.ts
@@ -21,6 +21,8 @@ const backgroundWorkerMocks = vi.hoisted(() => ({
   updateBackgroundWorkerConfig: vi.fn(),
   isBackgroundWorkerLeader: vi.fn(() => false),
   isBackgroundWorkerManaged: vi.fn(() => false),
+  isBackgroundWorkerStopping: vi.fn(() => false),
+  requestBackgroundWorker: vi.fn(),
 }));
 
 vi.mock("../src/utils/background-worker.js", () => ({
@@ -31,7 +33,8 @@ vi.mock("../src/utils/background-worker.js", () => ({
   updateBackgroundWorkerConfig: backgroundWorkerMocks.updateBackgroundWorkerConfig,
   isBackgroundWorkerLeader: backgroundWorkerMocks.isBackgroundWorkerLeader,
   isBackgroundWorkerManaged: backgroundWorkerMocks.isBackgroundWorkerManaged,
-  requestBackgroundWorker: vi.fn(),
+  isBackgroundWorkerStopping: backgroundWorkerMocks.isBackgroundWorkerStopping,
+  requestBackgroundWorker: backgroundWorkerMocks.requestBackgroundWorker,
   requestBackgroundWorkerRefresh: vi.fn(),
 }));
 
@@ -68,6 +71,9 @@ describe("MCP automatic indexing lifecycle", () => {
     backgroundWorkerMocks.isBackgroundWorkerLeader.mockReturnValue(false);
     backgroundWorkerMocks.isBackgroundWorkerManaged.mockReset();
     backgroundWorkerMocks.isBackgroundWorkerManaged.mockReturnValue(false);
+    backgroundWorkerMocks.isBackgroundWorkerStopping.mockReset();
+    backgroundWorkerMocks.isBackgroundWorkerStopping.mockReturnValue(false);
+    backgroundWorkerMocks.requestBackgroundWorker.mockReset();
   });
 
   afterEach(async () => {
@@ -169,6 +175,47 @@ describe("MCP automatic indexing lifecycle", () => {
     await second.close();
     expect(backgroundWorkerMocks.stopBackgroundWorker).toHaveBeenCalledTimes(1);
     expect(backgroundWorkerMocks.stopBackgroundWorker).toHaveBeenCalledWith(projectRoot, "codex");
+  });
+
+  it("restarts shared coordination when a replacement server joins during teardown", async () => {
+    const projectRoot = "/tmp/mcp-replacement-during-teardown";
+    const stop = pendingStop();
+    backgroundWorkerMocks.isBackgroundWorkerManaged.mockReturnValue(false);
+    backgroundWorkerMocks.stopBackgroundWorker
+      .mockReturnValueOnce(stop.promise)
+      .mockResolvedValueOnce(undefined);
+
+    const first = createMcpServer(projectRoot, safeProjectConfig(), "codex");
+    backgroundWorkerMocks.isBackgroundWorkerManaged.mockReturnValue(true);
+    const closing = first.close();
+    await vi.waitFor(() => {
+      expect(backgroundWorkerMocks.stopBackgroundWorker).toHaveBeenCalledOnce();
+    });
+
+    const replacement = createMcpServer(projectRoot, safeProjectConfig(), "codex");
+    expect(backgroundWorkerMocks.requestBackgroundWorker).toHaveBeenCalledWith(projectRoot, "codex");
+
+    stop.resolve();
+    await closing;
+    await replacement.close();
+    expect(backgroundWorkerMocks.stopBackgroundWorker).toHaveBeenCalledTimes(2);
+  });
+
+  it("restarts shared coordination when a server joins an external teardown", async () => {
+    const projectRoot = "/tmp/mcp-replacement-during-external-teardown";
+    backgroundWorkerMocks.isBackgroundWorkerManaged.mockReturnValue(false);
+    const first = createMcpServer(projectRoot, safeProjectConfig(), "codex");
+
+    backgroundWorkerMocks.isBackgroundWorkerManaged.mockReturnValue(true);
+    backgroundWorkerMocks.isBackgroundWorkerStopping.mockReturnValue(true);
+    const replacement = createMcpServer(projectRoot, safeProjectConfig(), "codex");
+
+    expect(backgroundWorkerMocks.requestBackgroundWorker).toHaveBeenCalledWith(projectRoot, "codex");
+
+    await first.close();
+    expect(backgroundWorkerMocks.stopBackgroundWorker).not.toHaveBeenCalled();
+    await replacement.close();
+    expect(backgroundWorkerMocks.stopBackgroundWorker).toHaveBeenCalledOnce();
   });
 
   it("keeps a safe shared worker running when a marker-required server joins", async () => {

--- a/tests/multiprocess-indexing.test.ts
+++ b/tests/multiprocess-indexing.test.ts
@@ -14,6 +14,7 @@ import { parseConfig } from "../src/config/schema.js";
 import { Indexer } from "../src/indexer/index.js";
 import { acquireIndexLock, releaseIndexLock } from "../src/indexer/index-lock.js";
 import { Database, InvertedIndex, VectorStore } from "../src/native/index.js";
+import { getBackgroundWorkerLeasePath } from "../src/utils/background-worker.js";
 
 interface WorkerMessage {
   type: string;
@@ -305,6 +306,7 @@ describe("multiprocess indexing", () => {
   async function createMcpClient(
     configPath: string,
     host: "claude" | "codex" | "jcode" | "opencode" | "pi" = "opencode",
+    options: { environment?: Record<string, string>; preloads?: string[] } = {},
   ): Promise<{
     client: Client;
     transport: StdioClientTransport;
@@ -312,10 +314,14 @@ describe("multiprocess indexing", () => {
   }> {
     const stderr: string[] = [];
     const cliPath = fileURLToPath(new URL("../src/cli.ts", import.meta.url));
+    const args = ["--import", "tsx"];
+    for (const preload of options.preloads ?? []) args.push("--import", preload);
+    args.push(cliPath, "--project", projectRoot, "--config", configPath, "--host", host);
     const transport = new StdioClientTransport({
       command: process.execPath,
-      args: ["--import", "tsx", cliPath, "--project", projectRoot, "--config", configPath, "--host", host],
+      args,
       cwd: path.dirname(cliPath),
+      env: { ...Object.fromEntries(Object.entries(process.env).filter(([, value]) => value !== undefined)), ...options.environment },
       stderr: "pipe",
     });
     transport.stderr?.on("data", (chunk) => stderr.push(String(chunk)));
@@ -336,6 +342,70 @@ describe("multiprocess indexing", () => {
     expect(result.ok).toBe(true);
     await worker.waitForExit();
     await embeddingServer.waitForIdle();
+  }
+
+  async function waitForCondition(
+    condition: () => boolean,
+    description: string,
+    timeoutMs = 10_000,
+  ): Promise<void> {
+    const startedAt = Date.now();
+    while (!condition()) {
+      if (Date.now() - startedAt > timeoutMs) throw new Error(`Timed out waiting for ${description}`);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+
+  async function waitForProcessExit(pid: number, timeoutMs = 5_000): Promise<void> {
+    const startedAt = Date.now();
+    while (true) {
+      try {
+        process.kill(pid, 0);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ESRCH") return;
+        throw error;
+      }
+      if (Date.now() - startedAt > timeoutMs) {
+        throw new Error(`Process ${pid} did not exit`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+
+  function writeBackgroundMcpConfig(
+    configPath: string,
+    indexingOverrides: Record<string, unknown> = {},
+  ): ReturnType<typeof parseConfig> {
+    const rawConfig = {
+      embeddingProvider: "custom",
+      scope: "project",
+      customProvider: {
+        baseUrl: embeddingServer.baseUrl,
+        model: "multiprocess-test",
+        dimensions: 8,
+        timeoutMs: 5000,
+        maxBatchSize: 64,
+        concurrency: 1,
+        requestIntervalMs: 0,
+      },
+      include: ["**/*.ts"],
+      exclude: ["**/.codebase-index/**", "**/.opencode/**", "**/.git/**", "**/node_modules/**"],
+      indexing: {
+        autoIndex: true,
+        autoIndexWaitMs: 5000,
+        autoIndexMaxRetries: 3,
+        autoIndexRetryDelayMs: 10,
+        watchFiles: true,
+        autoGc: false,
+        retries: 0,
+        retryDelayMs: 1,
+        gitBlame: { enabled: false },
+        ...indexingOverrides,
+      },
+      debug: { enabled: false },
+    };
+    fs.writeFileSync(configPath, JSON.stringify(rawConfig));
+    return parseConfig(rawConfig);
   }
 
   function createLocalIndexer(
@@ -1169,6 +1239,376 @@ describe("multiprocess indexing", () => {
     await Promise.all([first.client.close(), second.client.close()]);
     mcpClients = [];
     assertIndexIntegrity();
+  });
+
+  it("elects one Codex background worker, blocks a stale snapshot, and promotes a follower", async () => {
+    const configPath = path.join(tempDir, "codex-background-worker.json");
+    const parsedConfig = writeBackgroundMcpConfig(configPath, { autoIndexWaitMs: 0 });
+    const seededIndexer = new Indexer(projectRoot, parsedConfig, "codex");
+    localIndexers.push(seededIndexer);
+    await seededIndexer.index();
+    await embeddingServer.waitForIdle();
+    embeddingServer.reset();
+
+    const indexPath = path.join(projectRoot, ".codebase-index", "index");
+    const readyPath = path.join(tempDir, "background-publication-ready.json");
+    const releasePath = path.join(tempDir, "background-publication-release");
+    const watcherEventsPath = path.join(tempDir, "watcher-events.log");
+    const environment = {
+      TEST_BM25_TARGET_PATH: fs.realpathSync(path.join(indexPath, "inverted-index.json")),
+      TEST_BM25_READY_PATH: readyPath,
+      TEST_BM25_RELEASE_PATH: releasePath,
+      TEST_PROJECT_ROOT: projectRoot,
+      TEST_WATCHER_EVENTS_PATH: watcherEventsPath,
+    };
+    const preloads = [
+      new URL("./fixtures/bm25-publication-barrier.mjs", import.meta.url).href,
+      new URL("./fixtures/watcher-probe.mjs", import.meta.url).href,
+    ];
+
+    const [first, second] = await Promise.all([
+      createMcpClient(configPath, "codex", { environment, preloads }),
+      createMcpClient(configPath, "codex", { environment, preloads }),
+    ]);
+    expect(first.transport.pid).not.toBeNull();
+    expect(second.transport.pid).not.toBeNull();
+    expect(first.transport.pid).not.toBe(second.transport.pid);
+
+    const leasePath = getBackgroundWorkerLeasePath(projectRoot, parsedConfig, "codex");
+    await waitForCondition(() => fs.existsSync(leasePath), "background worker lease");
+    await waitForCondition(() => {
+      if (!fs.existsSync(watcherEventsPath)) return false;
+      const watcherStarts = fs.readFileSync(watcherEventsPath, "utf-8").trim().split("\n").filter(Boolean);
+      return new Set(watcherStarts).size === 1;
+    }, "watching from exactly one process");
+
+    const firstOwner = JSON.parse(fs.readFileSync(path.join(leasePath, "owner.json"), "utf-8")) as { pid: number };
+    expect([first.transport.pid, second.transport.pid]).toContain(firstOwner.pid);
+    const initialWatcherStarts = fs.readFileSync(watcherEventsPath, "utf-8").trim().split("\n").filter(Boolean);
+    expect(new Set(initialWatcherStarts)).toEqual(new Set([String(firstOwner.pid)]));
+    const leader = first.transport.pid === firstOwner.pid ? first : second;
+    const follower = leader === first ? second : first;
+
+    fs.writeFileSync(sourcePath, "export function alpha() { return 'stale'; }\nexport function gamma() { return alpha(); }\n");
+    await waitForFile(readyPath);
+    expect(embeddingServer.requestCount).toBe(1);
+    expect(embeddingServer.maxActive).toBe(1);
+
+    const searchResult = await follower.client.callTool({
+      name: "codebase_search",
+      arguments: { query: "beta" },
+    });
+    const searchText = (searchResult.content as Array<{ text?: string }>).map(({ text }) => text ?? "").join("\n");
+    expect(searchResult.isError).toBe(true);
+    expect(searchText).toMatch(/Automatic indexing is (?:idle|indexing)/i);
+    expect(searchText).not.toContain("INDEX_BUSY");
+    expect(embeddingServer.inputs.filter((input) => input.includes("stale"))).toHaveLength(1);
+
+    fs.writeFileSync(releasePath, "release");
+    await embeddingServer.waitForIdle();
+
+    await vi.waitFor(async () => {
+      const refreshedSearch = await follower.client.callTool({
+        name: "codebase_search",
+        arguments: { query: "gamma" },
+      });
+      const refreshedText = (refreshedSearch.content as Array<{ text?: string }>).map(({ text }) => text ?? "").join("\n");
+      expect(refreshedSearch.isError).not.toBe(true);
+      expect(refreshedText).toContain('function_declaration "gamma"');
+    }, { timeout: 10_000 });
+
+    process.kill(firstOwner.pid, "SIGKILL");
+    await waitForCondition(() => {
+      if (!fs.existsSync(leasePath)) return false;
+      const owner = JSON.parse(fs.readFileSync(path.join(leasePath, "owner.json"), "utf-8")) as { pid: number };
+      return owner.pid === follower.transport.pid;
+    }, "follower background worker promotion", 12_000);
+
+    await waitForCondition(() => {
+      if (!fs.existsSync(watcherEventsPath)) return false;
+      const watcherStarts = fs.readFileSync(watcherEventsPath, "utf-8").trim().split("\n").filter(Boolean);
+      return watcherStarts.includes(String(follower.transport.pid));
+    }, "promoted follower watcher activity", 12_000);
+    expect(new Set(fs.readFileSync(watcherEventsPath, "utf-8").trim().split("\n").filter(Boolean))).toEqual(new Set([
+      String(firstOwner.pid),
+      String(follower.transport.pid),
+    ]));
+
+    await vi.waitFor(async () => {
+      const status = await follower.client.callTool({ name: "index_status", arguments: {} });
+      const statusText = (status.content as Array<{ text?: string }>).map(({ text }) => text ?? "").join("\n");
+      expect(statusText).toContain("state: ready");
+    }, { timeout: 10_000 });
+    embeddingServer.reset();
+    fs.writeFileSync(sourcePath, "export function recovered() { return 'after-leader-crash'; }\n");
+    await embeddingServer.waitForRequestCount(1);
+    await embeddingServer.waitForIdle();
+    expect(embeddingServer.inputs).toEqual(expect.arrayContaining([
+      expect.stringContaining("after-leader-crash"),
+    ]));
+
+    await follower.client.close();
+    mcpClients = mcpClients.filter((client) => client !== follower.client && client !== leader.client);
+  });
+
+  it("promotes the remaining Codex process after a clean background-worker shutdown", async () => {
+    const configPath = path.join(tempDir, "codex-clean-background-worker.json");
+    const parsedConfig = writeBackgroundMcpConfig(configPath);
+    const seededIndexer = new Indexer(projectRoot, parsedConfig, "codex");
+    localIndexers.push(seededIndexer);
+    await seededIndexer.index();
+    await embeddingServer.waitForIdle();
+    embeddingServer.reset();
+
+    const indexPath = path.join(projectRoot, ".codebase-index", "index");
+    const watcherEventsPath = path.join(tempDir, "clean-watcher-events.log");
+    const environment = {
+      TEST_PROJECT_ROOT: projectRoot,
+      TEST_WATCHER_EVENTS_PATH: watcherEventsPath,
+    };
+    const preloads = [new URL("./fixtures/watcher-probe.mjs", import.meta.url).href];
+    const [first, second] = await Promise.all([
+      createMcpClient(configPath, "codex", { environment, preloads }),
+      createMcpClient(configPath, "codex", { environment, preloads }),
+    ]);
+    const leasePath = getBackgroundWorkerLeasePath(projectRoot, parsedConfig, "codex");
+    await waitForCondition(() => fs.existsSync(leasePath), "clean-shutdown background worker lease");
+    const owner = JSON.parse(fs.readFileSync(path.join(leasePath, "owner.json"), "utf-8")) as { pid: number };
+    const leader = first.transport.pid === owner.pid ? first : second;
+    const follower = leader === first ? second : first;
+
+    await leader.client.close();
+    mcpClients = mcpClients.filter((client) => client !== leader.client);
+    await waitForCondition(() => {
+      if (!fs.existsSync(leasePath)) return false;
+      const replacement = JSON.parse(fs.readFileSync(path.join(leasePath, "owner.json"), "utf-8")) as { pid: number };
+      return replacement.pid === follower.transport.pid;
+    }, "clean follower promotion", 12_000);
+    await waitForCondition(() => {
+      if (!fs.existsSync(watcherEventsPath)) return false;
+      const watcherStarts = fs.readFileSync(watcherEventsPath, "utf-8").split("\n").filter(Boolean);
+      return watcherStarts.includes(String(follower.transport.pid));
+    }, "clean promoted follower watcher activity", 12_000);
+
+    fs.writeFileSync(sourcePath, "export function cleanhandoff() { return 'after-clean-handoff'; }\n");
+    await embeddingServer.waitForRequestCount(1);
+    await embeddingServer.waitForIdle();
+    expect(embeddingServer.inputs).toEqual(expect.arrayContaining([
+      expect.stringContaining("after-clean-handoff"),
+    ]));
+
+    await follower.client.close();
+    mcpClients = mcpClients.filter((client) => client !== follower.client);
+    expect(fs.existsSync(indexPath)).toBe(true);
+  });
+
+  it("allows a follower to force an explicit index while another process leads background work", async () => {
+    const configPath = path.join(tempDir, "codex-manual-follower-index.json");
+    const parsedConfig = writeBackgroundMcpConfig(configPath);
+    const seededIndexer = new Indexer(projectRoot, parsedConfig, "codex");
+    localIndexers.push(seededIndexer);
+    await seededIndexer.index();
+    await embeddingServer.waitForIdle();
+    embeddingServer.reset();
+
+    const [first, second] = await Promise.all([
+      createMcpClient(configPath, "codex"),
+      createMcpClient(configPath, "codex"),
+    ]);
+    const leasePath = getBackgroundWorkerLeasePath(projectRoot, parsedConfig, "codex");
+    await waitForCondition(() => fs.existsSync(leasePath), "manual-follower background worker lease");
+    const owner = JSON.parse(fs.readFileSync(path.join(leasePath, "owner.json"), "utf-8")) as { pid: number };
+    const leader = first.transport.pid === owner.pid ? first : second;
+    const follower = leader === first ? second : first;
+    await vi.waitFor(async () => {
+      const status = await leader.client.callTool({ name: "index_status", arguments: {} });
+      const text = (status.content as Array<{ text?: string }>).map(({ text }) => text ?? "").join("\n");
+      expect(text).toContain("state: ready");
+    }, { timeout: 10_000 });
+
+    const explicitForce = await follower.client.callTool({
+      name: "index_codebase",
+      arguments: { force: true },
+    });
+    expect(explicitForce.isError, JSON.stringify(explicitForce.content)).not.toBe(true);
+    await embeddingServer.waitForIdle();
+    expect(embeddingServer.requestCount).toBe(1);
+    expect(JSON.parse(fs.readFileSync(path.join(leasePath, "owner.json"), "utf-8"))).toMatchObject({
+      pid: owner.pid,
+    });
+
+    await Promise.all([first.client.close(), second.client.close()]);
+    mcpClients = mcpClients.filter((client) => client !== first.client && client !== second.client);
+  });
+
+  it("exits a busy Codex leader without releasing its lease before follower recovery", async () => {
+    const configPath = path.join(tempDir, "codex-busy-shutdown.json");
+    const parsedConfig = writeBackgroundMcpConfig(configPath);
+    const seededIndexer = new Indexer(projectRoot, parsedConfig, "codex");
+    localIndexers.push(seededIndexer);
+    await seededIndexer.index();
+    await embeddingServer.waitForIdle();
+    embeddingServer.reset();
+
+    const [first, second] = await Promise.all([
+      createMcpClient(configPath, "codex"),
+      createMcpClient(configPath, "codex"),
+    ]);
+    const leasePath = getBackgroundWorkerLeasePath(projectRoot, parsedConfig, "codex");
+    await waitForCondition(() => fs.existsSync(leasePath), "busy-shutdown background worker lease");
+    const owner = JSON.parse(fs.readFileSync(path.join(leasePath, "owner.json"), "utf-8")) as { pid: number };
+    const leader = first.transport.pid === owner.pid ? first : second;
+    const follower = leader === first ? second : first;
+    const leaderPid = leader.transport.pid;
+    if (leaderPid === null) throw new Error("Expected an MCP leader process");
+
+    embeddingServer.block();
+    fs.writeFileSync(sourcePath, "export function busyhandoff() { return 'before-bounded-shutdown'; }\n");
+    await embeddingServer.waitForRequestCount(1);
+    await leader.client.close().catch(() => undefined);
+    mcpClients = mcpClients.filter((client) => client !== leader.client);
+    await waitForProcessExit(leaderPid);
+
+    expect(fs.existsSync(leasePath)).toBe(true);
+    const retainedOwner = JSON.parse(fs.readFileSync(path.join(leasePath, "owner.json"), "utf-8")) as { pid: number };
+    expect(retainedOwner.pid).toBe(leaderPid);
+    embeddingServer.release();
+    await embeddingServer.waitForIdle();
+
+    await waitForCondition(() => {
+      if (!fs.existsSync(leasePath)) return false;
+      const replacement = JSON.parse(fs.readFileSync(path.join(leasePath, "owner.json"), "utf-8")) as { pid: number };
+      return replacement.pid === follower.transport.pid;
+    }, "follower recovery after busy leader exit", 12_000);
+    await vi.waitFor(async () => {
+      const status = await follower.client.callTool({ name: "index_status", arguments: {} });
+      const text = (status.content as Array<{ text?: string }>).map(({ text }) => text ?? "").join("\n");
+      expect(text).toContain("state: ready");
+    }, { timeout: 10_000 });
+
+    embeddingServer.reset();
+    fs.writeFileSync(sourcePath, "export function recoveredbusyhandoff() { return 'after-bounded-shutdown'; }\n");
+    await embeddingServer.waitForRequestCount(1);
+    await embeddingServer.waitForIdle();
+    expect(embeddingServer.inputs).toEqual(expect.arrayContaining([
+      expect.stringContaining("after-bounded-shutdown"),
+    ]));
+
+    await follower.client.close();
+    mcpClients = mcpClients.filter((client) => client !== follower.client);
+  });
+
+  it("keeps watcher-driven indexing when auto-index startup is disabled", async () => {
+    const configPath = path.join(tempDir, "codex-watcher-only.json");
+    const parsedConfig = writeBackgroundMcpConfig(configPath, { autoIndex: false, watchFiles: true });
+    const seededIndexer = new Indexer(projectRoot, parsedConfig, "codex");
+    localIndexers.push(seededIndexer);
+    await seededIndexer.index();
+    await embeddingServer.waitForIdle();
+    embeddingServer.reset();
+
+    const mcp = await createMcpClient(configPath, "codex");
+    const leasePath = getBackgroundWorkerLeasePath(projectRoot, parsedConfig, "codex");
+    await waitForCondition(() => fs.existsSync(leasePath), "watcher-only background worker lease");
+    fs.writeFileSync(sourcePath, "export function watcheronly() { return 'watcher-only-refresh'; }\n");
+    await embeddingServer.waitForRequestCount(1);
+    await embeddingServer.waitForIdle();
+    expect(embeddingServer.inputs).toEqual(expect.arrayContaining([
+      expect.stringContaining("watcher-only-refresh"),
+    ]));
+
+    await mcp.client.close();
+    mcpClients = mcpClients.filter((client) => client !== mcp.client);
+  });
+
+  it("lets an auto-index-enabled follower request first-use indexing from a watcher-only leader", async () => {
+    const leaderConfigPath = path.join(tempDir, "codex-watcher-only-leader.json");
+    const followerConfigPath = path.join(tempDir, "codex-auto-index-follower.json");
+    const leaderConfig = writeBackgroundMcpConfig(leaderConfigPath, {
+      autoIndex: false,
+      watchFiles: true,
+    });
+    writeBackgroundMcpConfig(followerConfigPath, {
+      autoIndex: true,
+      autoIndexWaitMs: 12_000,
+      watchFiles: false,
+    });
+
+    const leader = await createMcpClient(leaderConfigPath, "codex");
+    const leasePath = getBackgroundWorkerLeasePath(projectRoot, leaderConfig, "codex");
+    await waitForCondition(() => fs.existsSync(leasePath), "watcher-only leader lease");
+    expect(JSON.parse(fs.readFileSync(path.join(leasePath, "owner.json"), "utf-8"))).toMatchObject({
+      pid: leader.transport.pid,
+    });
+
+    const follower = await createMcpClient(followerConfigPath, "codex");
+    const lookup = follower.client.callTool({
+      name: "call_graph",
+      arguments: { direction: "callers", name: "alpha" },
+    });
+    await embeddingServer.waitForRequestCount(1, 12_000);
+    await embeddingServer.waitForIdle();
+    expect((await lookup).isError).not.toBe(true);
+    expect(embeddingServer.requestCount).toBe(1);
+    expect(embeddingServer.maxActive).toBe(1);
+
+    await Promise.all([leader.client.close(), follower.client.close()]);
+    mcpClients = mcpClients.filter((client) => client !== leader.client && client !== follower.client);
+  });
+
+  it("has the leader refresh a stale index requested by a follower without file watching", async () => {
+    const configPath = path.join(tempDir, "codex-follower-refresh.json");
+    const parsedConfig = writeBackgroundMcpConfig(configPath, {
+      autoIndex: true,
+      autoIndexWaitMs: 0,
+      watchFiles: false,
+    });
+    const seededIndexer = new Indexer(projectRoot, parsedConfig, "codex");
+    localIndexers.push(seededIndexer);
+    await seededIndexer.index();
+    await embeddingServer.waitForIdle();
+    embeddingServer.reset();
+
+    const [first, second] = await Promise.all([
+      createMcpClient(configPath, "codex"),
+      createMcpClient(configPath, "codex"),
+    ]);
+    const leasePath = getBackgroundWorkerLeasePath(projectRoot, parsedConfig, "codex");
+    await waitForCondition(() => fs.existsSync(leasePath), "follower-refresh background worker lease");
+    const owner = JSON.parse(fs.readFileSync(path.join(leasePath, "owner.json"), "utf-8")) as { pid: number };
+    const follower = first.transport.pid === owner.pid ? second : first;
+
+    fs.writeFileSync(sourcePath, "export function alpha() { return 'follower-refresh'; }\nexport function gamma() { return alpha(); }\n");
+    const search = await follower.client.callTool({
+      name: "codebase_search",
+      arguments: { query: "beta" },
+    });
+    const searchText = (search.content as Array<{ text?: string }>).map(({ text }) => text ?? "").join("\n");
+    expect(search.isError).toBe(true);
+    expect(searchText).toMatch(/Automatic indexing is (?:idle|indexing)/i);
+    expect(searchText).not.toContain("INDEX_BUSY");
+    await waitForCondition(
+      () => embeddingServer.inputs.some((input) => input.includes("follower-refresh")),
+      "leader refresh requested by follower",
+      12_000,
+    );
+    await embeddingServer.waitForIdle();
+    expect(embeddingServer.inputs).toEqual(expect.arrayContaining([
+      expect.stringContaining("follower-refresh"),
+    ]));
+
+    await vi.waitFor(async () => {
+      const refreshedSearch = await follower.client.callTool({
+        name: "codebase_search",
+        arguments: { query: "gamma" },
+      });
+      const refreshedText = (refreshedSearch.content as Array<{ text?: string }>).map(({ text }) => text ?? "").join("\n");
+      expect(refreshedSearch.isError).not.toBe(true);
+      expect(refreshedText).toContain('function_declaration "gamma"');
+    }, { timeout: 10_000 });
+
+    await Promise.all([first.client.close(), second.client.close()]);
+    mcpClients = mcpClients.filter((client) => client !== first.client && client !== second.client);
   });
 
   it("supports first-use, healthy-skip, stale-refresh, and disabled auto-indexing over Jcode stdio", async () => {

--- a/tests/pi-conformance.test.ts
+++ b/tests/pi-conformance.test.ts
@@ -21,6 +21,13 @@ const operationMocks = vi.hoisted(() => ({
 const autoIndexMocks = vi.hoisted(() => ({
   isHomeDirectory: vi.fn(() => false),
   stopAutoIndex: vi.fn(async () => {}),
+  startAutoIndexForBackgroundWorker: vi.fn(),
+}));
+
+const backgroundWorkerMocks = vi.hoisted(() => ({
+  configureBackgroundWorker: vi.fn(),
+  stopBackgroundWorker: vi.fn(async () => {}),
+  waitForBackgroundWorkerStart: vi.fn(async () => {}),
 }));
 
 const configMocks = vi.hoisted(() => ({
@@ -56,6 +63,13 @@ vi.mock("../src/tools/operations.js", () => ({
 vi.mock("../src/utils/auto-index.js", () => ({
   isHomeDirectory: autoIndexMocks.isHomeDirectory,
   stopAutoIndex: autoIndexMocks.stopAutoIndex,
+  startAutoIndexForBackgroundWorker: autoIndexMocks.startAutoIndexForBackgroundWorker,
+}));
+
+vi.mock("../src/utils/background-worker.js", () => ({
+  configureBackgroundWorker: backgroundWorkerMocks.configureBackgroundWorker,
+  stopBackgroundWorker: backgroundWorkerMocks.stopBackgroundWorker,
+  waitForBackgroundWorkerStart: backgroundWorkerMocks.waitForBackgroundWorkerStart,
 }));
 
 vi.mock("../src/config/merger.js", () => ({
@@ -163,11 +177,15 @@ describe("Pi adapter conformance", () => {
     operationMocks.getIndexMetrics.mockClear();
     autoIndexMocks.stopAutoIndex.mockReset();
     autoIndexMocks.stopAutoIndex.mockResolvedValue(undefined);
+    autoIndexMocks.startAutoIndexForBackgroundWorker.mockReset();
     autoIndexMocks.isHomeDirectory.mockReset();
     autoIndexMocks.isHomeDirectory.mockReturnValue(false);
     configMocks.loadMergedConfig.mockReset();
     configMocks.loadMergedConfig.mockReturnValue({ indexing: { watchFiles: false, requireProjectMarker: false } });
     watcherMocks.createWatcherWithIndexer.mockReset();
+    backgroundWorkerMocks.configureBackgroundWorker.mockReset();
+    backgroundWorkerMocks.stopBackgroundWorker.mockReset();
+    backgroundWorkerMocks.stopBackgroundWorker.mockResolvedValue(undefined);
     operationMocks.getIndexerForProject.mockReset();
     operationMocks.getIndexerForProject.mockReturnValue({});
   });
@@ -178,6 +196,14 @@ describe("Pi adapter conformance", () => {
       indexing: { watchFiles: true, requireProjectMarker: false },
     });
     watcherMocks.createWatcherWithIndexer.mockReturnValue(watcher);
+    let configuredWatcher: { stop: () => Promise<void> } | null = null;
+    backgroundWorkerMocks.configureBackgroundWorker.mockImplementation((_root, _host, _config, hooks) => {
+      configuredWatcher ??= hooks.watcherFactory?.() ?? null;
+    });
+    backgroundWorkerMocks.stopBackgroundWorker.mockImplementation(async () => {
+      await configuredWatcher?.stop();
+      configuredWatcher = null;
+    });
 
     const { beforeAgentStartHandlers, sessionShutdownHandlers } = await registerPiTools();
     const event = { systemPrompt: "base prompt" };
@@ -196,7 +222,7 @@ describe("Pi adapter conformance", () => {
 
     await sessionShutdownHandlers[0]?.({ type: "session_shutdown" }, ctx);
     expect(watcher.stop).toHaveBeenCalledOnce();
-    expect(autoIndexMocks.stopAutoIndex).toHaveBeenCalledWith("/watched-project", "pi");
+    expect(backgroundWorkerMocks.stopBackgroundWorker).toHaveBeenCalledWith("/watched-project", "pi");
   });
 
   it("does not start a Pi watcher when watchFiles is disabled", async () => {
@@ -210,12 +236,71 @@ describe("Pi adapter conformance", () => {
     expect(watcherMocks.createWatcherWithIndexer).not.toHaveBeenCalled();
   });
 
+  it("initializes the Pi indexer before its background worker starts automatic indexing", async () => {
+    const events: string[] = [];
+    configMocks.loadMergedConfig.mockReturnValue({
+      indexing: { autoIndex: true, watchFiles: false, requireProjectMarker: false },
+    });
+    operationMocks.getIndexerForProject.mockImplementation(() => {
+      events.push("indexer");
+      return {};
+    });
+    backgroundWorkerMocks.configureBackgroundWorker.mockImplementation((_root, _host, _config, hooks) => {
+      events.push("worker");
+      hooks.startAutoIndex("startup");
+    });
+    autoIndexMocks.startAutoIndexForBackgroundWorker.mockImplementation(() => {
+      events.push("auto-index");
+    });
+    const { beforeAgentStartHandlers } = await registerPiTools();
+
+    await beforeAgentStartHandlers[0]?.(
+      { systemPrompt: "base prompt" },
+      { cwd: "/pi-auto-index-project" },
+    );
+
+    expect(events).toEqual(["indexer", "worker", "auto-index"]);
+    expect(watcherMocks.createWatcherWithIndexer).not.toHaveBeenCalled();
+  });
+
+  it("does not request automatic-index restarts for repeated Pi agent starts", async () => {
+    configMocks.loadMergedConfig.mockReturnValue({
+      indexing: { autoIndex: true, watchFiles: false, requireProjectMarker: false },
+    });
+    const { beforeAgentStartHandlers } = await registerPiTools();
+    const event = { systemPrompt: "base prompt" };
+    const ctx = { cwd: "/pi-repeated-start-project" };
+
+    await beforeAgentStartHandlers[0]?.(event, ctx);
+    await beforeAgentStartHandlers[0]?.(event, ctx);
+
+    expect(backgroundWorkerMocks.configureBackgroundWorker).toHaveBeenCalledTimes(2);
+    expect(backgroundWorkerMocks.configureBackgroundWorker.mock.calls.map((call) => call.length)).toEqual([4, 4]);
+  });
+
+  it("logs an invalid-project background worker teardown failure", async () => {
+    autoIndexMocks.isHomeDirectory.mockReturnValue(true);
+    const stopError = new Error("stop failed");
+    backgroundWorkerMocks.stopBackgroundWorker.mockRejectedValue(stopError);
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { beforeAgentStartHandlers } = await registerPiTools();
+
+    await beforeAgentStartHandlers[0]?.(
+      { systemPrompt: "base prompt" },
+      { cwd: "/invalid-pi-project" },
+    );
+    await vi.waitFor(() => {
+      expect(error).toHaveBeenCalledWith("[codebase-index] Failed to stop Pi background worker:", stopError);
+    });
+    error.mockRestore();
+  });
+
   it("awaits automatic indexing shutdown when the Pi session closes", async () => {
     let releaseStop!: () => void;
     const stopping = new Promise<void>((resolve) => {
       releaseStop = resolve;
     });
-    autoIndexMocks.stopAutoIndex.mockReturnValueOnce(stopping);
+    backgroundWorkerMocks.stopBackgroundWorker.mockReturnValueOnce(stopping);
     const { sessionShutdownHandlers } = await registerPiTools();
 
     let settled = false;
@@ -227,7 +312,7 @@ describe("Pi adapter conformance", () => {
     });
     await Promise.resolve();
 
-    expect(autoIndexMocks.stopAutoIndex).toHaveBeenCalledWith("/repo", "pi");
+    expect(backgroundWorkerMocks.stopBackgroundWorker).toHaveBeenCalledWith("/repo", "pi");
     expect(settled).toBe(false);
     releaseStop();
     await shutdown;

--- a/tests/plugin-hooks.test.ts
+++ b/tests/plugin-hooks.test.ts
@@ -36,6 +36,17 @@ const mockState = vi.hoisted(() => ({
   }>,
 }));
 
+const backgroundWorkerMocks = vi.hoisted(() => ({
+  configureBackgroundWorker: vi.fn(),
+  stopBackgroundWorker: vi.fn(async () => {}),
+  updateBackgroundWorkerConfig: vi.fn(),
+  waitForBackgroundWorkerStart: vi.fn(async () => {}),
+}));
+
+const fileMocks = vi.hoisted(() => ({
+  hasProjectMarker: vi.fn(() => true),
+}));
+
 vi.mock("../src/config/merger.js", () => ({
   loadMergedConfig: vi.fn(() => ({})),
 }));
@@ -45,11 +56,22 @@ vi.mock("../src/config/schema.js", () => ({
 }));
 
 vi.mock("../src/utils/files.js", () => ({
-  hasProjectMarker: vi.fn(() => true),
+  hasProjectMarker: fileMocks.hasProjectMarker,
 }));
 
 vi.mock("../src/watcher/index.js", () => ({
   createWatcherWithIndexer: mockState.createWatcherWithIndexer,
+}));
+
+vi.mock("../src/utils/background-worker.js", () => ({
+  configureBackgroundWorker: backgroundWorkerMocks.configureBackgroundWorker,
+  stopBackgroundWorker: backgroundWorkerMocks.stopBackgroundWorker,
+  updateBackgroundWorkerConfig: backgroundWorkerMocks.updateBackgroundWorkerConfig,
+  waitForBackgroundWorkerStart: backgroundWorkerMocks.waitForBackgroundWorkerStart,
+  isBackgroundWorkerLeader: vi.fn(() => false),
+  isBackgroundWorkerManaged: vi.fn(() => false),
+  requestBackgroundWorker: vi.fn(),
+  requestBackgroundWorkerRefresh: vi.fn(),
 }));
 
 vi.mock("../src/commands/loader.js", () => ({
@@ -109,14 +131,6 @@ import { configureAutoIndex, resetAutoIndexCoordinatorsForTests } from "../src/u
 import type { ParsedCodebaseIndexConfig } from "../src/config/schema.js";
 import { OPENCODE_TOOL_NAMES } from "../src/tools/tool-names.js";
 
-function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T | PromiseLike<T>) => void } {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  const promise = new Promise<T>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-  return { promise, resolve };
-}
-
 describe("plugin routing hint hook selection", () => {
   beforeEach(() => {
     mockState.config = {
@@ -139,6 +153,10 @@ describe("plugin routing hint hook selection", () => {
     mockState.hints = ["runtime-routing-hint"];
     mockState.routingControllers.length = 0;
     mockState.createWatcherWithIndexer.mockClear();
+    backgroundWorkerMocks.configureBackgroundWorker.mockReset();
+    backgroundWorkerMocks.stopBackgroundWorker.mockReset().mockResolvedValue(undefined);
+    backgroundWorkerMocks.updateBackgroundWorkerConfig.mockReset();
+    fileMocks.hasProjectMarker.mockReset().mockReturnValue(true);
     mockState.indexer.forceIndex.mockReset().mockResolvedValue({});
     mockState.indexer.getStatus.mockReset().mockResolvedValue({ indexed: true });
     mockState.indexer.index.mockReset().mockResolvedValue({});
@@ -170,9 +188,29 @@ describe("plugin routing hint hook selection", () => {
     try {
       await plugin({ directory: homeLink } as Parameters<typeof plugin>[0]);
       expect(mockState.createWatcherWithIndexer).not.toHaveBeenCalled();
+      expect(backgroundWorkerMocks.configureBackgroundWorker).not.toHaveBeenCalled();
+      expect(backgroundWorkerMocks.stopBackgroundWorker).toHaveBeenCalledWith(homeLink, "opencode");
     } finally {
       warn.mockRestore();
       rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not configure a worker when a project marker is required but missing", async () => {
+    const projectRoot = "/tmp/missing-project-marker";
+    mockState.config.indexing.autoIndex = true;
+    mockState.config.indexing.watchFiles = true;
+    fileMocks.hasProjectMarker.mockReturnValue(false);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      await plugin({ directory: projectRoot } as Parameters<typeof plugin>[0]);
+
+      expect(mockState.createWatcherWithIndexer).not.toHaveBeenCalled();
+      expect(backgroundWorkerMocks.configureBackgroundWorker).not.toHaveBeenCalled();
+      expect(backgroundWorkerMocks.stopBackgroundWorker).toHaveBeenCalledWith(projectRoot, "opencode");
+    } finally {
+      warn.mockRestore();
     }
   });
 
@@ -217,103 +255,41 @@ describe("plugin routing hint hook selection", () => {
     expect(new Set(Object.keys(runtime.tool ?? {})).size).toBe(OPENCODE_TOOL_NAMES.length);
   });
 
-  it("waits for the previous watcher to stop before creating the next one", async () => {
-    mockState.config.indexing.autoIndex = true;
+  it("delegates watcher ownership to the background worker on reload", async () => {
     mockState.config.indexing.watchFiles = true;
-    const indexGate = createDeferred<{}>();
-    mockState.indexer.index.mockImplementationOnce(() => indexGate.promise);
-    const stopGate = createDeferred<void>();
-    const firstWatcher = {
-      stop: vi.fn(() => stopGate.promise),
-    };
-    const secondWatcher = { stop: vi.fn().mockResolvedValue(undefined) };
-    mockState.createWatcherWithIndexer
-      .mockReturnValueOnce(firstWatcher)
-      .mockReturnValueOnce(secondWatcher);
+    const projectRoot = "/tmp/reload-project";
 
-    await plugin({ directory: "/tmp/reload-project" } as Parameters<typeof plugin>[0]);
-    await vi.waitFor(() => expect(mockState.indexer.index).toHaveBeenCalledOnce());
-
-    const secondReload = plugin({ directory: "/tmp/reload-project" } as Parameters<typeof plugin>[0]);
-    await vi.waitFor(() => expect(firstWatcher.stop).toHaveBeenCalledOnce());
-    expect(mockState.createWatcherWithIndexer).toHaveBeenCalledOnce();
-
-    stopGate.resolve();
-    await secondReload;
-
-    expect(mockState.createWatcherWithIndexer).toHaveBeenCalledTimes(2);
-    expect(mockState.indexer.index).toHaveBeenCalledOnce();
-    indexGate.resolve({});
-    await vi.waitFor(() => expect(mockState.indexer.getStatus).toHaveBeenCalled());
-  });
-
-  it("does not create a second watcher when stopping the previous one fails", async () => {
-    mockState.config.indexing.watchFiles = true;
-    const stopError = new Error("stop failed");
-    const firstWatcher = {
-      stop: vi.fn()
-        .mockRejectedValueOnce(stopError)
-        .mockResolvedValue(undefined),
-    };
-    mockState.createWatcherWithIndexer.mockReturnValue(firstWatcher);
-    const error = vi.spyOn(console, "error").mockImplementation(() => {});
-    const projectRoot = "/tmp/stop-failure-project";
-
-    try {
-      await plugin({ directory: projectRoot } as Parameters<typeof plugin>[0]);
-      const failedReload = await plugin({ directory: projectRoot } as Parameters<typeof plugin>[0]);
-
-      expect(failedReload.tool).toBeUndefined();
-      expect(firstWatcher.stop).toHaveBeenCalledOnce();
-      expect(error).toHaveBeenCalledWith("[codebase-index] Failed to stop replaced watcher:", stopError);
-      expect(mockState.createWatcherWithIndexer).toHaveBeenCalledOnce();
-    } finally {
-      mockState.config.indexing.watchFiles = false;
-      await plugin({ directory: projectRoot } as Parameters<typeof plugin>[0]);
-      error.mockRestore();
-    }
-  });
-
-  it("serializes concurrent reloads while replaced watcher shutdowns are pending", async () => {
-    mockState.config.indexing.watchFiles = true;
-    const firstStopGate = createDeferred<void>();
-    const secondStopGate = createDeferred<void>();
-    const firstWatcher = { stop: vi.fn(() => firstStopGate.promise) };
-    const secondWatcher = { stop: vi.fn(() => secondStopGate.promise) };
-    const finalWatcher = { stop: vi.fn().mockResolvedValue(undefined) };
-    mockState.createWatcherWithIndexer
-      .mockReturnValueOnce(firstWatcher)
-      .mockReturnValueOnce(secondWatcher)
-      .mockReturnValueOnce(finalWatcher);
-
-    const projectRoot = "/tmp/concurrent-reload-project";
-    const reloads = [
-      plugin({ directory: projectRoot } as Parameters<typeof plugin>[0]),
-      plugin({ directory: projectRoot } as Parameters<typeof plugin>[0]),
-      plugin({ directory: projectRoot } as Parameters<typeof plugin>[0]),
-    ];
-
-    await vi.waitFor(() => expect(firstWatcher.stop).toHaveBeenCalledOnce());
-    expect(mockState.createWatcherWithIndexer).toHaveBeenCalledOnce();
-    expect(secondWatcher.stop).not.toHaveBeenCalled();
-
-    firstStopGate.resolve();
-    await vi.waitFor(() => expect(secondWatcher.stop).toHaveBeenCalledOnce());
-    expect(mockState.createWatcherWithIndexer).toHaveBeenCalledTimes(2);
-    expect(finalWatcher.stop).not.toHaveBeenCalled();
-
-    secondStopGate.resolve();
-    await Promise.all(reloads);
-
-    expect(mockState.createWatcherWithIndexer).toHaveBeenCalledTimes(3);
-    expect(firstWatcher.stop).toHaveBeenCalledOnce();
-    expect(secondWatcher.stop).toHaveBeenCalledOnce();
-    expect(finalWatcher.stop).not.toHaveBeenCalled();
-
-    mockState.config.indexing.watchFiles = false;
+    await plugin({ directory: projectRoot } as Parameters<typeof plugin>[0]);
     await plugin({ directory: projectRoot } as Parameters<typeof plugin>[0]);
 
-    expect(finalWatcher.stop).toHaveBeenCalledOnce();
+    expect(backgroundWorkerMocks.configureBackgroundWorker).toHaveBeenCalledTimes(2);
+    expect(backgroundWorkerMocks.configureBackgroundWorker).toHaveBeenLastCalledWith(
+      projectRoot,
+      "opencode",
+      mockState.config,
+      expect.objectContaining({
+        watcherFactory: expect.any(Function),
+        watcherFactoryForConfig: expect.any(Function),
+        replaceWatcher: true,
+      }),
+      { restartAutoIndex: true },
+    );
+  });
+
+  it("clears the watcher factory when file watching is disabled", async () => {
+    mockState.config.indexing.watchFiles = false;
+    await plugin({ directory: "/tmp/unwatched-project" } as Parameters<typeof plugin>[0]);
+
+    expect(backgroundWorkerMocks.configureBackgroundWorker).toHaveBeenCalledWith(
+      "/tmp/unwatched-project",
+      "opencode",
+      mockState.config,
+      expect.objectContaining({
+        watcherFactory: null,
+        watcherFactoryForConfig: expect.any(Function),
+      }),
+      { restartAutoIndex: true },
+    );
   });
 
   it("injects hints through system transform when role is system", async () => {

--- a/tests/worktree-fallback.test.ts
+++ b/tests/worktree-fallback.test.ts
@@ -9,6 +9,7 @@ import { parseConfig } from "../src/config/schema.js";
 import { resolveProjectConfigPath, resolveProjectIndexPath, resolveWritableProjectConfigPath } from "../src/config/paths.js";
 import { Indexer } from "../src/indexer/index.js";
 import { Database, hashContent, InvertedIndex, VectorStore } from "../src/native/index.js";
+import { getBackgroundWorkerLeasePath } from "../src/utils/background-worker.js";
 
 function readBranchFileHashes(indexPath: string, branch: string): Record<string, string> {
   const branchHash = hashContent(branch).slice(0, 16);
@@ -229,6 +230,28 @@ describe("worktree fallback (issue #60)", () => {
     } finally {
       await indexer.close();
     }
+  });
+
+  it("keeps worker leases distinct for an inherited index and a worktree-local index", () => {
+    const mainConfig = parseConfig(loadMergedConfig(mainRepoDir, "opencode"));
+    const inheritedConfig = parseConfig(loadMergedConfig(worktreeDir, "opencode"));
+    const mainLease = getBackgroundWorkerLeasePath(mainRepoDir, mainConfig, "opencode");
+    const inheritedLease = getBackgroundWorkerLeasePath(worktreeDir, inheritedConfig, "opencode");
+
+    expect(path.dirname(inheritedLease)).toBe(path.dirname(mainLease));
+    expect(inheritedLease).not.toBe(mainLease);
+
+    fs.mkdirSync(path.join(worktreeDir, ".opencode"), { recursive: true });
+    fs.writeFileSync(
+      path.join(worktreeDir, ".opencode", "codebase-index.json"),
+      JSON.stringify({ scope: "project" }),
+      "utf-8",
+    );
+    const localConfig = parseConfig(loadMergedConfig(worktreeDir, "opencode"));
+    const localLease = getBackgroundWorkerLeasePath(worktreeDir, localConfig, "opencode");
+
+    expect(path.dirname(localLease)).toBe(path.join(fs.realpathSync.native(path.join(worktreeDir, ".opencode")), "index"));
+    expect(localLease).not.toBe(inheritedLease);
   });
 
   it("rebinds branch-scoped runtime caches when one Indexer switches branches", async () => {


### PR DESCRIPTION
## Problem

Each MCP conversation opened on the same project starts its own stdio process, and each process used to start its own watcher and auto-indexer. Because coordination was in memory, nothing was deduplicated across processes. On a real-sized project, this multiplied MCP processes and saturated CPU without useful WAL writes or embedding requests.

## What this PR fixes

- Adds one background worker per project through a filesystem lease distinct from `indexing.lock`: only the leader starts file/Git watching and automatic indexing; other processes remain normal MCP readers.
- A follower search no longer receives `INDEX_BUSY` merely because another process is refreshing the index. The leader handles the follower's refresh request, after which the follower can read the published snapshot.
- Handles leader replacement after normal shutdown or process death through heartbeat renewal, dead-PID recovery, and follower promotion.
- Requires no daemon, index migration, path change, or user configuration change.

## Intentional limitation

Searches against a merely stale index (`files-changed` or `branch-changed`) remain blocked deliberately. SQLite, vectors, and BM25 are not atomically published as one generation, so serving a stale snapshot could mix partial states. Atomic multi-artifact publication is outside this PR's scope.

## Reproduction and design

Starting two `node dist/cli.js --host codex` transports for the same project previously created two independent in-memory coordinators, watchers, and automatic indexing attempts. The new canonical project-root plus index-path lease elects one leader while preserving `indexing.lock` as the only mutation-safety lock. Manual `index`, `--force`, `--estimate-only`, `--config`, and host behavior remain independent of the background lease.

The lifecycle integration covers MCP, OpenCode, and Pi. Followers never start background watchers or jobs, retry bounded election after a leader exits, and can still request a refresh from the elected leader. Shutdown stops watcher coordination before releasing the lease, while an unfinished indexing job retains its lease until process exit makes safe takeover possible.

## Compatibility

- No MCP tool schema, name, argument, response format, index format, index path, migration, global configuration, or local runtime installation changes.
- Worktree isolation remains based on the existing absolute-path/index identity rules.
- `autoIndex: false` and `watchFiles: false` retain their existing semantics.
- Stdio lifecycle coverage includes transport close and signal-driven teardown.

## Validation

- Added real multi-process Codex stdio coverage for one leader, one watcher, one background embedding batch, follower refresh, clean promotion, dead-leader recovery, explicit follower indexing, and lease expiry.
- Added coverage for all supported host modes, worktree paths, safe-project gating, watcher startup, and Pi repeated agent starts.
- `npm run build`, `npm run typecheck`, `npm run lint`, and `git diff --check` pass.
- The full Vitest suite passes serially: 102 files and 1,592 tests.
- `npm run test:run` still hits the repository's known macOS FSEvents `EMFILE` limit in four watcher tests when it runs in parallel. The same tests pass in the serial full-suite run.

No installation or user reconfiguration is required.