### PR TITLE
feat: resolve local TypeScript and JavaScript call targets

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -151,6 +151,8 @@ Focused helpers keep ranking and batch mechanics out of the orchestrator:
 - `file-batches.ts` defines deterministic file-count and source-byte batch limits.
 - `failed-state-persistence.ts` streams versioned JSONL failure state and legacy reads.
 - `call-graph-constants.ts` owns the shared declaration chunk-type allowlist.
+- `local-module-resolution.ts` resolves conservative TypeScript/JavaScript local relative imports and re-exports from current-branch source without LSP or SCIP.
+- `call-graph-coverage.ts` produces deterministic resolved/unresolved totals and per-language graph diagnostics.
 
 Key public methods include:
 
@@ -161,6 +163,7 @@ Key public methods include:
 | `findSimilar()` | Find semantically similar code for a snippet |
 | `getStatus()` | Report readiness, compatibility, and index metadata |
 | `healthCheck()` | Inspect and clean stale index state |
+| `getCallGraphCoverage()` | Report branch-aware graph resolution coverage by language |
 
 ### Embedding Provider (`src/embeddings/`)
 
@@ -186,7 +189,7 @@ Rust components exposed via NAPI:
 | InvertedIndex | Custom | BM25 keyword search |
 | Hasher | xxhash-rust | Fast content hashing |
 
-The crate root in `native/src/lib.rs` remains the NAPI assembly facade. The Database NAPI class lives in `native/src/bindings/database.rs`. SQLite call-graph rows and queries live in `native/src/db/call_graph.rs`, while the remaining schema, migrations, chunk, embedding, and branch persistence stay in `native/src/db.rs`.
+The crate root in `native/src/lib.rs` remains the NAPI assembly facade. The Database NAPI class lives in `native/src/bindings/database.rs`. SQLite call-graph rows and queries live in `native/src/db/call_graph.rs`, while the remaining schema, migrations, chunk, embedding, and branch persistence stay in `native/src/db.rs`. Source-level TypeScript/JavaScript module resolution stays above this boundary in the TypeScript indexer; the persisted call-edge contract and NAPI value shapes remain unchanged.
 
 ### Tool Runtime (`src/tools/`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Source-backed architecture context**: Added the portable `architecture_context` tool across OpenCode, MCP, and Pi. It produces deterministic, token-bounded repository maps with source-derived responsibility excerpts, cited community and boundary evidence, strict query and directory focus, graph-sparse source-directory fallback, uncertainty notes, precise follow-up tool calls, and optional Git-backed recent activity. Architecture planning evaluation now measures graded evidence relevance and actual response token cost.
+- **Local JavaScript module graph resolution**: TypeScript and JavaScript call edges now resolve through local relative ES module imports, aliases, default and namespace imports, named re-exports, and `export *` chains. Resolution remains conservative for ambiguous or missing modules and exports, existing indexes migrate without re-embedding unchanged chunks, and graph coverage diagnostics report branch-aware resolved and unresolved totals by language.
 
 ## [0.25.1] - 2026-08-23
 

