### PR TITLE
chore: prepare v0.25.1 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "codebase-index",
       "description": "Semantic code search and codebase graph tools for Claude Code",
       "source": "./",
-      "version": "0.25.0"
+      "version": "0.25.1"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Semantic code search and codebase graph tools for Claude Code",
   "displayName": "Codebase Index",
   "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Semantic code search and codebase graph tools for Codex",
   "author": {
     "name": "Kenneth",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.1] - 2026-08-23
+
 ### Fixed
 
 - **MCP background worker coordination**: Concurrent MCP sessions for the same project now elect one local background worker for file watching and automatic indexing. Other sessions do not start background work and continue serving normal MCP requests, including explicit indexing operations. No daemon, installation, configuration, index-path, or storage migration is required.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.25.0",
+      "version": "0.25.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Host-neutral semantic codebase search with embeddings, symbol discovery, and call-graph tooling",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release preparation

Prepares v0.25.1 for the fixes merged since v0.25.0:

- Correct exclude-glob handling so excluded files are not embedded and stale retries are dropped.
- Coordinate MCP background workers per project without blocking MCP initialization.
- Synchronize package, Claude plugin, Codex plugin, and changelog versions.

## Validation

- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run` (102 files, 1,602 tests)

The GitHub v0.25.1 release remains a draft. This PR does not publish npm packages, create a tag, or publish the release.