--- a/docs/scip-typescript-enrichment-feasibility.md
+++ b/docs/scip-typescript-enrichment-feasibility.md
@@ -1,0 +1,294 @@
+# Optional local SCIP TypeScript enrichment feasibility
+
+**Date:** 2026-08-26
+
+**Decision:** Feasible as an import-only, feature-flagged experiment. Do not implement it on this branch yet.
+
+## Summary
+
+SCIP can improve TypeScript and JavaScript target resolution where OCBI's current tree-sitter and local-module heuristics leave an edge unresolved. It is not a replacement for OCBI parsing or call extraction.
+
+The safest first integration is:
+
+1. keep OCBI as the source of symbols, call sites, call types, and source excerpts;
+2. optionally consume a user-generated local `index.scip`;
+3. invoke a user-installed `scip` CLI with `execFile` to produce bounded JSON;
+4. use SCIP only to resolve currently unresolved TypeScript/JavaScript edges;
+5. fall back to the existing graph without failing indexing.
+
+No adapter was implemented because neither `scip-typescript` nor `scip` is installed in the current environment, and the remaining correctness gates need a real generated index: position-encoding conversion, symbol-to-OCBI definition matching, stale-enrichment removal, and memory behavior on realistic SCIP JSON. Adding `@scip-code/scip` or a protobuf runtime would also add production dependencies, contrary to the current constraint.
+
+## Evidence from the current repository
+
+### Existing graph pipeline
+
+- `src/indexer/index.ts:116-122` enables call extraction for TypeScript, TSX, JavaScript, and JSX.
+- `src/indexer/index.ts:1349-1370` creates stable OCBI `SymbolData` records from parsed source symbols. SCIP should map to these records rather than introduce a second symbol catalog.
+- `src/indexer/index.ts:4265-4369` discovers files, hashes them, and already forces JavaScript-family graph refreshes when a JavaScript-family source changes.
+- `src/indexer/index.ts:4452-4474` builds the branch-aware `LocalModuleCallResolver` and lazily loads unchanged modules.
+- `src/indexer/index.ts:4566-4747` extracts call sites, identifies enclosing OCBI symbols, applies same-file and local-module resolution, then batch-writes symbols and edges.
+- `src/native/types.ts:50-86` has a deliberately small graph contract: call type, source location, target name, optional target symbol, confidence, and resolution state. SCIP can enrich this shape without a native schema migration.
+- `native/src/db/call_graph.rs:321-368` uses `INSERT OR REPLACE` for call edges. Reprocessing a file can therefore clear a stale enriched target by writing the same edge ID with no `to_symbol_id`.
+- `src/indexer/call-graph-coverage.ts:33-79` already computes resolved and unresolved edge counts by language. This is the correct first observability and benchmark surface.
+- `src/watcher/index.ts:30-69` turns any included file or config change into a normal background index request. A whole-project SCIP generator must not be silently attached to every watcher event.
+
+### Current architecture-context behavior
+
+`architecture_context` reads source files and derives cited excerpts from graph symbol ranges (`src/tools/architecture-context.ts:271-300`), while its public adapter remains thin (`src/adapters/opencode/tools.ts:398-409`). Better target resolution can improve communities, entry points, relationships, and cited source selection without changing the public tool. The enrichment must preserve OCBI file paths and symbol ranges so the existing source excerpt path remains authoritative.
+
+### SCIP ecosystem facts
+
+Authoritative upstream evidence checked on 2026-08-26:
+
+- [`scip-typescript`](https://github.com/sourcegraph/scip-typescript) is a compiler-backed TypeScript/JavaScript indexer. Its documented flow is `scip-typescript index`, producing `index.scip`.
+- Its [CLI options](https://github.com/sourcegraph/scip-typescript/blob/main/src/CommandLineOptions.ts) include `--output`, `--infer-tsconfig`, explicit Yarn and pnpm workspace flags, `--no-global-caches`, and `--max-file-byte-size`.
+- Its [index command](https://github.com/sourcegraph/scip-typescript/blob/main/src/main.ts) truncates and rewrites the output, walks projects sequentially, and emits a complete workspace index. This is not changed-file incremental indexing.
+- The latest npm package observed was `@sourcegraph/scip-typescript@0.4.0`, published in October 2025. It depends on TypeScript 5.6.2 and `google-protobuf`; OCBI currently supports Node 20+ and uses TypeScript 5.9.3 for development.
+- The [SCIP schema](https://github.com/scip-code/scip/blob/main/scip.proto) is streaming protobuf. Documents contain relative paths, occurrences, definitions, and an explicit position encoding.
+- The [`scip` CLI](https://github.com/scip-code/scip/blob/main/docs/CLI.md) supports `scip print --json`; upstream warns only that non-JSON print output is unstable for scripts.
+- Official TypeScript decoding is available through [`@scip-code/scip`](https://github.com/scip-code/scip/tree/main/bindings/typescript), which also brings `@bufbuild/protobuf`. Both are Apache-2.0, but adding them would be new production dependencies.
+
+## Fit and limitations
+
+### What SCIP should enrich
+
+SCIP should resolve an existing OCBI edge when all of these hold:
+
+1. the source language is TypeScript, TSX, JavaScript, or JSX;
+2. OCBI already extracted the call/import/inheritance site and its enclosing source symbol;
+3. the OCBI edge is unresolved;
+4. a SCIP occurrence matches that source identifier after position-encoding normalization;
+5. the SCIP symbol has exactly one project-local definition that maps to exactly one existing OCBI symbol.
+
+This preserves OCBI's call semantics. SCIP occurrences are references, not a drop-in call graph, so creating an OCBI edge for every SCIP reference would incorrectly turn type references, reads, writes, and other identifiers into calls.
+
+### Expected wins
+
+- `tsconfig` path aliases and project references;
+- package `exports` and workspace package resolution;
+- renamed and namespace imports beyond the current local resolver's syntax coverage;
+- method targets where compiler type information disambiguates same-named declarations;
+- re-export chains that remain ambiguous to syntax-only resolution.
+
+### Known gaps and risks
+
+- SCIP TypeScript emits a whole-workspace index. Running it for each watcher batch would make normal background indexing expensive and noisy.
+- Workspace selection is explicit. OCBI would otherwise need to infer Yarn versus pnpm behavior or expose generator arguments.
+- SCIP positions may be UTF-16 code units while tree-sitter columns are byte-oriented. Non-ASCII source requires tested conversion through line text, not direct line/column equality.
+- A SCIP symbol is not an OCBI symbol ID. Definitions must map by canonical project-relative path, range overlap, and declaration compatibility. Name-only matching is unsafe.
+- `scip print --json` can be much larger than the protobuf input. A no-dependency pilot must cap output before `JSON.parse`, which limits it to small and medium repositories.
+- The current edge table has no enrichment provenance. A pilot can avoid a migration by enriching only in-memory `edgeBatch` entries and forcing JavaScript-family reprocessing whenever adapter state changes.
+- `scip-typescript` uses its bundled TypeScript version. Repositories relying on newer compiler behavior may produce incomplete or inaccurate data.
+- Running a project tool consumes local CPU and memory and reads installed dependencies. It must remain explicit opt-in and must never use `npx`, install packages, run an external service, or invoke a shell.
+
+## Proposed first-milestone configuration
+
+Add this nested section to `IndexingConfig` in `src/config/schema.ts` and defaults in `src/config/defaults.ts`:
+
+```ts
+interface ScipTypeScriptConfig {
+  /** Default false. */
+  enabled: boolean;
+  /** Existing SCIP file, relative to the materialized project root. Default "index.scip". */
+  indexFile: string;
+  /** User-installed local decoder executable. Default "scip". */
+  decoderCommand: string;
+  /** Maximum decoder runtime. Default 30_000, clamped to 1_000..300_000. */
+  timeoutMs: number;
+  /** Maximum JSON output accepted. Default 67_108_864, clamped to 1 MiB..256 MiB. */
+  maxOutputBytes: number;
+  /** Reject an index older than relevant project sources/config. Default true. */
+  requireFreshIndex: boolean;
+}
+```
+
+Example:
+
+```json
+{
+  "indexing": {
+    "scipTypeScript": {
+      "enabled": true,
+      "indexFile": ".codebase-index/scip/index.scip",
+      "decoderCommand": "/opt/homebrew/bin/scip",
+      "timeoutMs": 30000,
+      "maxOutputBytes": 67108864,
+      "requireFreshIndex": true
+    }
+  }
+}
+```
+
+Deliberately excluded from milestone one:
+
+- no `scip-typescript` generator command;
+- no arbitrary command arguments;
+- no `npx`, package-manager, network, or auto-install behavior;
+- no direct protobuf dependency;
+- no host-adapter-specific config;
+- no support outside the TypeScript/JavaScript family.
+
+A later generator mode should be a separate decision after benchmarks. It would need an explicit manual-only lifecycle and separate workspace configuration.
+
+For `requireFreshIndex`, treat TypeScript/JavaScript sources, `tsconfig*.json`, `jsconfig*.json`, `package.json`, workspace manifests, and lockfiles as relevant inputs. Reject the SCIP file when its modification time is older than the newest relevant input. This is intentionally conservative but not cryptographic proof that the SCIP file represents the current tree; the benchmark spike should determine whether a generated sidecar fingerprint is required.
+
+## Exact integration boundaries
+
+### New module
+
+Create `src/indexer/scip-typescript-enrichment.ts` with host-neutral functions only:
+
+```ts
+interface ScipEnrichmentInput {
+  projectRoot: string;
+  materializedProjectRoot: string;
+  indexFile: string;
+  decoderCommand: string;
+  timeoutMs: number;
+  maxOutputBytes: number;
+  sourceFiles: ReadonlyMap<string, string>;
+  symbols: readonly SymbolData[];
+  edges: readonly CallEdgeData[];
+}
+
+interface ScipEnrichmentResult {
+  edges: CallEdgeData[];
+  matchedEdges: number;
+  unmatchedOccurrences: number;
+  ambiguousDefinitions: number;
+  decoderVersion?: string;
+}
+```
+
+Responsibilities:
+
+- resolve and validate `indexFile` beneath `materializedProjectRoot`;
+- reject non-files and path escapes;
+- invoke `execFile(decoderCommand, ["print", "--json", indexFile])` with timeout, byte cap, no shell, and no stdin;
+- validate only the required JSON fields;
+- canonicalize document paths and reject absolute or `..` paths;
+- convert SCIP position encodings using source line text;
+- index project-local definition occurrences by SCIP symbol;
+- match only unresolved OCBI edges and return copied enriched edges;
+- never write SQLite or mutate the indexer directly.
+
+### Existing indexer
+
+Modify `src/indexer/index.ts` in two narrow places:
+
+1. **Refresh decision near `src/indexer/index.ts:4292-4369`.** Add a branch-scoped adapter metadata fingerprint. If the adapter configuration, SCIP file fingerprint, freshness state, or adapter version changed, mark all JavaScript-family files changed. This guarantees old enriched targets are replaced by ordinary OCBI edges when the adapter is disabled, stale, missing, or failing.
+2. **Edge overlay near `src/indexer/index.ts:4566-4747`.** After ordinary `edgeBatch` construction and before `upsertCallEdgesBatch`, apply successfully prepared SCIP resolutions to unresolved edges only.
+
+Prepare/parse the SCIP data before `database.beginWriteTransaction()` where possible. Do not hold the SQLite write transaction while an external process runs. Keep the existing index mutation lease so branch and materialized-root state cannot change underneath the import.
+
+### Persistence and public surfaces
+
+- No Rust schema or NAPI contract change is required for the first milestone.
+- Store branch-scoped metadata keys for adapter version, SCIP file fingerprint, last outcome, and matched-edge count.
+- Add an optional `scipTypeScript` block to `StatusResult` only after the pilot proves useful. Until then, emit one bounded logger event per index run.
+- Do not change OpenCode, MCP, Pi, `architecture_context`, `call_graph`, or `code_communities` adapters. They already consume the shared graph.
+
+## Lifecycle and fallback behavior
+
+| Condition | Behavior |
+|---|---|
+| Feature disabled | Run the current indexer unchanged. If previously enabled, force one JavaScript-family graph refresh to clear enriched targets. |
+| SCIP file missing/unreadable | Warn once, use ordinary OCBI edges, record non-fatal adapter status. |
+| SCIP file stale | Do not import it. Reprocess JavaScript-family graph edges and use ordinary OCBI resolution. |
+| Decoder missing/non-zero/timeout | Kill the child, discard all staged enrichment, continue ordinary indexing. |
+| JSON exceeds cap or is malformed | Terminate or reject the decoder output, discard all staged enrichment, continue ordinary indexing. |
+| Project root/path mismatch | Reject affected documents or the entire import before writes; never resolve outside the project. |
+| Occurrence has no unique local definition | Leave the OCBI edge unresolved. |
+| SCIP disagrees with an already resolved OCBI edge | Keep the existing OCBI target in milestone one and count the disagreement for benchmark review. |
+| Indexing transaction fails later | Existing transaction rollback behavior applies; SCIP input is read-only. |
+| Watcher event | Normal OCBI reindex. The import runs only when its file/config fingerprint or relevant source freshness requires reevaluation. No generator runs. |
+| Branch/worktree | Resolve the SCIP file from `materializedProjectRoot`; persist adapter metadata under the existing branch catalog identity. |
+
+The adapter must be monotonic in milestone one: it can change `unresolved -> resolved`, never `resolved -> different resolved`.
+
+## Test plan before implementation approval
+
+### Unit tests
+
+Add `tests/scip-typescript-enrichment.test.ts` using a fake executable created in a temporary directory. Tests must cover:
+
+- disabled path performs no process invocation;
+- `execFile` argument vector is exact and never shell-expanded;
+- missing executable, non-zero exit, timeout, oversized output, malformed JSON;
+- absolute paths, `..` traversal, mismatched project roots, and external symbols;
+- UTF-8 and UTF-16 columns with non-ASCII identifiers;
+- unique definition match, ambiguous definition, no definition, overloads, and duplicate names;
+- unresolved-only monotonic overlay;
+- deterministic output ordering.
+
+### Indexer integration tests
+
+Extend `tests/call-graph.test.ts` with fixture JSON representing `scip print --json` output:
+
+- path alias import;
+- namespace import and re-export chain;
+- project reference/workspace target;
+- ambiguous method names where type information selects one target;
+- stale SCIP file causes heuristic fallback and clears prior enrichment;
+- enabling/disabling the flag forces exactly one graph refresh;
+- failed enrichment does not fail indexing or alter resolved baseline edges;
+- branch/worktree path mapping remains source-backed.
+
+A real end-to-end test must be gated on locally available `scip-typescript` and `scip` binaries. Fake-command tests alone are not sufficient for release approval.
+
+## Benchmark plan and acceptance gates
+
+### Cohort
+
+1. Current OCBI repository at a fixed commit.
+2. Existing frozen JavaScript repositories `axios` and `express` from `benchmarks/golden/expanded-cross-repo/cohort.json`.
+3. One fixed, type-heavy TypeScript monorepo with path aliases and project references, added as a separate pilot rather than changing current baselines.
+4. Hand-labeled fixtures for aliases, re-exports, namespace imports, methods, overloads, inheritance, and Unicode positions.
+
+### Compare
+
+Run three modes against the same commits:
+
+- current OCBI baseline;
+- OCBI plus import-only SCIP enrichment;
+- SCIP upper-bound analysis, including disagreements with already resolved OCBI edges, without applying those disagreements.
+
+### Metrics
+
+- edge target precision and recall against hand labels;
+- resolved-edge rate by language using `summarizeCallGraphCoverage`;
+- count and precision of newly resolved edges;
+- disagreements with existing resolved edges;
+- `architecture_context` source-citation validity and relationship usefulness on `npm run eval:architecture`;
+- community count, coupling stability, and hub churn;
+- cold and warm index wall time;
+- peak RSS of `scip-typescript`, `scip print --json`, and OCBI;
+- protobuf size, JSON size, SQLite growth, and temporary disk usage;
+- watcher-triggered index latency and fallback latency.
+
+### Go criteria
+
+Proceed beyond an experiment only if all hold:
+
+- at least 98% precision on newly resolved hand-labeled edges;
+- at least 10 percentage points improvement in unresolved TypeScript/JavaScript edge resolution on two realistic repositories;
+- no regression in existing resolved-edge precision or source-citation validity;
+- no architecture evaluation regression beyond the existing budget;
+- import overhead at p95 is below 20% of baseline OCBI indexing time for repositories whose JSON stays under the configured cap;
+- every missing/stale/crash/timeout case demonstrably falls back without failing ordinary indexing.
+
+If JSON memory or size fails the pilot, stop. The next step would require explicit approval for a direct protobuf decoder dependency or a native streaming decoder, not a larger `maxOutputBytes` default.
+
+## Decision and blockers
+
+**Decision:** Keep this branch document-only. The architecture supports a narrow enrichment overlay, but a safe implementation is not yet validated locally.
+
+**Blockers before code:**
+
+1. install or otherwise provide fixed `scip-typescript` and `scip` binaries for a real fixture run;
+2. capture and freeze representative `scip print --json` output;
+3. verify exact TypeScript occurrence ranges, definition roles, symbol formats, and UTF-16 handling;
+4. measure JSON expansion and peak RSS on this repository;
+5. confirm the refresh/fallback path clears previously enriched targets under watcher, config-toggle, branch, and stale-file scenarios.
+
+The recommended next task is a benchmark-only spike with pinned local binaries and no production dependency changes. Implement the adapter only after that spike passes the correctness and memory gates above.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -91,7 +91,7 @@ Pi exposes all 16 portable tools, including `architecture_context`, `call_graph`
 
 ### `architecture_context`
 
-Use `architecture_context` when an agent needs a concise repository map before focused retrieval or edits. Each module includes a responsibility excerpt derived from readable source and exact symbol/file/line citations. Cross-module boundaries include representative source and target symbols, while missing or sparse graph coverage is reported explicitly instead of inferred.
+Use `architecture_context` when an agent needs a concise repository map before focused retrieval or edits. Each module includes a responsibility excerpt derived from readable source and exact symbol/file/line citations. Cross-module boundaries include representative source and target symbols, while missing or sparse graph coverage is reported explicitly instead of inferred. Coverage includes branch-aware resolved and unresolved edge totals plus a deterministic per-language breakdown.
 
 `query` and `directory` constrain which modules can consume the response budget. `depth` controls detail from 1 to 3, and `tokenBudget` is enforced from 128 to 4000 estimated tokens without cutting claims or citations mid-entry. When community data is unavailable, the tool can still group matching indexed symbols by source directory, but it labels that fallback and does not invent relationships.
 
@@ -147,7 +147,7 @@ Returns recent in-memory debug logs when debug logging is enabled.
 
 ### `call_graph`
 
-Finds direct callers or callees for a function or method. File-path disambiguation is available when names are duplicated.
+Finds direct callers or callees for a function or method. File-path disambiguation is available when names are duplicated. For TypeScript and JavaScript, indexed call targets can follow local relative ES module imports and re-export chains, including aliases. Package imports, tsconfig path aliases, CommonJS-only exports, missing modules, and ambiguous module or star-export targets remain unresolved rather than being guessed.
 
 ### `call_graph_path`
 

--- a/native/src/db/call_graph.rs
+++ b/native/src/db/call_graph.rs
@@ -402,6 +402,18 @@ pub fn get_callers(
                 (s.language IN ('apex', 'php') AND ce.target_name = ?2 COLLATE NOCASE)
                 OR
                 (s.language NOT IN ('apex', 'php') AND ce.target_name = ?2 COLLATE BINARY)
+                OR EXISTS (
+                    SELECT 1
+                    FROM symbols target
+                    INNER JOIN branch_symbols target_bs
+                        ON target.id = target_bs.symbol_id AND target_bs.branch = ?1
+                    WHERE target.id = ce.to_symbol_id
+                      AND (
+                          (target.language IN ('apex', 'php') AND target.name = ?2 COLLATE NOCASE)
+                          OR
+                          (target.language NOT IN ('apex', 'php') AND target.name = ?2 COLLATE BINARY)
+                      )
+                )
             ) AND ce.call_type = ?3
             "#,
             vec![branch.to_string(), symbol_name.to_string(), ct.to_string()],
@@ -417,6 +429,18 @@ pub fn get_callers(
                 (s.language IN ('apex', 'php') AND ce.target_name = ?2 COLLATE NOCASE)
                 OR
                 (s.language NOT IN ('apex', 'php') AND ce.target_name = ?2 COLLATE BINARY)
+                OR EXISTS (
+                    SELECT 1
+                    FROM symbols target
+                    INNER JOIN branch_symbols target_bs
+                        ON target.id = target_bs.symbol_id AND target_bs.branch = ?1
+                    WHERE target.id = ce.to_symbol_id
+                      AND (
+                          (target.language IN ('apex', 'php') AND target.name = ?2 COLLATE NOCASE)
+                          OR
+                          (target.language NOT IN ('apex', 'php') AND target.name = ?2 COLLATE BINARY)
+                      )
+                )
             "#,
             vec![branch.to_string(), symbol_name.to_string()],
         )
@@ -477,6 +501,18 @@ pub fn get_callers_with_context(
                 (s.language IN ('apex', 'php') AND ce.target_name = ?2 COLLATE NOCASE)
                 OR
                 (s.language NOT IN ('apex', 'php') AND ce.target_name = ?2 COLLATE BINARY)
+                OR EXISTS (
+                    SELECT 1
+                    FROM symbols target
+                    INNER JOIN branch_symbols target_bs
+                        ON target.id = target_bs.symbol_id AND target_bs.branch = ?1
+                    WHERE target.id = ce.to_symbol_id
+                      AND (
+                          (target.language IN ('apex', 'php') AND target.name = ?2 COLLATE NOCASE)
+                          OR
+                          (target.language NOT IN ('apex', 'php') AND target.name = ?2 COLLATE BINARY)
+                      )
+                )
             ) AND ce.call_type = ?3
             "#,
             vec![branch.to_string(), symbol_name.to_string(), ct.to_string()],
@@ -503,6 +539,18 @@ pub fn get_callers_with_context(
                 (s.language IN ('apex', 'php') AND ce.target_name = ?2 COLLATE NOCASE)
                 OR
                 (s.language NOT IN ('apex', 'php') AND ce.target_name = ?2 COLLATE BINARY)
+                OR EXISTS (
+                    SELECT 1
+                    FROM symbols target
+                    INNER JOIN branch_symbols target_bs
+                        ON target.id = target_bs.symbol_id AND target_bs.branch = ?1
+                    WHERE target.id = ce.to_symbol_id
+                      AND (
+                          (target.language IN ('apex', 'php') AND target.name = ?2 COLLATE NOCASE)
+                          OR
+                          (target.language NOT IN ('apex', 'php') AND target.name = ?2 COLLATE BINARY)
+                      )
+                )
             "#,
             vec![branch.to_string(), symbol_name.to_string()],
         )

--- a/src/indexer/call-graph-coverage.ts
+++ b/src/indexer/call-graph-coverage.ts
@@ -1,0 +1,95 @@
+import type { CallEdgeData, SymbolData } from "../native/types.js";
+
+export interface CallGraphLanguageCoverage {
+  language: string;
+  totalEdges: number;
+  resolvedEdges: number;
+  unresolvedEdges: number;
+  resolutionRate: number;
+}
+
+export interface CallGraphCoverage {
+  totalEdges: number;
+  resolvedEdges: number;
+  unresolvedEdges: number;
+  resolutionRate: number;
+  languages: CallGraphLanguageCoverage[];
+}
+
+function resolutionRate(resolvedEdges: number, totalEdges: number): number {
+  return totalEdges === 0 ? 0 : resolvedEdges / totalEdges;
+}
+
+export function emptyCallGraphCoverage(): CallGraphCoverage {
+  return {
+    totalEdges: 0,
+    resolvedEdges: 0,
+    unresolvedEdges: 0,
+    resolutionRate: 0,
+    languages: [],
+  };
+}
+
+export function summarizeCallGraphCoverage(
+  symbols: readonly SymbolData[],
+  edges: readonly CallEdgeData[],
+): CallGraphCoverage {
+  const symbolsById = new Map(symbols.map((symbol) => [symbol.id, symbol]));
+  const languageCounts = new Map<string, { totalEdges: number; resolvedEdges: number }>();
+  let totalEdges = 0;
+  let resolvedEdges = 0;
+
+  const orderedEdges = edges.slice().sort((left, right) =>
+    left.fromSymbolId.localeCompare(right.fromSymbolId)
+    || left.line - right.line
+    || left.col - right.col
+    || left.id.localeCompare(right.id)
+  );
+  for (const edge of orderedEdges) {
+    const source = symbolsById.get(edge.fromSymbolId);
+    if (!source) continue;
+
+    const resolved = edge.isResolved
+      && edge.toSymbolId !== undefined
+      && symbolsById.has(edge.toSymbolId);
+    totalEdges += 1;
+    if (resolved) resolvedEdges += 1;
+
+    const counts = languageCounts.get(source.language) ?? { totalEdges: 0, resolvedEdges: 0 };
+    counts.totalEdges += 1;
+    if (resolved) counts.resolvedEdges += 1;
+    languageCounts.set(source.language, counts);
+  }
+
+  return {
+    totalEdges,
+    resolvedEdges,
+    unresolvedEdges: totalEdges - resolvedEdges,
+    resolutionRate: resolutionRate(resolvedEdges, totalEdges),
+    languages: [...languageCounts.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([language, counts]) => ({
+        language,
+        totalEdges: counts.totalEdges,
+        resolvedEdges: counts.resolvedEdges,
+        unresolvedEdges: counts.totalEdges - counts.resolvedEdges,
+        resolutionRate: resolutionRate(counts.resolvedEdges, counts.totalEdges),
+      })),
+  };
+}
+
+export function formatCallGraphCoverage(coverage: CallGraphCoverage): string {
+  if (coverage.totalEdges === 0) {
+    return "No call edges were observed in scope.";
+  }
+
+  const languageSummary = coverage.languages
+    .map((entry) => `${entry.language} ${entry.resolvedEdges}/${entry.totalEdges}`)
+    .join(", ");
+  const unresolved = coverage.unresolvedEdges === 0
+    ? "all observed edges resolved"
+    : `${coverage.unresolvedEdges} unresolved`;
+  return `${coverage.resolvedEdges}/${coverage.totalEdges} observed call edges resolved (${unresolved})${
+    languageSummary ? `; by language: ${languageSummary}` : ""
+  }.`;
+}

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -32,7 +32,7 @@ import {
   parseFileAsText,
   estimateTokens,
 } from "../native/index.js";
-import type { SymbolData, CallEdgeData, PathHopData, ReachabilityData, CommunityData, CommunityCouplingData, CentralityData } from "../native/index.js";
+import type { ParsedFile, SymbolData, CallEdgeData, PathHopData, ReachabilityData, CommunityData, CommunityCouplingData, CentralityData } from "../native/index.js";
 import { getBranchOrDefault, getBaseBranch, isGitRepo } from "../git/index.js";
 import { isFullGitCommit, resolveLocalGitCommit, withMaterializedBranch } from "../git/branch-materialization.js";
 import type { HostMode } from "../config/host.js";
@@ -110,6 +110,8 @@ import {
 } from "./failed-state-persistence.js";
 import { iterateOrderedFileBatches, type FileBatchLimits } from "./file-batches.js";
 import { canonicalizePathForComparison } from "../utils/canonical-path.js";
+import { summarizeCallGraphCoverage, type CallGraphCoverage } from "./call-graph-coverage.js";
+import { isJavaScriptFamilyFilePath, LocalModuleCallResolver } from "./local-module-resolution.js";
 
 export const CALL_GRAPH_LANGUAGES = new Set(["typescript", "tsx", "javascript", "jsx", "python", "go", "rust", "swift", "php", "apex", "zig", "gdscript", "matlab", "bash", "c", "cpp", "metal"]);
 // Languages whose identifiers are case-insensitive at the language level.
@@ -179,7 +181,7 @@ function resolveSameCommunityCandidateIds(
     .map((candidate) => candidate.id));
 }
 // Existing indexes without this metadata are the implicit version 1.
-const CALL_GRAPH_RESOLUTION_VERSION = "4";
+const CALL_GRAPH_RESOLUTION_VERSION = "5";
 const PHP_FUNCTION_SYMBOL_CHUNK_TYPES = new Set([
   "function_declaration",
   "function",
@@ -1342,6 +1344,30 @@ export class Indexer {
   private refreshRuntimeArtifactPaths(): void {
     this.fileHashCachePath = this.getRuntimeArtifactPath("file-hashes.json");
     this.failedBatchesPath = this.getRuntimeArtifactPath("failed-batches.json");
+  }
+
+  private buildCallGraphSymbols(parsed: ParsedFile, sourceHash: string): SymbolData[] {
+    const preparedNamespace = this.getPreparedBranchNamespace();
+    return parsed.symbols
+      .filter((parsedSymbol) => CALL_GRAPH_SYMBOL_CHUNK_TYPES.has(parsedSymbol.kind))
+      .map((parsedSymbol) => {
+        const symbolId = `sym_${hashContent(
+          (preparedNamespace ? `${preparedNamespace}:` : "")
+          + parsed.path + ":" + parsedSymbol.name + ":" + parsedSymbol.kind + ":"
+          + parsedSymbol.startLine + ":" + parsedSymbol.startCol + ":" + sourceHash,
+        ).slice(0, 16)}`;
+        return {
+          id: symbolId,
+          filePath: parsed.path,
+          name: parsedSymbol.name,
+          kind: parsedSymbol.kind,
+          startLine: parsedSymbol.startLine,
+          startCol: parsedSymbol.startCol,
+          endLine: parsedSymbol.endLine,
+          endCol: parsedSymbol.endCol,
+          language: parsedSymbol.language,
+        };
+      });
   }
 
   private getPreparedChunkId(chunkId: string): string {
@@ -4259,10 +4285,18 @@ export class Indexer {
     });
 
     const changedFileDescriptors: ChangedFileDescriptor[] = [];
+    const changedFilePathSet = new Set<string>();
+    const allFileDescriptors = new Map<string, ChangedFileDescriptor>();
     const unchangedFilePaths = new Set<string>();
     const currentFileHashes = new Map<string, string>();
+    const currentStoredFilePaths = new Set(files.map((file) => this.toStoredFilePath(file.path)));
     const needsCallGraphResolutionMigration =
       database.getMetadata(this.getCallGraphResolutionMetadataKey()) !== CALL_GRAPH_RESOLUTION_VERSION;
+    let javaScriptGraphSourcesChanged = Array.from(this.fileHashCache.keys()).some((filePath) =>
+      (!scopedRoots || this.isFileInCurrentScope(filePath, scopedRoots))
+      && isJavaScriptFamilyFilePath(filePath)
+      && !currentStoredFilePaths.has(filePath)
+    );
 
     for (const file of files) {
       const storedPath = this.toStoredFilePath(file.path);
@@ -4283,12 +4317,25 @@ export class Indexer {
         continue;
       }
       currentFileHashes.set(storedPath, currentHash);
+      const descriptor: ChangedFileDescriptor = {
+        storedPath,
+        materializedPath: file.path,
+        hash: currentHash,
+        sourceBytes: file.size,
+      };
+      allFileDescriptors.set(storedPath, descriptor);
 
       const cachedHashMatches = this.fileHashCache.get(storedPath) === currentHash;
-      const needsCallGraphRefresh = cachedHashMatches &&
-        needsCallGraphResolutionMigration &&
-        database.getChunksByFile(storedPath).some((chunk) =>
-          chunk.language === "php" || chunk.language === "c" || chunk.language === "cpp"
+      if (!cachedHashMatches && isJavaScriptFamilyFilePath(storedPath)) {
+        javaScriptGraphSourcesChanged = true;
+      }
+      const needsCallGraphRefresh = cachedHashMatches
+        && needsCallGraphResolutionMigration
+        && (
+          isJavaScriptFamilyFilePath(storedPath)
+          || database.getChunksByFile(storedPath).some((chunk) =>
+            chunk.language === "php" || chunk.language === "c" || chunk.language === "cpp"
+          )
         );
       const requiresSwiftParserUpgrade =
         reparseCachedSwiftFiles && path.extname(storedPath).toLowerCase() === ".swift";
@@ -4298,23 +4345,34 @@ export class Indexer {
         forceScopedReembed && scopedRoots !== null && this.isFileInCurrentScope(storedPath, scopedRoots);
 
       if (
-        cachedHashMatches &&
-        !inMigrationScope &&
-        !needsCallGraphRefresh &&
-        !requiresSwiftParserUpgrade &&
-        !requiresMetalParserUpgrade &&
-        !refreshCachedSymbols
+        cachedHashMatches
+        && !inMigrationScope
+        && !needsCallGraphRefresh
+        && !requiresSwiftParserUpgrade
+        && !requiresMetalParserUpgrade
+        && !refreshCachedSymbols
       ) {
         unchangedFilePaths.add(storedPath);
-        this.logger.recordCacheHit();
       } else {
-        changedFileDescriptors.push({
-          storedPath,
-          materializedPath: file.path,
-          hash: currentHash,
-          sourceBytes: file.size,
-        });
+        changedFileDescriptors.push(descriptor);
+        changedFilePathSet.add(storedPath);
+      }
+    }
+
+    if (javaScriptGraphSourcesChanged) {
+      for (const [storedPath, descriptor] of allFileDescriptors) {
+        if (!isJavaScriptFamilyFilePath(storedPath) || changedFilePathSet.has(storedPath)) continue;
+        unchangedFilePaths.delete(storedPath);
+        changedFileDescriptors.push(descriptor);
+        changedFilePathSet.add(storedPath);
+      }
+    }
+
+    for (const storedPath of allFileDescriptors.keys()) {
+      if (changedFilePathSet.has(storedPath)) {
         this.logger.recordCacheMiss();
+      } else {
+        this.logger.recordCacheHit();
       }
     }
 
@@ -4385,6 +4443,35 @@ export class Indexer {
       intervalCap: providerRateLimits.concurrency,
     });
     const rateLimitState: EmbeddingRateLimitState = { backoffMs: 0 };
+    const sourceDescriptorsByPath = new Map(
+      [...allFileDescriptors.values()].map((descriptor) => [
+        descriptor.storedPath.split(path.sep).join("/"),
+        descriptor,
+      ]),
+    );
+    const localModuleResolver = new LocalModuleCallResolver({
+      filePaths: [...sourceDescriptorsByPath.keys()],
+      loadModule: async (filePath) => {
+        const descriptor = sourceDescriptorsByPath.get(filePath);
+        if (!descriptor) return undefined;
+        const content = await fsPromises.readFile(descriptor.materializedPath, "utf-8");
+        if (unchangedFilePaths.has(descriptor.storedPath)) {
+          const symbols = database.getSymbolsByFile(descriptor.storedPath).filter((symbol) =>
+            !restrictExistingChunksToBranch || previousBranchSymbolIdSet.has(symbol.id)
+          );
+          return { content, symbols };
+        }
+
+        const parsed = parseFiles(
+          [{ path: descriptor.storedPath, content }],
+          this.config.indexing.linesPerChunk,
+        )[0];
+        return {
+          content,
+          symbols: parsed ? this.buildCallGraphSymbols(parsed, descriptor.hash) : [],
+        };
+      },
+    });
     let writeTransactionActive = false;
 
     try {
@@ -4479,6 +4566,7 @@ export class Indexer {
         const chunkDataBatch: ChunkData[] = [];
         const pendingChunks: PendingChunk[] = [];
         const symbolBatch: SymbolData[] = [];
+        const symbolBatchIds = new Set<string>();
         const edgeBatch: CallEdgeData[] = [];
 
         for (const parsed of parsedFiles) {
@@ -4566,32 +4654,18 @@ export class Indexer {
             });
           }
 
-          const fileSymbols: SymbolData[] = [];
-          for (const parsedSymbol of parsed.symbols) {
-            if (!CALL_GRAPH_SYMBOL_CHUNK_TYPES.has(parsedSymbol.kind)) {
-              continue;
+          const fileSymbols = this.buildCallGraphSymbols(parsed, descriptor.hash);
+          for (const symbol of fileSymbols) {
+            if (!symbolBatchIds.has(symbol.id)) {
+              symbolBatch.push(symbol);
+              symbolBatchIds.add(symbol.id);
             }
-            const preparedNamespace = this.getPreparedBranchNamespace();
-            const symbolId = `sym_${hashContent(
-              (preparedNamespace ? `${preparedNamespace}:` : "") +
-              parsed.path + ":" + parsedSymbol.name + ":" + parsedSymbol.kind + ":" +
-              parsedSymbol.startLine + ":" + parsedSymbol.startCol + ":" + descriptor.hash,
-            ).slice(0, 16)}`;
-            const symbol: SymbolData = {
-              id: symbolId,
-              filePath: parsed.path,
-              name: parsedSymbol.name,
-              kind: parsedSymbol.kind,
-              startLine: parsedSymbol.startLine,
-              startCol: parsedSymbol.startCol,
-              endLine: parsedSymbol.endLine,
-              endCol: parsedSymbol.endCol,
-              language: parsedSymbol.language,
-            };
-            fileSymbols.push(symbol);
-            symbolBatch.push(symbol);
-            allSymbolIds.add(symbolId);
+            allSymbolIds.add(symbol.id);
           }
+          localModuleResolver.seedModule(parsed.path, {
+            content: loadedFile.content,
+            symbols: fileSymbols,
+          });
 
           const fileLanguage = parsed.symbols[0]?.language ?? parsed.chunks[0]?.language;
           if (!fileLanguage || !CALL_GRAPH_LANGUAGES.has(fileLanguage)) {
@@ -4625,7 +4699,23 @@ export class Indexer {
             candidates = candidates?.filter((symbol) =>
               isCompatibleCFamilyCallTarget(fileLanguage, site.callType, symbol.kind)
             );
-            const resolvedTarget = candidates?.length === 1 ? candidates[0] : undefined;
+            let resolvedTarget = candidates?.length === 1 ? candidates[0] : undefined;
+            if (
+              !resolvedTarget
+              && (!candidates || candidates.length === 0)
+              && isJavaScriptFamilyFilePath(parsed.path)
+            ) {
+              resolvedTarget = await localModuleResolver.resolveCallTarget(
+                parsed.path,
+                loadedFile.content,
+                site,
+              );
+              if (resolvedTarget && !symbolBatchIds.has(resolvedTarget.id)) {
+                symbolBatch.push(resolvedTarget);
+                symbolBatchIds.add(resolvedTarget.id);
+                allSymbolIds.add(resolvedTarget.id);
+              }
+            }
             edgeBatch.push({
               id: `edge_${hashContent(
                 enclosingSymbol.id + ":" + site.calleeName + ":" + site.line + ":" + site.column,
@@ -6824,7 +6914,38 @@ export class Indexer {
       }
     }
 
-    return { symbols: [...seenSymbols.values()], edges: [...seenEdges.values()] };
+    const symbols = [...seenSymbols.values()].sort((left, right) =>
+      left.filePath.localeCompare(right.filePath)
+      || left.startLine - right.startLine
+      || left.startCol - right.startCol
+      || left.id.localeCompare(right.id)
+    );
+    const edges = [...seenEdges.values()].sort((left, right) =>
+      left.fromSymbolId.localeCompare(right.fromSymbolId)
+      || left.line - right.line
+      || left.col - right.col
+      || left.id.localeCompare(right.id)
+    );
+    return { symbols, edges };
+  }
+
+  async getCallGraphCoverage(): Promise<CallGraphCoverage> {
+    const { database, readIssues } = await this.ensureInitialized();
+    this.requireReadableComponents(readIssues, "database");
+    const symbolsById = new Map<string, SymbolData>();
+    const edgesById = new Map<string, CallEdgeData>();
+
+    for (const branchKey of this.getBranchCatalogKeys()) {
+      const branchSymbols = database.getSymbolsForBranch(branchKey);
+      for (const symbol of branchSymbols) {
+        symbolsById.set(symbol.id, symbol);
+        for (const edge of database.getCallees(symbol.id, branchKey)) {
+          edgesById.set(edge.id, edge);
+        }
+      }
+    }
+
+    return summarizeCallGraphCoverage([...symbolsById.values()], [...edgesById.values()]);
   }
 
   async close(): Promise<void> {

--- a/src/indexer/local-module-resolution.ts
+++ b/src/indexer/local-module-resolution.ts
@@ -1,0 +1,530 @@
+import type { CallSiteData, SymbolData } from "../native/types.js";
+
+import * as path from "node:path";
+
+const JAVASCRIPT_SOURCE_EXTENSIONS = [
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".cts",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+] as const;
+const JAVASCRIPT_RUNTIME_EXTENSIONS = new Set([".js", ".jsx", ".mjs", ".cjs"]);
+const TYPESCRIPT_SOURCE_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts"] as const;
+const DECLARATION_MODIFIERS = new Set(["abstract", "async", "declare"]);
+const CLASS_SYMBOL_KINDS = new Set(["class", "class_declaration", "class_definition"]);
+const FUNCTION_SYMBOL_KINDS = new Set([
+  "arrow_function",
+  "function",
+  "function_declaration",
+  "function_definition",
+]);
+
+interface Token {
+  kind: "identifier" | "punctuation" | "string";
+  value: string;
+  braceDepth: number;
+}
+
+interface ImportBinding {
+  importedName: string;
+  source: string;
+}
+
+interface NamespaceImportBinding {
+  source: string;
+}
+
+type ExportBinding =
+  | { kind: "local"; localName: string }
+  | { kind: "reexport"; importedName: string; source: string };
+
+interface ModuleRecord {
+  imports: Map<string, ImportBinding[]>;
+  namespaceImports: Map<string, NamespaceImportBinding[]>;
+  exports: Map<string, ExportBinding[]>;
+  starExports: string[];
+}
+
+export interface LocalModuleData {
+  content: string;
+  symbols: readonly SymbolData[];
+}
+
+export interface LocalModuleResolverOptions {
+  filePaths: readonly string[];
+  loadModule: (filePath: string) => Promise<LocalModuleData | undefined>;
+}
+
+export function isJavaScriptFamilyFilePath(filePath: string): boolean {
+  return JAVASCRIPT_SOURCE_EXTENSIONS.includes(
+    path.posix.extname(normalizeFilePath(filePath)).toLowerCase() as (typeof JAVASCRIPT_SOURCE_EXTENSIONS)[number],
+  );
+}
+
+function normalizeFilePath(filePath: string): string {
+  return path.posix.normalize(filePath.replaceAll("\\", "/"));
+}
+
+function isIdentifierStart(char: string): boolean {
+  return /[A-Za-z_$]/u.test(char);
+}
+
+function isIdentifierPart(char: string): boolean {
+  return /[A-Za-z0-9_$]/u.test(char);
+}
+
+function tokenizeModuleSource(content: string): Token[] {
+  const tokens: Token[] = [];
+  let braceDepth = 0;
+  let index = 0;
+
+  while (index < content.length) {
+    const char = content[index];
+    const next = content[index + 1];
+
+    if (/\s/u.test(char)) {
+      index += 1;
+      continue;
+    }
+
+    if (char === "/" && next === "/") {
+      index += 2;
+      while (index < content.length && content[index] !== "\n") index += 1;
+      continue;
+    }
+
+    if (char === "/" && next === "*") {
+      index += 2;
+      while (index + 1 < content.length && !(content[index] === "*" && content[index + 1] === "/")) {
+        index += 1;
+      }
+      index = Math.min(content.length, index + 2);
+      continue;
+    }
+
+    if (char === "`" || char === "\"" || char === "'") {
+      const quote = char;
+      let value = "";
+      index += 1;
+      while (index < content.length) {
+        const current = content[index];
+        if (current === "\\") {
+          if (index + 1 < content.length) {
+            value += content[index + 1];
+            index += 2;
+          } else {
+            index += 1;
+          }
+          continue;
+        }
+        if (current === quote) {
+          index += 1;
+          break;
+        }
+        value += current;
+        index += 1;
+      }
+      if (quote !== "`") {
+        tokens.push({ kind: "string", value, braceDepth });
+      }
+      continue;
+    }
+
+    if (isIdentifierStart(char)) {
+      const start = index;
+      index += 1;
+      while (index < content.length && isIdentifierPart(content[index])) index += 1;
+      tokens.push({ kind: "identifier", value: content.slice(start, index), braceDepth });
+      continue;
+    }
+
+    tokens.push({ kind: "punctuation", value: char, braceDepth });
+    if (char === "{") braceDepth += 1;
+    if (char === "}") braceDepth = Math.max(0, braceDepth - 1);
+    index += 1;
+  }
+
+  return tokens;
+}
+
+function appendMapValue<T>(map: Map<string, T[]>, key: string, value: T): void {
+  const values = map.get(key) ?? [];
+  values.push(value);
+  map.set(key, values);
+}
+
+function findFromSource(tokens: readonly Token[], start: number): string | undefined {
+  for (let index = start; index + 1 < tokens.length; index += 1) {
+    if (tokens[index].braceDepth !== 0) continue;
+    if (tokens[index].value === ";") return undefined;
+    if (tokens[index].value === "from" && tokens[index + 1]?.kind === "string") {
+      return tokens[index + 1].value;
+    }
+  }
+  return undefined;
+}
+
+function parseNamedSpecifiers(
+  tokens: readonly Token[],
+  openBraceIndex: number,
+): Array<{ importedName: string; exportedName: string }> {
+  const result: Array<{ importedName: string; exportedName: string }> = [];
+  const depth = tokens[openBraceIndex].braceDepth + 1;
+  let index = openBraceIndex + 1;
+
+  while (index < tokens.length) {
+    const token = tokens[index];
+    if (token.value === "}" && token.braceDepth === depth) break;
+    if (token.braceDepth !== depth || token.value === ",") {
+      index += 1;
+      continue;
+    }
+
+    let typeOnly = false;
+    if (token.value === "type") {
+      typeOnly = true;
+      index += 1;
+    }
+
+    const imported = tokens[index];
+    if (!imported || imported.kind !== "identifier" || imported.braceDepth !== depth) {
+      index += 1;
+      continue;
+    }
+    index += 1;
+
+    let exportedName = imported.value;
+    if (tokens[index]?.value === "as" && tokens[index]?.braceDepth === depth) {
+      const alias = tokens[index + 1];
+      if (alias?.kind === "identifier" && alias.braceDepth === depth) {
+        exportedName = alias.value;
+        index += 2;
+      }
+    }
+
+    if (!typeOnly) {
+      result.push({ importedName: imported.value, exportedName });
+    }
+    while (index < tokens.length && tokens[index].braceDepth === depth && tokens[index].value !== ",") {
+      index += 1;
+    }
+  }
+
+  return result;
+}
+
+function parseImportDeclaration(tokens: readonly Token[], index: number, record: ModuleRecord): void {
+  let cursor = index + 1;
+  if (tokens[cursor]?.value === "type") return;
+  if (tokens[cursor]?.kind === "string") return;
+
+  const pending: Array<{ importedName: string; localName: string }> = [];
+  let namespaceLocalName: string | undefined;
+
+  if (tokens[cursor]?.kind === "identifier") {
+    pending.push({ importedName: "default", localName: tokens[cursor].value });
+    cursor += 1;
+    if (tokens[cursor]?.value === ",") cursor += 1;
+  }
+
+  if (tokens[cursor]?.value === "{") {
+    for (const specifier of parseNamedSpecifiers(tokens, cursor)) {
+      pending.push({ importedName: specifier.importedName, localName: specifier.exportedName });
+    }
+  } else if (tokens[cursor]?.value === "*" && tokens[cursor + 1]?.value === "as") {
+    const local = tokens[cursor + 2];
+    if (local?.kind === "identifier") namespaceLocalName = local.value;
+  }
+
+  const source = findFromSource(tokens, index + 1);
+  if (!source) return;
+  for (const binding of pending) {
+    appendMapValue(record.imports, binding.localName, { importedName: binding.importedName, source });
+  }
+  if (namespaceLocalName) {
+    appendMapValue(record.namespaceImports, namespaceLocalName, { source });
+  }
+}
+
+function nextDeclarationToken(tokens: readonly Token[], start: number): number {
+  let cursor = start;
+  while (DECLARATION_MODIFIERS.has(tokens[cursor]?.value)) cursor += 1;
+  return cursor;
+}
+
+function parseExportDeclaration(tokens: readonly Token[], index: number, record: ModuleRecord): void {
+  let cursor = index + 1;
+  if (tokens[cursor]?.value === "type") return;
+
+  if (tokens[cursor]?.value === "*") {
+    if (tokens[cursor + 1]?.value === "as") return;
+    const source = findFromSource(tokens, cursor + 1);
+    if (source) record.starExports.push(source);
+    return;
+  }
+
+  if (tokens[cursor]?.value === "{") {
+    const specifiers = parseNamedSpecifiers(tokens, cursor);
+    const source = findFromSource(tokens, cursor + 1);
+    for (const specifier of specifiers) {
+      const binding: ExportBinding = source
+        ? { kind: "reexport", importedName: specifier.importedName, source }
+        : { kind: "local", localName: specifier.importedName };
+      appendMapValue(record.exports, specifier.exportedName, binding);
+    }
+    return;
+  }
+
+  let isDefault = false;
+  if (tokens[cursor]?.value === "default") {
+    isDefault = true;
+    cursor += 1;
+  }
+  cursor = nextDeclarationToken(tokens, cursor);
+
+  if (tokens[cursor]?.value === "function" || tokens[cursor]?.value === "class") {
+    cursor += 1;
+    if (tokens[cursor]?.value === "*") cursor += 1;
+    const name = tokens[cursor];
+    if (name?.kind === "identifier") {
+      appendMapValue(record.exports, isDefault ? "default" : name.value, {
+        kind: "local",
+        localName: name.value,
+      });
+    }
+    return;
+  }
+
+  if (["const", "let", "var", "enum"].includes(tokens[cursor]?.value)) {
+    const name = tokens[cursor + 1];
+    if (name?.kind === "identifier") {
+      appendMapValue(record.exports, isDefault ? "default" : name.value, {
+        kind: "local",
+        localName: name.value,
+      });
+    }
+    return;
+  }
+
+  if (isDefault && tokens[cursor]?.kind === "identifier") {
+    appendMapValue(record.exports, "default", { kind: "local", localName: tokens[cursor].value });
+  }
+}
+
+function parseModuleRecord(content: string): ModuleRecord {
+  const record: ModuleRecord = {
+    imports: new Map(),
+    namespaceImports: new Map(),
+    exports: new Map(),
+    starExports: [],
+  };
+  const tokens = tokenizeModuleSource(content);
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token.braceDepth !== 0 || token.kind !== "identifier") continue;
+    if (token.value === "import") parseImportDeclaration(tokens, index, record);
+    if (token.value === "export") parseExportDeclaration(tokens, index, record);
+  }
+
+  record.starExports.sort();
+  return record;
+}
+
+function deduplicateSymbols(symbols: readonly SymbolData[]): SymbolData[] {
+  const byId = new Map<string, SymbolData>();
+  for (const symbol of symbols) byId.set(symbol.id, symbol);
+  return [...byId.values()].sort((left, right) =>
+    left.filePath.localeCompare(right.filePath)
+    || left.startLine - right.startLine
+    || left.startCol - right.startCol
+    || left.name.localeCompare(right.name)
+    || left.id.localeCompare(right.id)
+  );
+}
+
+function filterCallTargetCandidates(callType: string, symbols: readonly SymbolData[]): SymbolData[] {
+  if (callType === "Constructor") {
+    return symbols.filter((symbol) => CLASS_SYMBOL_KINDS.has(symbol.kind));
+  }
+  if (callType === "Call") {
+    return symbols.filter((symbol) => FUNCTION_SYMBOL_KINDS.has(symbol.kind));
+  }
+  return [...symbols];
+}
+
+function namespaceQualifier(content: string, site: CallSiteData): string | undefined {
+  const line = content.split(/\r?\n/u)[site.line - 1];
+  if (!line) return undefined;
+  const prefix = line.slice(0, site.column);
+  return prefix.match(/([A-Za-z_$][A-Za-z0-9_$]*)\s*(?:\?\.|\.)\s*$/u)?.[1];
+}
+
+export class LocalModuleCallResolver {
+  private readonly modulePaths = new Set<string>();
+  private readonly loadModule: LocalModuleResolverOptions["loadModule"];
+  private readonly moduleData = new Map<string, Promise<LocalModuleData | undefined>>();
+  private readonly moduleRecords = new Map<string, Promise<ModuleRecord | undefined>>();
+  private readonly exportCache = new Map<string, SymbolData[]>();
+
+  constructor(options: LocalModuleResolverOptions) {
+    for (const filePath of options.filePaths) {
+      const normalized = normalizeFilePath(filePath);
+      if (isJavaScriptFamilyFilePath(normalized)) this.modulePaths.add(normalized);
+    }
+    this.loadModule = options.loadModule;
+  }
+
+  seedModule(filePath: string, data: LocalModuleData): void {
+    const normalized = normalizeFilePath(filePath);
+    if (!this.modulePaths.has(normalized)) return;
+    this.moduleData.set(normalized, Promise.resolve(data));
+    this.moduleRecords.set(normalized, Promise.resolve(parseModuleRecord(data.content)));
+    for (const key of this.exportCache.keys()) {
+      if (key.startsWith(`${normalized}\0`)) this.exportCache.delete(key);
+    }
+  }
+
+  async resolveCallTarget(
+    importerFilePath: string,
+    importerContent: string,
+    site: CallSiteData,
+  ): Promise<SymbolData | undefined> {
+    const importer = normalizeFilePath(importerFilePath);
+    if (!this.modulePaths.has(importer)) return undefined;
+    const record = await this.getModuleRecord(importer, importerContent);
+    if (!record) return undefined;
+
+    const candidates: SymbolData[] = [];
+    const qualifier = namespaceQualifier(importerContent, site);
+    if (!qualifier) {
+      for (const binding of record.imports.get(site.calleeName) ?? []) {
+        candidates.push(...await this.resolveImportedBinding(importer, binding, site.callType));
+      }
+    } else {
+      for (const binding of record.namespaceImports.get(qualifier) ?? []) {
+        candidates.push(...await this.resolveImportedBinding(
+          importer,
+          { importedName: site.calleeName, source: binding.source },
+          site.callType,
+        ));
+      }
+    }
+
+    const unique = deduplicateSymbols(candidates);
+    return unique.length === 1 ? unique[0] : undefined;
+  }
+
+  private async getModuleData(filePath: string): Promise<LocalModuleData | undefined> {
+    const normalized = normalizeFilePath(filePath);
+    const existing = this.moduleData.get(normalized);
+    if (existing) return existing;
+    const loaded = this.loadModule(normalized);
+    this.moduleData.set(normalized, loaded);
+    return loaded;
+  }
+
+  private async getModuleRecord(filePath: string, knownContent?: string): Promise<ModuleRecord | undefined> {
+    const normalized = normalizeFilePath(filePath);
+    if (knownContent !== undefined) {
+      const parsed = Promise.resolve(parseModuleRecord(knownContent));
+      this.moduleRecords.set(normalized, parsed);
+      return parsed;
+    }
+    const existing = this.moduleRecords.get(normalized);
+    if (existing) return existing;
+    const parsed = this.getModuleData(normalized).then((data) => data ? parseModuleRecord(data.content) : undefined);
+    this.moduleRecords.set(normalized, parsed);
+    return parsed;
+  }
+
+  private resolveModuleSpecifier(importerFilePath: string, specifier: string): string[] {
+    if (!specifier.startsWith(".")) return [];
+    const base = normalizeFilePath(path.posix.join(path.posix.dirname(importerFilePath), specifier));
+    if (this.modulePaths.has(base)) return [base];
+
+    const extension = path.posix.extname(base).toLowerCase();
+    const candidates = new Set<string>();
+    if (JAVASCRIPT_RUNTIME_EXTENSIONS.has(extension)) {
+      const withoutExtension = base.slice(0, -extension.length);
+      for (const sourceExtension of TYPESCRIPT_SOURCE_EXTENSIONS) {
+        const candidate = `${withoutExtension}${sourceExtension}`;
+        if (this.modulePaths.has(candidate)) candidates.add(candidate);
+      }
+    } else if (extension.length === 0) {
+      for (const sourceExtension of JAVASCRIPT_SOURCE_EXTENSIONS) {
+        const fileCandidate = `${base}${sourceExtension}`;
+        const indexCandidate = path.posix.join(base, `index${sourceExtension}`);
+        if (this.modulePaths.has(fileCandidate)) candidates.add(fileCandidate);
+        if (this.modulePaths.has(indexCandidate)) candidates.add(indexCandidate);
+      }
+    }
+
+    return [...candidates].sort();
+  }
+
+  private async resolveImportedBinding(
+    importerFilePath: string,
+    binding: ImportBinding,
+    callType: string,
+  ): Promise<SymbolData[]> {
+    const candidates: SymbolData[] = [];
+    for (const targetModule of this.resolveModuleSpecifier(importerFilePath, binding.source)) {
+      candidates.push(...await this.resolveExport(targetModule, binding.importedName, callType, new Set()));
+    }
+    return deduplicateSymbols(candidates);
+  }
+
+  private async resolveExport(
+    moduleFilePath: string,
+    exportedName: string,
+    callType: string,
+    visiting: Set<string>,
+  ): Promise<SymbolData[]> {
+    const normalized = normalizeFilePath(moduleFilePath);
+    const cacheKey = `${normalized}\0${exportedName}\0${callType}`;
+    const cached = this.exportCache.get(cacheKey);
+    if (cached) return cached;
+    if (visiting.has(cacheKey)) return [];
+
+    const nextVisiting = new Set(visiting);
+    nextVisiting.add(cacheKey);
+    const record = await this.getModuleRecord(normalized);
+    const data = await this.getModuleData(normalized);
+    if (!record || !data) return [];
+
+    const candidates: SymbolData[] = [];
+    const explicitBindings = record.exports.get(exportedName);
+    if (explicitBindings) {
+      for (const binding of explicitBindings) {
+        if (binding.kind === "local") {
+          candidates.push(...data.symbols.filter((symbol) => symbol.name === binding.localName));
+          continue;
+        }
+        for (const targetModule of this.resolveModuleSpecifier(normalized, binding.source)) {
+          candidates.push(...await this.resolveExport(
+            targetModule,
+            binding.importedName,
+            callType,
+            nextVisiting,
+          ));
+        }
+      }
+    } else if (exportedName !== "default") {
+      for (const source of record.starExports) {
+        for (const targetModule of this.resolveModuleSpecifier(normalized, source)) {
+          candidates.push(...await this.resolveExport(targetModule, exportedName, callType, nextVisiting));
+        }
+      }
+    }
+
+    const filtered = filterCallTargetCandidates(callType, deduplicateSymbols(candidates));
+    const result = deduplicateSymbols(filtered);
+    this.exportCache.set(cacheKey, result);
+    return result;
+  }
+}

--- a/src/indexer/local-module-resolution.ts
+++ b/src/indexer/local-module-resolution.ts
@@ -406,11 +406,12 @@ export class LocalModuleCallResolver {
         candidates.push(...await this.resolveImportedBinding(importer, binding, site.callType));
       }
     } else {
+      const namespaceCallType = site.callType === "MethodCall" ? "Call" : site.callType;
       for (const binding of record.namespaceImports.get(qualifier) ?? []) {
         candidates.push(...await this.resolveImportedBinding(
           importer,
           { importedName: site.calleeName, source: binding.source },
-          site.callType,
+          namespaceCallType,
         ));
       }
     }

--- a/src/tools/architecture-context.ts
+++ b/src/tools/architecture-context.ts
@@ -1,3 +1,4 @@
+import type { CallGraphCoverage } from "../indexer/call-graph-coverage.js";
 import type {
   CentralityData,
   CommunityCouplingData,
@@ -10,6 +11,7 @@ import { readFileSync } from "node:fs";
 import * as path from "node:path";
 
 import { estimateTokens } from "../utils/cost.js";
+import { formatCallGraphCoverage } from "../indexer/call-graph-coverage.js";
 import { deriveModules } from "./visualize/modules.js";
 
 export const ARCHITECTURE_CONTEXT_DEFAULT_DEPTH = 2;
@@ -54,7 +56,7 @@ export interface ArchitectureContextSources {
   projectRoot?: string;
   sourceSymbols?: SymbolData[];
   focusedSymbols?: SymbolData[];
-  graphCoverage?: { totalEdges: number; resolvedEdges: number };
+  graphCoverage?: CallGraphCoverage;
   recentActivity?: ArchitectureRecentActivity[];
 }
 
@@ -87,6 +89,7 @@ export interface ArchitectureContextResult {
     scoped: boolean;
     graphSparse: boolean;
     sourceFallback: boolean;
+    graph?: CallGraphCoverage;
     note: string;
   };
   recommendations: string[];
@@ -622,7 +625,7 @@ export function buildArchitectureContext(
     : communityResult.scopedMembers.length;
   const graphSparse = sourceFallback || boundaryCandidates.length === 0;
   const resolutionNote = graphCoverage
-    ? ` ${graphCoverage.resolvedEdges}/${graphCoverage.totalEdges} observed call edges are resolved in scope.`
+    ? ` ${formatCallGraphCoverage(graphCoverage)}`
     : "";
   const note = queryRequested && focusedSymbols.length === 0
     ? "No indexed symbols matched the requested query and scope. No global architecture is substituted."
@@ -639,6 +642,7 @@ export function buildArchitectureContext(
     scoped: Boolean(input.directory || input.query),
     graphSparse,
     sourceFallback,
+    graph: graphCoverage,
     note,
   };
   const recommendationCandidates = recommendationsFor(input, moduleCandidates, graphSparse);

--- a/src/tools/operations.ts
+++ b/src/tools/operations.ts
@@ -5,6 +5,7 @@ import { getHostProjectConfigRelativePath } from "../config/paths.js";
 import type { HostMode } from "../config/host.js";
 import type { CallEdgeData, PathHopData, SymbolData } from "../native/index.js";
 import { Indexer } from "../indexer/index.js";
+import { summarizeCallGraphCoverage } from "../indexer/call-graph-coverage.js";
 import { findKnowledgeBasePathIndex, hasMatchingKnowledgeBasePath, resolveKnowledgeBasePath } from "./knowledge-base-paths.js";
 import { buildCodeCommunitiesResult } from "./format-communities.js";
 import {
@@ -980,12 +981,7 @@ export async function getArchitectureContextForIndexer(
     projectRoot,
     sourceSymbols: visualization.symbols,
     focusedSymbols,
-    graphCoverage: {
-      totalEdges: scopedEdges.length,
-      resolvedEdges: scopedEdges.filter((edge) =>
-        edge.isResolved && edge.toSymbolId !== undefined && scopedSymbolIds.has(edge.toSymbolId)
-      ).length,
-    },
+    graphCoverage: summarizeCallGraphCoverage(scopedSymbols, scopedEdges),
     recentActivity,
   });
 }

--- a/tests/architecture-context.test.ts
+++ b/tests/architecture-context.test.ts
@@ -94,7 +94,19 @@ describe("architecture_context", () => {
       {
         projectRoot: tempDir,
         sourceSymbols: symbols,
-        graphCoverage: { totalEdges: 2, resolvedEdges: 1 },
+        graphCoverage: {
+          totalEdges: 2,
+          resolvedEdges: 1,
+          unresolvedEdges: 1,
+          resolutionRate: 0.5,
+          languages: [{
+            language: "typescript",
+            totalEdges: 2,
+            resolvedEdges: 1,
+            unresolvedEdges: 1,
+            resolutionRate: 0.5,
+          }],
+        },
       },
     );
   }
@@ -110,6 +122,13 @@ describe("architecture_context", () => {
     expect(first.text).toContain("implementation_lookup");
     expect(first.modules.every((module) => module.evidence.length > 0)).toBe(true);
     expect(first.modules.every((module) => module.evidence.some((evidence) => evidence.excerpt))).toBe(true);
+    expect(first.coverage.graph).toMatchObject({
+      totalEdges: 2,
+      resolvedEdges: 1,
+      unresolvedEdges: 1,
+    });
+    expect(first.coverage.note).toContain("1 unresolved");
+    expect(first.coverage.note).toContain("by language: typescript 1/2");
   });
 
   it("keeps relative directory scope strict against absolute indexed paths", () => {
@@ -150,7 +169,17 @@ describe("architecture_context", () => {
       [],
       [],
       [],
-      { projectRoot: tempDir, sourceSymbols: symbols, graphCoverage: { totalEdges: 0, resolvedEdges: 0 } },
+      {
+        projectRoot: tempDir,
+        sourceSymbols: symbols,
+        graphCoverage: {
+          totalEdges: 0,
+          resolvedEdges: 0,
+          unresolvedEdges: 0,
+          resolutionRate: 0,
+          languages: [],
+        },
+      },
     );
 
     expect(result.modules.length).toBeGreaterThan(0);
@@ -159,6 +188,7 @@ describe("architecture_context", () => {
     expect(result.coverage.graphSparse).toBe(true);
     expect(result.boundaries).toEqual([]);
     expect(result.text).toContain("no relationship is inferred");
+    expect(result.coverage.note).toContain("No call edges were observed in scope");
   });
 
   it("enforces the requested response token budget while preserving whole cited claims", () => {

--- a/tests/automatic-branch-index.test.ts
+++ b/tests/automatic-branch-index.test.ts
@@ -318,7 +318,7 @@ function changed(): number {
       ),
     ).toBe(true);
     for (const [prefix, version] of [
-      ["index.callGraphResolutionVersion", "4"],
+      ["index.callGraphResolutionVersion", "5"],
       [swiftPrefix, "1"],
       ["index.parser.metalVersion", "1"],
     ] as const) {

--- a/tests/call-graph.test.ts
+++ b/tests/call-graph.test.ts
@@ -2507,7 +2507,293 @@ main() {
     });
   });
 
+  describe("local TypeScript and JavaScript module resolution", () => {
+    function mockEmbeddings(): ReturnType<typeof vi.spyOn> {
+      return vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init?) => {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { input?: string | string[] };
+        const inputs = Array.isArray(body.input) ? body.input : [body.input ?? ""];
+        return new Response(
+          JSON.stringify({
+            data: inputs.map(() => ({ embedding: Array(8).fill(0.125) })),
+            usage: { total_tokens: Math.max(1, inputs.length) },
+          }),
+          { status: 200 },
+        );
+      });
+    }
+
+    function copyLocalModuleFixture(projectDir: string): void {
+      fs.cpSync(path.join(fixturesDir, "local-modules"), projectDir, { recursive: true });
+    }
+
+    it("resolves relative imports, aliases, and re-exports while abstaining on ambiguity", async () => {
+      const projectDir = path.join(tempDir, "local-module-project");
+      fs.mkdirSync(projectDir, { recursive: true });
+      copyLocalModuleFixture(projectDir);
+      const fetchSpy = mockEmbeddings();
+      const indexer = new Indexer(projectDir, createIndexerConfig(), "opencode");
+
+      try {
+        await indexer.index();
+        const symbols = await indexer.getSymbolsForBranch();
+        const byName = (name: string): SymbolData => {
+          const matches = symbols.filter((symbol) => symbol.name === name);
+          expect(matches.length).toBeGreaterThan(0);
+          return matches[0];
+        };
+        const edgeFrom = async (callerName: string, targetName: string): Promise<CallEdgeData> => {
+          const edge = (await indexer.getCallees(byName(callerName).id)).find(
+            (candidate) => candidate.targetName === targetName,
+          );
+          expect(edge).toBeDefined();
+          return edge!;
+        };
+
+        await expect(edgeFrom("runDirect", "directTarget")).resolves.toMatchObject({
+          isResolved: true,
+          toSymbolId: byName("directTarget").id,
+        });
+        await expect(edgeFrom("runAlias", "localAlias")).resolves.toMatchObject({
+          isResolved: true,
+          toSymbolId: byName("directTarget").id,
+        });
+        await expect(edgeFrom("runReexport", "localReexport")).resolves.toMatchObject({
+          isResolved: true,
+          toSymbolId: byName("originalTarget").id,
+        });
+
+        const duplicateTargets = symbols.filter((symbol) => symbol.name === "duplicateTarget");
+        expect(duplicateTargets).toHaveLength(2);
+        const duplicateA = duplicateTargets.find((symbol) => symbol.filePath.endsWith("duplicate-a.ts"));
+        await expect(edgeFrom("runDuplicate", "duplicateTarget")).resolves.toMatchObject({
+          isResolved: true,
+          toSymbolId: duplicateA!.id,
+        });
+        const ambiguousEdge = await edgeFrom("runAmbiguous", "ambiguousTarget");
+        expect(ambiguousEdge).toMatchObject({ isResolved: false });
+        expect(ambiguousEdge.toSymbolId).toBeUndefined();
+        const missingEdge = await edgeFrom("runMissing", "missingTarget");
+        expect(missingEdge).toMatchObject({ isResolved: false });
+        expect(missingEdge.toSymbolId).toBeUndefined();
+        await expect(edgeFrom("runLocal", "localTarget")).resolves.toMatchObject({
+          isResolved: true,
+          toSymbolId: byName("localTarget").id,
+        });
+        await expect(edgeFrom("runJavaScript", "jsAlias")).resolves.toMatchObject({
+          isResolved: true,
+          toSymbolId: byName("javascriptTarget").id,
+        });
+
+        const directCallers = await indexer.getCallers("directTarget");
+        expect(directCallers.map((edge) => edge.fromSymbolName).sort()).toEqual(["runAlias", "runDirect"]);
+
+        const coverage = await indexer.getCallGraphCoverage();
+        expect(coverage).toMatchObject({
+          totalEdges: 8,
+          resolvedEdges: 6,
+          unresolvedEdges: 2,
+          resolutionRate: 0.75,
+        });
+        expect(coverage.languages).toEqual([
+          {
+            language: "javascript",
+            totalEdges: 1,
+            resolvedEdges: 1,
+            unresolvedEdges: 0,
+            resolutionRate: 1,
+          },
+          {
+            language: "typescript",
+            totalEdges: 7,
+            resolvedEdges: 5,
+            unresolvedEdges: 2,
+            resolutionRate: 5 / 7,
+          },
+        ]);
+      } finally {
+        await indexer.close();
+        fetchSpy.mockRestore();
+      }
+    });
+
+    it("reprocesses unchanged importers when a local re-export changes", async () => {
+      const projectDir = path.join(tempDir, "local-module-refresh-project");
+      fs.mkdirSync(projectDir, { recursive: true });
+      copyLocalModuleFixture(projectDir);
+      const fetchSpy = mockEmbeddings();
+      let indexer = new Indexer(projectDir, createIndexerConfig(), "opencode");
+
+      try {
+        await indexer.index();
+        let symbols = await indexer.getSymbolsForBranch();
+        let caller = symbols.find((symbol) => symbol.name === "runReexport");
+        let edge = (await indexer.getCallees(caller!.id)).find(
+          (candidate) => candidate.targetName === "localReexport",
+        );
+        expect(edge?.isResolved).toBe(true);
+        await indexer.close();
+
+        fs.writeFileSync(
+          path.join(projectDir, "barrel.ts"),
+          'export { missingOriginal as publicTarget } from "./reexport-source.js";\n',
+        );
+        indexer = new Indexer(projectDir, createIndexerConfig(), "opencode");
+        await indexer.index();
+        symbols = await indexer.getSymbolsForBranch();
+        caller = symbols.find((symbol) => symbol.name === "runReexport");
+        edge = (await indexer.getCallees(caller!.id)).find(
+          (candidate) => candidate.targetName === "localReexport",
+        );
+        expect(edge).toMatchObject({ isResolved: false });
+        expect(edge?.toSymbolId).toBeUndefined();
+      } finally {
+        await indexer.close();
+        fetchSpy.mockRestore();
+      }
+    });
+
+    it("migrates unchanged local import edges without re-embedding chunks", async () => {
+      const projectDir = path.join(tempDir, "local-module-migration-project");
+      fs.mkdirSync(projectDir, { recursive: true });
+      copyLocalModuleFixture(projectDir);
+      const fetchSpy = mockEmbeddings();
+      let indexer = new Indexer(projectDir, createIndexerConfig(), "opencode");
+
+      try {
+        await indexer.index();
+        const symbols = await indexer.getSymbolsForBranch();
+        const caller = symbols.find((symbol) => symbol.name === "runAlias");
+        const edge = (await indexer.getCallees(caller!.id)).find(
+          (candidate) => candidate.targetName === "localAlias",
+        );
+        expect(edge?.isResolved).toBe(true);
+        await indexer.close();
+
+        const database = new Database(path.join(projectDir, ".opencode", "index", "codebase.db"));
+        database.upsertCallEdge({
+          id: edge!.id,
+          fromSymbolId: edge!.fromSymbolId,
+          targetName: edge!.targetName,
+          callType: edge!.callType,
+          confidence: edge!.confidence,
+          line: edge!.line,
+          col: edge!.col,
+          isResolved: false,
+        });
+        database.setMetadata(migrationMetadataKey("index.callGraphResolutionVersion"), "4");
+        database.close();
+        const embeddingCallsBeforeMigration = fetchSpy.mock.calls.length;
+
+        indexer = new Indexer(projectDir, createIndexerConfig(), "opencode");
+        await indexer.index();
+        const migratedSymbols = await indexer.getSymbolsForBranch();
+        const migratedCaller = migratedSymbols.find((symbol) => symbol.name === "runAlias");
+        const migratedTarget = migratedSymbols.find((symbol) => symbol.name === "directTarget");
+        const migratedEdge = (await indexer.getCallees(migratedCaller!.id)).find(
+          (candidate) => candidate.targetName === "localAlias",
+        );
+        expect(migratedEdge).toMatchObject({
+          isResolved: true,
+          toSymbolId: migratedTarget!.id,
+        });
+        expect(fetchSpy).toHaveBeenCalledTimes(embeddingCallsBeforeMigration);
+      } finally {
+        await indexer.close();
+        fetchSpy.mockRestore();
+      }
+    });
+  });
+
   describe("branch awareness", () => {
+    it("reports graph coverage only for the active branch", async () => {
+      writeGitBranchHead("main");
+      const db = openIndexerDb();
+      const symbols: SymbolData[] = [
+        {
+          id: "sym_main_coverage_caller",
+          filePath: "src/main-caller.ts",
+          name: "mainCaller",
+          kind: "function_declaration",
+          startLine: 1,
+          startCol: 0,
+          endLine: 3,
+          endCol: 0,
+          language: "typescript",
+        },
+        {
+          id: "sym_main_coverage_target",
+          filePath: "src/main-target.ts",
+          name: "mainTarget",
+          kind: "function_declaration",
+          startLine: 1,
+          startCol: 0,
+          endLine: 3,
+          endCol: 0,
+          language: "typescript",
+        },
+        {
+          id: "sym_feature_coverage_caller",
+          filePath: "src/feature-caller.js",
+          name: "featureCaller",
+          kind: "function_declaration",
+          startLine: 1,
+          startCol: 0,
+          endLine: 3,
+          endCol: 0,
+          language: "javascript",
+        },
+      ];
+      db.upsertSymbolsBatch(symbols);
+      db.addSymbolsToBranchBatch("main", [symbols[0].id, symbols[1].id]);
+      db.addSymbolsToBranchBatch("feature", [symbols[2].id]);
+      db.upsertCallEdgesBatch([
+        {
+          id: "edge_main_coverage",
+          fromSymbolId: symbols[0].id,
+          targetName: symbols[1].name,
+          toSymbolId: symbols[1].id,
+          callType: "Call",
+          confidence: "Direct",
+          line: 2,
+          col: 2,
+          isResolved: true,
+        },
+        {
+          id: "edge_feature_coverage",
+          fromSymbolId: symbols[2].id,
+          targetName: "missingFeatureTarget",
+          callType: "Call",
+          confidence: "Direct",
+          line: 2,
+          col: 2,
+          isResolved: false,
+        },
+      ]);
+      db.close();
+
+      let indexer = new Indexer(tempDir, createIndexerConfig(), "opencode");
+      try {
+        await expect(indexer.getCallGraphCoverage()).resolves.toMatchObject({
+          totalEdges: 1,
+          resolvedEdges: 1,
+          unresolvedEdges: 0,
+          languages: [{ language: "typescript", totalEdges: 1, resolvedEdges: 1 }],
+        });
+        await indexer.close();
+
+        writeGitBranchHead("feature");
+        indexer = new Indexer(tempDir, createIndexerConfig(), "opencode");
+        await expect(indexer.getCallGraphCoverage()).resolves.toMatchObject({
+          totalEdges: 1,
+          resolvedEdges: 0,
+          unresolvedEdges: 1,
+          languages: [{ language: "javascript", totalEdges: 1, resolvedEdges: 0 }],
+        });
+      } finally {
+        await indexer.close();
+      }
+    });
+
     it("should filter symbols by current branch", () => {
       const db = openDb();
 

--- a/tests/fixtures/call-graph/local-modules/ambiguous-a.ts
+++ b/tests/fixtures/call-graph/local-modules/ambiguous-a.ts
@@ -1,0 +1,3 @@
+export function ambiguousTarget(): string {
+  return "a";
+}

--- a/tests/fixtures/call-graph/local-modules/ambiguous-b.ts
+++ b/tests/fixtures/call-graph/local-modules/ambiguous-b.ts
@@ -1,0 +1,3 @@
+export function ambiguousTarget(): string {
+  return "b";
+}

--- a/tests/fixtures/call-graph/local-modules/ambiguous-barrel.ts
+++ b/tests/fixtures/call-graph/local-modules/ambiguous-barrel.ts
@@ -1,0 +1,2 @@
+export * from "./ambiguous-a.js";
+export * from "./ambiguous-b.js";

--- a/tests/fixtures/call-graph/local-modules/barrel.ts
+++ b/tests/fixtures/call-graph/local-modules/barrel.ts
@@ -1,0 +1,1 @@
+export { originalTarget as publicTarget } from "./reexport-source.js";

--- a/tests/fixtures/call-graph/local-modules/direct.ts
+++ b/tests/fixtures/call-graph/local-modules/direct.ts
@@ -1,0 +1,3 @@
+export function directTarget(): number {
+  return 1;
+}

--- a/tests/fixtures/call-graph/local-modules/duplicate-a.ts
+++ b/tests/fixtures/call-graph/local-modules/duplicate-a.ts
@@ -1,0 +1,3 @@
+export function duplicateTarget(): string {
+  return "a";
+}

--- a/tests/fixtures/call-graph/local-modules/duplicate-b.ts
+++ b/tests/fixtures/call-graph/local-modules/duplicate-b.ts
@@ -1,0 +1,3 @@
+export function duplicateTarget(): string {
+  return "b";
+}

--- a/tests/fixtures/call-graph/local-modules/js-main.js
+++ b/tests/fixtures/call-graph/local-modules/js-main.js
@@ -1,0 +1,5 @@
+import { javascriptTarget as jsAlias } from "./js-target.js";
+
+export function runJavaScript() {
+  return jsAlias();
+}

--- a/tests/fixtures/call-graph/local-modules/js-target.js
+++ b/tests/fixtures/call-graph/local-modules/js-target.js
@@ -1,0 +1,3 @@
+export function javascriptTarget() {
+  return 4;
+}

--- a/tests/fixtures/call-graph/local-modules/main.ts
+++ b/tests/fixtures/call-graph/local-modules/main.ts
@@ -1,0 +1,37 @@
+import { directTarget, directTarget as localAlias } from "./direct.js";
+import { publicTarget as localReexport } from "./barrel.js";
+import { duplicateTarget } from "./duplicate-a.js";
+import { ambiguousTarget } from "./ambiguous-barrel.js";
+import { missingTarget } from "./missing.js";
+
+export function localTarget(): number {
+  return 3;
+}
+
+export function runDirect(): number {
+  return directTarget();
+}
+
+export function runAlias(): number {
+  return localAlias();
+}
+
+export function runReexport(): number {
+  return localReexport();
+}
+
+export function runDuplicate(): string {
+  return duplicateTarget();
+}
+
+export function runAmbiguous(): string {
+  return ambiguousTarget();
+}
+
+export function runMissing(): unknown {
+  return missingTarget();
+}
+
+export function runLocal(): number {
+  return localTarget();
+}

--- a/tests/fixtures/call-graph/local-modules/reexport-source.ts
+++ b/tests/fixtures/call-graph/local-modules/reexport-source.ts
@@ -1,0 +1,3 @@
+export function originalTarget(): number {
+  return 2;
+}

--- a/tests/indexer-checkpoint-resume.test.ts
+++ b/tests/indexer-checkpoint-resume.test.ts
@@ -366,7 +366,9 @@ describe("indexer checkpoint resume", () => {
     writeSourceFile(betaFile, ["betaOne", "betaTwo"]);
     writeSourceFile(gammaFile, ["gammaOne", "gammaTwo"]);
     await expect(indexer.index((progress) => {
-      if (progress.phase === "embedding" && progress.filesProcessed === progress.totalFiles) {
+      // `totalFiles` covers the indexed project, including unchanged alpha.
+      // Interrupt after the first newly indexed file checkpoint instead.
+      if (progress.phase === "embedding" && progress.filesProcessed === 1) {
         throw new Error("simulated interruption after new-file checkpoint");
       }
     })).rejects.toThrow("simulated interruption after new-file checkpoint");

--- a/tests/local-module-resolution.test.ts
+++ b/tests/local-module-resolution.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vitest";
+
+import { LocalModuleCallResolver, type LocalModuleData } from "../src/indexer/local-module-resolution.js";
+import type { CallSiteData, SymbolData } from "../src/native/index.js";
+
+function symbol(id: string, filePath: string, name: string, kind = "function_declaration"): SymbolData {
+  return {
+    id,
+    filePath,
+    name,
+    kind,
+    startLine: 1,
+    startCol: 0,
+    endLine: 3,
+    endCol: 0,
+    language: filePath.endsWith(".js") ? "javascript" : "typescript",
+  };
+}
+
+function callSite(calleeName: string, line = 2, column = 2, callType: CallSiteData["callType"] = "Call"): CallSiteData {
+  return { calleeName, line, column, callType, confidence: "Direct" };
+}
+
+function resolver(modules: Record<string, LocalModuleData>): LocalModuleCallResolver {
+  return new LocalModuleCallResolver({
+    filePaths: Object.keys(modules),
+    loadModule: async (filePath) => modules[filePath],
+  });
+}
+
+describe("LocalModuleCallResolver", () => {
+  it("resolves direct, aliased, default, and namespace imports", async () => {
+    const main = [
+      'import defaultTarget, { directTarget as localAlias } from "./target.js";',
+      'import * as targetApi from "./target.js";',
+      "export function run() {",
+      "  localAlias();",
+      "  defaultTarget();",
+      "  targetApi.directTarget();",
+      "}",
+    ].join("\n");
+    const directTarget = symbol("direct", "src/target.ts", "directTarget");
+    const defaultTarget = symbol("default", "src/target.ts", "defaultImplementation");
+    const instance = resolver({
+      "src/main.ts": { content: main, symbols: [symbol("run", "src/main.ts", "run")] },
+      "src/target.ts": {
+        content: [
+          "export function directTarget() { return 1; }",
+          "export default function defaultImplementation() { return 2; }",
+        ].join("\n"),
+        symbols: [directTarget, defaultTarget],
+      },
+    });
+
+    await expect(instance.resolveCallTarget("src/main.ts", main, callSite("localAlias", 4, 2)))
+      .resolves.toEqual(directTarget);
+    await expect(instance.resolveCallTarget("src/main.ts", main, callSite("defaultTarget", 5, 2)))
+      .resolves.toEqual(defaultTarget);
+    await expect(instance.resolveCallTarget("src/main.ts", main, callSite("directTarget", 6, 12, "MethodCall")))
+      .resolves.toEqual(directTarget);
+  });
+
+  it("follows named aliases and export-star re-export chains", async () => {
+    const main = [
+      'import { publicTarget as localTarget, starTarget } from "./barrel.js";',
+      "export function run() {",
+      "  localTarget();",
+      "  starTarget();",
+      "}",
+    ].join("\n");
+    const original = symbol("original", "src/original.ts", "originalTarget");
+    const star = symbol("star", "src/star.ts", "starTarget");
+    const instance = resolver({
+      "src/main.ts": { content: main, symbols: [symbol("run", "src/main.ts", "run")] },
+      "src/barrel.ts": {
+        content: [
+          'export { originalTarget as publicTarget } from "./original.js";',
+          'export * from "./nested.js";',
+        ].join("\n"),
+        symbols: [],
+      },
+      "src/nested.ts": { content: 'export * from "./star.js";', symbols: [] },
+      "src/original.ts": {
+        content: "export function originalTarget() { return 1; }",
+        symbols: [original],
+      },
+      "src/star.ts": { content: "export function starTarget() { return 2; }", symbols: [star] },
+    });
+
+    await expect(instance.resolveCallTarget("src/main.ts", main, callSite("localTarget", 3, 2)))
+      .resolves.toEqual(original);
+    await expect(instance.resolveCallTarget("src/main.ts", main, callSite("starTarget", 4, 2)))
+      .resolves.toEqual(star);
+  });
+
+  it("uses the relative module path to disambiguate duplicate symbol names", async () => {
+    const main = [
+      'import { duplicateTarget } from "./a.js";',
+      "export function run() { duplicateTarget(); }",
+    ].join("\n");
+    const targetA = symbol("a", "src/a.ts", "duplicateTarget");
+    const targetB = symbol("b", "src/b.ts", "duplicateTarget");
+    const instance = resolver({
+      "src/main.ts": { content: main, symbols: [symbol("run", "src/main.ts", "run")] },
+      "src/a.ts": { content: "export function duplicateTarget() {}", symbols: [targetA] },
+      "src/b.ts": { content: "export function duplicateTarget() {}", symbols: [targetB] },
+    });
+
+    await expect(instance.resolveCallTarget("src/main.ts", main, callSite("duplicateTarget", 2, 24)))
+      .resolves.toEqual(targetA);
+  });
+
+  it("does not mistake an ordinary member call for a named import", async () => {
+    const main = [
+      'import { directTarget as localAlias } from "./target.js";',
+      "export function run(holder: { localAlias(): void }) { holder.localAlias(); }",
+    ].join("\n");
+    const instance = resolver({
+      "src/main.ts": { content: main, symbols: [symbol("run", "src/main.ts", "run")] },
+      "src/target.ts": {
+        content: "export function directTarget() {}",
+        symbols: [symbol("target", "src/target.ts", "directTarget")],
+      },
+    });
+
+    await expect(instance.resolveCallTarget("src/main.ts", main, callSite("localAlias", 2, 61, "MethodCall")))
+      .resolves.toBeUndefined();
+  });
+
+  it("abstains for ambiguous star exports and ambiguous extensionless modules", async () => {
+    const main = [
+      'import { ambiguousTarget } from "./barrel.js";',
+      'import { extensionlessTarget } from "./extensionless";',
+      "export function run() { ambiguousTarget(); extensionlessTarget(); }",
+    ].join("\n");
+    const instance = resolver({
+      "src/main.ts": { content: main, symbols: [symbol("run", "src/main.ts", "run")] },
+      "src/barrel.ts": {
+        content: 'export * from "./a.js";\nexport * from "./b.js";',
+        symbols: [],
+      },
+      "src/a.ts": {
+        content: "export function ambiguousTarget() {}",
+        symbols: [symbol("a", "src/a.ts", "ambiguousTarget")],
+      },
+      "src/b.ts": {
+        content: "export function ambiguousTarget() {}",
+        symbols: [symbol("b", "src/b.ts", "ambiguousTarget")],
+      },
+      "src/extensionless.ts": {
+        content: "export function extensionlessTarget() {}",
+        symbols: [symbol("ts", "src/extensionless.ts", "extensionlessTarget")],
+      },
+      "src/extensionless.js": {
+        content: "export function extensionlessTarget() {}",
+        symbols: [symbol("js", "src/extensionless.js", "extensionlessTarget")],
+      },
+    });
+
+    await expect(instance.resolveCallTarget("src/main.ts", main, callSite("ambiguousTarget", 3, 24)))
+      .resolves.toBeUndefined();
+    await expect(instance.resolveCallTarget("src/main.ts", main, callSite("extensionlessTarget", 3, 43)))
+      .resolves.toBeUndefined();
+  });
+
+  it("abstains for missing, external, type-only, and cyclic exports", async () => {
+    const main = [
+      'import { missingTarget } from "./missing.js";',
+      'import { externalTarget } from "external-package";',
+      'import type { TypeOnlyTarget } from "./types.js";',
+      'import { cyclicTarget } from "./cycle-a.js";',
+      "export function run() { missingTarget(); externalTarget(); TypeOnlyTarget(); cyclicTarget(); }",
+    ].join("\n");
+    const instance = resolver({
+      "src/main.ts": { content: main, symbols: [symbol("run", "src/main.ts", "run")] },
+      "src/types.ts": {
+        content: "export function TypeOnlyTarget() {}",
+        symbols: [symbol("type", "src/types.ts", "TypeOnlyTarget")],
+      },
+      "src/cycle-a.ts": { content: 'export * from "./cycle-b.js";', symbols: [] },
+      "src/cycle-b.ts": { content: 'export * from "./cycle-a.js";', symbols: [] },
+    });
+
+    for (const name of ["missingTarget", "externalTarget", "TypeOnlyTarget", "cyclicTarget"]) {
+      await expect(instance.resolveCallTarget("src/main.ts", main, callSite(name, 5, 24)))
+        .resolves.toBeUndefined();
+    }
+  });
+
+  it("selects a constructor-compatible symbol and returns deterministic repeated results", async () => {
+    const main = [
+      'import { Service } from "./service.js";',
+      "export function run() { return new Service(); }",
+    ].join("\n");
+    const interfaceSymbol = symbol("interface", "src/service.ts", "Service", "interface_declaration");
+    const classSymbol = symbol("class", "src/service.ts", "Service", "class_declaration");
+    const instance = resolver({
+      "src/main.ts": { content: main, symbols: [symbol("run", "src/main.ts", "run")] },
+      "src/service.ts": {
+        content: "export interface Service {}\nexport class Service {}",
+        symbols: [interfaceSymbol, classSymbol],
+      },
+    });
+    const site = callSite("Service", 2, 35, "Constructor");
+
+    const first = await instance.resolveCallTarget("src/main.ts", main, site);
+    const second = await instance.resolveCallTarget("src/main.ts", main, site);
+    expect(first).toEqual(classSymbol);
+    expect(second).toEqual(first);
+  });
+});

--- a/tests/pr-impact.test.ts
+++ b/tests/pr-impact.test.ts
@@ -28,7 +28,7 @@ function symbolExtractorMetadataKey(catalogIdentity: string): string {
 
 function setBranchMigrationMetadataCurrent(database: Database, catalogIdentity: string): void {
   const suffix = hashContent(catalogIdentity).slice(0, 24);
-  database.setMetadata(`index.callGraphResolutionVersion.${suffix}`, "4");
+  database.setMetadata(`index.callGraphResolutionVersion.${suffix}`, "5");
   database.setMetadata(`index.parser.swiftVersion.${suffix}`, "1");
   database.setMetadata(`index.parser.metalVersion.${suffix}`, "1");
   database.setMetadata(symbolExtractorMetadataKey(catalogIdentity), "1");


### PR DESCRIPTION
## Summary
- resolve direct, aliased, default, namespace, and re-exported local TS/JS module call targets conservatively
- reprocess affected importers on resolver migration without re-embedding unchanged chunks, and surface graph coverage by resolution mode
- document the deliberately deferred, opt-in SCIP enrichment path and update integration fixtures for resolver migration semantics

## Safety
- resolves only deterministic relative local modules
- abstains on external packages, type-only imports, cycles, ambiguous exports, and ambiguous extensionless files

## Validation
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run` (105 files, 1,630 tests)