### PR TITLE
feat: resolve deterministic tsconfig path aliases

### DIFF
--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -1260,6 +1260,19 @@ export class Indexer {
     return parseTsConfigForModuleResolution(configText);
   }
 
+  private getLocalModuleResolutionConfigHash(): string {
+    const configNames = ["tsconfig.json", "jsconfig.json"];
+    const configState = configNames.map((name) => {
+      const configPath = path.join(this.materializedProjectRoot, name);
+      try {
+        return [name, readFileSync(configPath, "utf-8")] as const;
+      } catch {
+        return [name, null] as const;
+      }
+    });
+    return hashContent(JSON.stringify(configState));
+  }
+
   private getIndexPath(): string {
     return this.indexPathOverride ?? resolveProjectIndexPath(this.projectRoot, this.config.scope, this.host);
   }
@@ -1709,6 +1722,12 @@ export class Indexer {
     catalogIdentity = this.getBranchCatalogIdentity(),
   ): string {
     return this.getBranchMigrationMetadataKey("index.callGraphResolutionVersion", catalogIdentity);
+  }
+
+  private getLocalModuleResolutionConfigMetadataKey(
+    catalogIdentity = this.getBranchCatalogIdentity(),
+  ): string {
+    return this.getBranchMigrationMetadataKey("index.localModuleResolutionConfigHash", catalogIdentity);
   }
 
   private getSwiftParserVersionMetadataKey(
@@ -3868,6 +3887,10 @@ export class Indexer {
     this.database.setMetadata("index.embeddingModel", provider.modelInfo.model);
     this.database.setMetadata("index.embeddingDimensions", provider.modelInfo.dimensions.toString());
     this.database.setMetadata(this.getCallGraphResolutionMetadataKey(), CALL_GRAPH_RESOLUTION_VERSION);
+    this.database.setMetadata(
+      this.getLocalModuleResolutionConfigMetadataKey(),
+      this.getLocalModuleResolutionConfigHash(),
+    );
     if (this.config.scope === "global") {
       if (completeProjectEmbeddingStrategyReset) {
         this.database.setMetadata(this.getProjectEmbeddingStrategyMetadataKey(), EMBEDDING_STRATEGY_VERSION);
@@ -4315,6 +4338,9 @@ export class Indexer {
     const currentStoredFilePaths = new Set(files.map((file) => this.toStoredFilePath(file.path)));
     const needsCallGraphResolutionMigration =
       database.getMetadata(this.getCallGraphResolutionMetadataKey()) !== CALL_GRAPH_RESOLUTION_VERSION;
+    const localModuleResolutionConfigChanged =
+      database.getMetadata(this.getLocalModuleResolutionConfigMetadataKey())
+      !== this.getLocalModuleResolutionConfigHash();
     let javaScriptGraphSourcesChanged = Array.from(this.fileHashCache.keys()).some((filePath) =>
       (!scopedRoots || this.isFileInCurrentScope(filePath, scopedRoots))
       && isJavaScriptFamilyFilePath(filePath)
@@ -4353,7 +4379,7 @@ export class Indexer {
         javaScriptGraphSourcesChanged = true;
       }
       const needsCallGraphRefresh = cachedHashMatches
-        && needsCallGraphResolutionMigration
+        && (needsCallGraphResolutionMigration || localModuleResolutionConfigChanged)
         && (
           isJavaScriptFamilyFilePath(storedPath)
           || database.getChunksByFile(storedPath).some((chunk) =>

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -111,7 +111,12 @@ import {
 import { iterateOrderedFileBatches, type FileBatchLimits } from "./file-batches.js";
 import { canonicalizePathForComparison } from "../utils/canonical-path.js";
 import { summarizeCallGraphCoverage, type CallGraphCoverage } from "./call-graph-coverage.js";
-import { isJavaScriptFamilyFilePath, LocalModuleCallResolver } from "./local-module-resolution.js";
+import {
+  isJavaScriptFamilyFilePath,
+  LocalModuleCallResolver,
+  parseTsConfigForModuleResolution,
+  type LocalModulePathAliases,
+} from "./local-module-resolution.js";
 
 export const CALL_GRAPH_LANGUAGES = new Set(["typescript", "tsx", "javascript", "jsx", "python", "go", "rust", "swift", "php", "apex", "zig", "gdscript", "matlab", "bash", "c", "cpp", "metal"]);
 // Languages whose identifiers are case-insensitive at the language level.
@@ -1235,6 +1240,24 @@ export class Indexer {
     this.indexPath = this.getIndexPath();
     this.refreshRuntimeArtifactPaths();
     this.logger = initializeLogger(config.debug);
+  }
+
+  private loadTsConfigPathAliases(): LocalModulePathAliases | undefined {
+    const tsConfigPath = path.join(this.materializedProjectRoot, "tsconfig.json");
+    const jsConfigPath = path.join(this.materializedProjectRoot, "jsconfig.json");
+    const configPaths = [tsConfigPath, jsConfigPath].filter((pathToCheck) => existsSync(pathToCheck));
+    if (configPaths.length !== 1) {
+      return undefined;
+    }
+
+    let configText: string;
+    try {
+      configText = readFileSync(configPaths[0], "utf-8");
+    } catch {
+      return undefined;
+    }
+
+    return parseTsConfigForModuleResolution(configText);
   }
 
   private getIndexPath(): string {
@@ -4449,6 +4472,7 @@ export class Indexer {
         descriptor,
       ]),
     );
+    const localModulePathAliases = this.loadTsConfigPathAliases();
     const localModuleResolver = new LocalModuleCallResolver({
       filePaths: [...sourceDescriptorsByPath.keys()],
       loadModule: async (filePath) => {
@@ -4471,6 +4495,7 @@ export class Indexer {
           symbols: parsed ? this.buildCallGraphSymbols(parsed, descriptor.hash) : [],
         };
       },
+      ...(localModulePathAliases === undefined ? {} : { tsConfigPathAliases: localModulePathAliases }),
     });
     let writeTransactionActive = false;
 

--- a/src/indexer/local-module-resolution.ts
+++ b/src/indexer/local-module-resolution.ts
@@ -49,6 +49,16 @@ interface ModuleRecord {
   starExports: string[];
 }
 
+export interface LocalModulePathAlias {
+  pattern: string;
+  targets: readonly string[];
+}
+
+export interface LocalModulePathAliases {
+  baseUrl: string;
+  aliases: readonly LocalModulePathAlias[];
+}
+
 export interface LocalModuleData {
   content: string;
   symbols: readonly SymbolData[];
@@ -57,6 +67,7 @@ export interface LocalModuleData {
 export interface LocalModuleResolverOptions {
   filePaths: readonly string[];
   loadModule: (filePath: string) => Promise<LocalModuleData | undefined>;
+  tsConfigPathAliases?: LocalModulePathAliases;
 }
 
 export function isJavaScriptFamilyFilePath(filePath: string): boolean {
@@ -67,6 +78,136 @@ export function isJavaScriptFamilyFilePath(filePath: string): boolean {
 
 function normalizeFilePath(filePath: string): string {
   return path.posix.normalize(filePath.replaceAll("\\", "/"));
+}
+
+function hasAtMostOneWildcard(value: string): boolean {
+  const first = value.indexOf("*");
+  return first === -1 || first === value.lastIndexOf("*");
+}
+
+function normalizePathAliasTarget(rawTarget: string): string {
+  const normalized = normalizeFilePath(rawTarget.trim());
+  if (normalized.length > 1 && normalized.endsWith("/")) {
+    return normalized.slice(0, -1);
+  }
+  return normalized;
+}
+
+function validateCompilerOptionsObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeBaseUrl(rawBaseUrl: string | undefined): string | undefined {
+  if (!rawBaseUrl) {
+    return undefined;
+  }
+
+  const trimmedBaseUrl = normalizeFilePath(rawBaseUrl.trim());
+  if (trimmedBaseUrl === ".") {
+    return ".";
+  }
+  if (trimmedBaseUrl === "") {
+    return ".";
+  }
+  if (path.posix.isAbsolute(trimmedBaseUrl)) {
+    return undefined;
+  }
+  if (trimmedBaseUrl === ".." || trimmedBaseUrl.startsWith("../") || trimmedBaseUrl.startsWith("./..")) {
+    return undefined;
+  }
+  return trimmedBaseUrl;
+}
+
+export function parseTsConfigForModuleResolution(configText: string): LocalModulePathAliases | undefined {
+  let rawConfig: unknown;
+  try {
+    rawConfig = JSON.parse(configText);
+  } catch {
+    return undefined;
+  }
+
+  if (!validateCompilerOptionsObject(rawConfig)) {
+    return undefined;
+  }
+
+  const compilerOptions = rawConfig.compilerOptions;
+  if (!validateCompilerOptionsObject(compilerOptions)) {
+    return undefined;
+  }
+
+  const normalizedBaseUrl = normalizeBaseUrl(typeof compilerOptions.baseUrl === "string" ? compilerOptions.baseUrl : undefined);
+  const rawPaths = compilerOptions.paths;
+  if (rawPaths === undefined && normalizedBaseUrl === undefined) {
+    return undefined;
+  }
+
+  const aliases: LocalModulePathAlias[] = [];
+    if (rawPaths !== undefined) {
+      if (!validateCompilerOptionsObject(rawPaths)) {
+        return undefined;
+      }
+
+      for (const [pattern, targetsValue] of Object.entries(rawPaths)) {
+        const normalizedPattern = normalizePathAliasTarget(pattern);
+        if (normalizedPattern.length === 0 || normalizedPattern === ".") {
+          return undefined;
+        }
+        if (!hasAtMostOneWildcard(normalizedPattern)) {
+          return undefined;
+        }
+
+        if (!Array.isArray(targetsValue)) {
+          return undefined;
+        }
+
+        const targets: string[] = [];
+        for (const target of targetsValue) {
+          if (typeof target !== "string") {
+            return undefined;
+          }
+          const normalizedTarget = normalizePathAliasTarget(target);
+          if (!hasAtMostOneWildcard(normalizedTarget)) {
+            return undefined;
+          }
+          if (normalizedTarget.startsWith("/") || normalizedTarget === ".." || normalizedTarget.startsWith("../")) {
+            return undefined;
+          }
+          if (normalizedTarget.length === 0) {
+            return undefined;
+          }
+          targets.push(normalizedTarget);
+        }
+
+        if (targets.length === 0) {
+          return undefined;
+        }
+
+        aliases.push({ pattern: normalizedPattern, targets });
+      }
+    }
+
+  if (aliases.length === 0 && normalizedBaseUrl === undefined) {
+    return undefined;
+  }
+
+  return {
+    baseUrl: normalizedBaseUrl ?? ".",
+    aliases,
+  };
+}
+
+function isProjectLocalPath(candidatePath: string): boolean {
+  if (path.posix.isAbsolute(candidatePath) || candidatePath === ".." || candidatePath.startsWith("../")) {
+    return false;
+  }
+  return true;
+}
+
+function trimLeadingCurrentDir(candidatePath: string): string {
+  if (candidatePath === ".") {
+    return ".";
+  }
+  return candidatePath.startsWith("./") ? candidatePath.slice(2) : candidatePath;
 }
 
 function isIdentifierStart(char: string): boolean {
@@ -370,6 +511,8 @@ export class LocalModuleCallResolver {
   private readonly moduleData = new Map<string, Promise<LocalModuleData | undefined>>();
   private readonly moduleRecords = new Map<string, Promise<ModuleRecord | undefined>>();
   private readonly exportCache = new Map<string, SymbolData[]>();
+  private readonly baseUrl?: string;
+  private readonly pathAliases: ReadonlyArray<LocalModulePathAlias> = [];
 
   constructor(options: LocalModuleResolverOptions) {
     for (const filePath of options.filePaths) {
@@ -377,6 +520,10 @@ export class LocalModuleCallResolver {
       if (isJavaScriptFamilyFilePath(normalized)) this.modulePaths.add(normalized);
     }
     this.loadModule = options.loadModule;
+    if (options.tsConfigPathAliases) {
+      this.baseUrl = options.tsConfigPathAliases.baseUrl;
+      this.pathAliases = options.tsConfigPathAliases.aliases;
+    }
   }
 
   seedModule(filePath: string, data: LocalModuleData): void {
@@ -444,28 +591,111 @@ export class LocalModuleCallResolver {
   }
 
   private resolveModuleSpecifier(importerFilePath: string, specifier: string): string[] {
-    if (!specifier.startsWith(".")) return [];
-    const base = normalizeFilePath(path.posix.join(path.posix.dirname(importerFilePath), specifier));
-    if (this.modulePaths.has(base)) return [base];
+    if (specifier.startsWith(".")) {
+      const base = normalizeFilePath(path.posix.join(path.posix.dirname(importerFilePath), specifier));
+      return this.resolveModuleCandidates(base);
+    }
 
-    const extension = path.posix.extname(base).toLowerCase();
+    const aliasCandidates = this.resolveModuleSpecifierFromAliases(specifier);
+    if (aliasCandidates !== undefined) {
+      return aliasCandidates;
+    }
+
+    if (this.baseUrl === undefined) {
+      return [];
+    }
+
+    return this.resolveModuleCandidates(normalizeFilePath(path.posix.join(this.baseUrl, specifier)));
+  }
+
+  private resolveModuleSpecifierFromAliases(specifier: string): string[] | undefined {
+    if (this.pathAliases.length === 0) return undefined;
+
+    const matchedAliasTargets = new Set<string>();
+    let anyAliasMatched = false;
+
+    for (const alias of this.pathAliases) {
+      const wildcard = this.matchPathAliasPattern(specifier, alias.pattern);
+      if (wildcard === undefined) {
+        continue;
+      }
+      anyAliasMatched = true;
+
+      for (const targetPattern of alias.targets) {
+        const target = this.replaceWildcard(targetPattern, wildcard);
+          const rawPath = normalizeFilePath(path.posix.join(this.baseUrl ?? ".", target));
+        if (!isProjectLocalPath(rawPath)) continue;
+        for (const candidate of this.resolveModuleCandidates(trimLeadingCurrentDir(rawPath))) {
+          matchedAliasTargets.add(candidate);
+        }
+      }
+    }
+
+    if (!anyAliasMatched) return undefined;
+    return [...matchedAliasTargets].sort();
+  }
+
+  private resolveModuleCandidates(base: string): string[] {
+    if (!isProjectLocalPath(base)) return [];
+
     const candidates = new Set<string>();
+    const normalizedBase = trimLeadingCurrentDir(base);
+    if (this.modulePaths.has(normalizedBase)) {
+      candidates.add(normalizedBase);
+    }
+
+    const extension = path.posix.extname(normalizedBase).toLowerCase();
     if (JAVASCRIPT_RUNTIME_EXTENSIONS.has(extension)) {
-      const withoutExtension = base.slice(0, -extension.length);
+      const withoutExtension = normalizedBase.slice(0, -extension.length);
       for (const sourceExtension of TYPESCRIPT_SOURCE_EXTENSIONS) {
         const candidate = `${withoutExtension}${sourceExtension}`;
         if (this.modulePaths.has(candidate)) candidates.add(candidate);
       }
-    } else if (extension.length === 0) {
-      for (const sourceExtension of JAVASCRIPT_SOURCE_EXTENSIONS) {
-        const fileCandidate = `${base}${sourceExtension}`;
-        const indexCandidate = path.posix.join(base, `index${sourceExtension}`);
-        if (this.modulePaths.has(fileCandidate)) candidates.add(fileCandidate);
-        if (this.modulePaths.has(indexCandidate)) candidates.add(indexCandidate);
+      return [...candidates].sort();
+    }
+
+    if (extension.length > 0 && JAVASCRIPT_SOURCE_EXTENSIONS.includes(extension as (typeof JAVASCRIPT_SOURCE_EXTENSIONS)[number])) {
+      if (this.modulePaths.has(normalizedBase)) {
+        return [...candidates].sort();
       }
     }
 
+    if (extension.length !== 0) return [...candidates].sort();
+
+    for (const sourceExtension of JAVASCRIPT_SOURCE_EXTENSIONS) {
+      const fileCandidate = `${normalizedBase}${sourceExtension}`;
+      const indexCandidate = path.posix.join(normalizedBase, `index${sourceExtension}`);
+      if (this.modulePaths.has(fileCandidate)) candidates.add(fileCandidate);
+      if (this.modulePaths.has(indexCandidate)) candidates.add(indexCandidate);
+    }
+
     return [...candidates].sort();
+  }
+
+  private matchPathAliasPattern(specifier: string, pattern: string): string | undefined {
+    const wildcard = pattern.indexOf("*");
+    if (wildcard === -1) {
+      return specifier === pattern ? "" : undefined;
+    }
+
+    const prefix = pattern.slice(0, wildcard);
+    const suffix = pattern.slice(wildcard + 1);
+    if (specifier.length < prefix.length + suffix.length) {
+      return undefined;
+    }
+    if (!specifier.startsWith(prefix) || !specifier.endsWith(suffix)) {
+      return undefined;
+    }
+
+    return specifier.slice(prefix.length, specifier.length - suffix.length);
+  }
+
+  private replaceWildcard(target: string, wildcard: string): string {
+    const wildcardIndex = target.indexOf("*");
+    if (wildcardIndex === -1) {
+      return target;
+    }
+    return `${target.slice(0, wildcardIndex)}${wildcard}${target.slice(wildcardIndex + 1)}`;
   }
 
   private async resolveImportedBinding(

--- a/src/indexer/local-module-resolution.ts
+++ b/src/indexer/local-module-resolution.ts
@@ -118,10 +118,123 @@ function normalizeBaseUrl(rawBaseUrl: string | undefined): string | undefined {
   return trimmedBaseUrl;
 }
 
+function removeJsoncComments(configText: string): string {
+  const output: string[] = [];
+  let inString: string | null = null;
+  let isEscaped = false;
+
+  for (let index = 0; index < configText.length; index += 1) {
+    const char = configText[index];
+    const nextChar = configText[index + 1];
+
+    if (inString !== null) {
+      output.push(char);
+      if (isEscaped) {
+        isEscaped = false;
+        continue;
+      }
+      if (char === "\\") {
+        isEscaped = true;
+        continue;
+      }
+      if (char === inString) {
+        inString = null;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = char;
+      output.push(char);
+      continue;
+    }
+
+    if (char === "/" && nextChar === "/") {
+      index += 1;
+      while (index + 1 < configText.length && configText[index + 1] !== "\n") {
+        index += 1;
+      }
+      continue;
+    }
+
+    if (char === "/" && nextChar === "*") {
+      index += 2;
+      while (index + 1 < configText.length) {
+        if (configText[index] === "*" && configText[index + 1] === "/") {
+          index += 1;
+          break;
+        }
+        index += 1;
+      }
+      continue;
+    }
+
+    output.push(char);
+  }
+
+  return output.join("");
+}
+
+function removeJsonTrailingCommas(configText: string): string {
+  const output: string[] = [];
+  let inString: string | null = null;
+  let isEscaped = false;
+
+  for (let index = 0; index < configText.length; index += 1) {
+    const char = configText[index];
+
+    if (inString !== null) {
+      output.push(char);
+      if (isEscaped) {
+        isEscaped = false;
+        continue;
+      }
+      if (char === "\\") {
+        isEscaped = true;
+        continue;
+      }
+      if (char === inString) {
+        inString = null;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = char;
+      output.push(char);
+      continue;
+    }
+
+    if (char !== ",") {
+      output.push(char);
+      continue;
+    }
+
+    let nextIndex = index + 1;
+    while (nextIndex < configText.length && /\s/u.test(configText[nextIndex])) {
+      nextIndex += 1;
+    }
+
+    const nextChar = configText[nextIndex];
+    if (nextChar === "}" || nextChar === "]" || nextChar === undefined) {
+      continue;
+    }
+
+    output.push(char);
+  }
+
+  return output.join("");
+}
+
+function parseJsonConfig(configText: string): unknown {
+  const sanitizedJson = removeJsonTrailingCommas(removeJsoncComments(configText));
+  return JSON.parse(sanitizedJson);
+}
+
 export function parseTsConfigForModuleResolution(configText: string): LocalModulePathAliases | undefined {
   let rawConfig: unknown;
   try {
-    rawConfig = JSON.parse(configText);
+    rawConfig = parseJsonConfig(configText);
   } catch {
     return undefined;
   }
@@ -137,7 +250,7 @@ export function parseTsConfigForModuleResolution(configText: string): LocalModul
 
   const normalizedBaseUrl = normalizeBaseUrl(typeof compilerOptions.baseUrl === "string" ? compilerOptions.baseUrl : undefined);
   const rawPaths = compilerOptions.paths;
-  if (rawPaths === undefined && normalizedBaseUrl === undefined) {
+  if (rawPaths === undefined) {
     return undefined;
   }
 
@@ -186,7 +299,7 @@ export function parseTsConfigForModuleResolution(configText: string): LocalModul
       }
     }
 
-  if (aliases.length === 0 && normalizedBaseUrl === undefined) {
+  if (aliases.length === 0) {
     return undefined;
   }
 
@@ -601,11 +714,11 @@ export class LocalModuleCallResolver {
       return aliasCandidates;
     }
 
-    if (this.baseUrl === undefined) {
+    if (this.pathAliases.length === 0) {
       return [];
     }
 
-    return this.resolveModuleCandidates(normalizeFilePath(path.posix.join(this.baseUrl, specifier)));
+    return [];
   }
 
   private resolveModuleSpecifierFromAliases(specifier: string): string[] | undefined {

--- a/tests/call-graph.test.ts
+++ b/tests/call-graph.test.ts
@@ -2655,6 +2655,23 @@ main() {
         const externalEdge = await edgeFrom("runExternal", "externalTarget");
         expect(externalEdge).toMatchObject({ isResolved: false });
         expect(externalEdge.toSymbolId).toBeUndefined();
+
+        const embeddingCallsBeforeConfigChange = fetchSpy.mock.calls.length;
+        fs.writeFileSync(path.join(projectDir, "tsconfig.json"), JSON.stringify({
+          compilerOptions: {
+            baseUrl: ".",
+            paths: {
+              "@core/*": ["src/missing/*"],
+              "@ambiguous/*": ["src/ambiguous-a/*", "src/ambiguous-b/*"],
+            },
+          },
+        }));
+        await indexer.index();
+
+        const refreshedEdge = await edgeFrom("runDeterministic", "deterministicTarget");
+        expect(refreshedEdge).toMatchObject({ isResolved: false });
+        expect(refreshedEdge.toSymbolId).toBeUndefined();
+        expect(fetchSpy).toHaveBeenCalledTimes(embeddingCallsBeforeConfigChange);
       } finally {
         await indexer.close();
         fetchSpy.mockRestore();

--- a/tests/call-graph.test.ts
+++ b/tests/call-graph.test.ts
@@ -2526,6 +2526,10 @@ main() {
       fs.cpSync(path.join(fixturesDir, "local-modules"), projectDir, { recursive: true });
     }
 
+    function copyAliasFixture(projectDir: string): void {
+      fs.cpSync(path.join(fixturesDir, "local-module-alias-resolution"), projectDir, { recursive: true });
+    }
+
     it("resolves relative imports, aliases, and re-exports while abstaining on ambiguity", async () => {
       const projectDir = path.join(tempDir, "local-module-project");
       fs.mkdirSync(projectDir, { recursive: true });
@@ -2610,6 +2614,47 @@ main() {
             resolutionRate: 5 / 7,
           },
         ]);
+      } finally {
+        await indexer.close();
+        fetchSpy.mockRestore();
+      }
+    });
+
+    it("resolves explicit path aliases deterministically and abstains for external/ambiguous alias targets", async () => {
+      const projectDir = path.join(tempDir, "local-module-alias-project");
+      fs.mkdirSync(projectDir, { recursive: true });
+      copyAliasFixture(projectDir);
+      const fetchSpy = mockEmbeddings();
+      const indexer = new Indexer(projectDir, createIndexerConfig(), "opencode");
+
+      try {
+        await indexer.index();
+        const symbols = await indexer.getSymbolsForBranch();
+        const byName = (name: string): SymbolData => {
+          const matches = symbols.filter((symbol) => symbol.name === name);
+          expect(matches.length).toBeGreaterThan(0);
+          return matches[0];
+        };
+
+        const edgeFrom = async (callerName: string, targetName: string): Promise<CallEdgeData> => {
+          const callerSymbol = byName(callerName);
+          const edge = (await indexer.getCallees(callerSymbol.id)).find((candidate) => candidate.targetName === targetName);
+          expect(edge).toBeDefined();
+          return edge!;
+        };
+
+        await expect(edgeFrom("runDeterministic", "deterministicTarget")).resolves.toMatchObject({
+          isResolved: true,
+          toSymbolId: byName("deterministicTarget").id,
+        });
+
+        const ambiguousEdge = await edgeFrom("runAmbiguous", "ambiguousTarget");
+        expect(ambiguousEdge).toMatchObject({ isResolved: false });
+        expect(ambiguousEdge.toSymbolId).toBeUndefined();
+
+        const externalEdge = await edgeFrom("runExternal", "externalTarget");
+        expect(externalEdge).toMatchObject({ isResolved: false });
+        expect(externalEdge.toSymbolId).toBeUndefined();
       } finally {
         await indexer.close();
         fetchSpy.mockRestore();

--- a/tests/fixtures/call-graph/local-module-alias-resolution/src/ambiguous-a/target.ts
+++ b/tests/fixtures/call-graph/local-module-alias-resolution/src/ambiguous-a/target.ts
@@ -1,0 +1,3 @@
+export function ambiguousTarget(_value: number): number {
+  return 2;
+}

--- a/tests/fixtures/call-graph/local-module-alias-resolution/src/ambiguous-b/target.ts
+++ b/tests/fixtures/call-graph/local-module-alias-resolution/src/ambiguous-b/target.ts
@@ -1,0 +1,3 @@
+export function ambiguousTarget(_value: number): number {
+  return 3;
+}

--- a/tests/fixtures/call-graph/local-module-alias-resolution/src/core/deterministic.ts
+++ b/tests/fixtures/call-graph/local-module-alias-resolution/src/core/deterministic.ts
@@ -1,0 +1,3 @@
+export function deterministicTarget(_value: number): number {
+  return 1;
+}

--- a/tests/fixtures/call-graph/local-module-alias-resolution/src/main.ts
+++ b/tests/fixtures/call-graph/local-module-alias-resolution/src/main.ts
@@ -1,0 +1,15 @@
+import { deterministicTarget } from "@core/deterministic";
+import { ambiguousTarget } from "@ambiguous/target";
+import { externalTarget } from "external-package";
+
+export function runDeterministic(): number {
+  return deterministicTarget(1);
+}
+
+export function runAmbiguous(): number {
+  return ambiguousTarget(1);
+}
+
+export function runExternal(): number {
+  return externalTarget();
+}

--- a/tests/fixtures/call-graph/local-module-alias-resolution/tsconfig.json
+++ b/tests/fixtures/call-graph/local-module-alias-resolution/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  // baseUrl is intentionally non-empty to confirm explicit paths-only behavior.
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@core/*": ["src/core/*"],
+      "@ambiguous/*": ["src/ambiguous-a/*", "src/ambiguous-b/*"],
+    },
+  }
+}

--- a/tests/local-module-resolution.test.ts
+++ b/tests/local-module-resolution.test.ts
@@ -229,6 +229,39 @@ describe("LocalModuleCallResolver", () => {
     });
   });
 
+  it("supports common JSONC tsconfig syntax", () => {
+    const parsed = parseTsConfigForModuleResolution([
+      '{',
+      '  // compilerOptions',
+      '  "compilerOptions": {',
+      '    "baseUrl": "./src",',
+      '    "paths": {',
+      '      "@/*": ["./*/index"],',
+      '      "@foo/*": ["./foo/*"],',
+      '    },',
+      '  },',
+      '}',
+    ].join("\n"));
+
+    expect(parsed).toEqual({
+      baseUrl: "src",
+      aliases: [
+        { pattern: "@/*", targets: ["*/index"] },
+        { pattern: "@foo/*", targets: ["foo/*"] },
+      ],
+    });
+  });
+
+  it("abstains when tsconfig does not define paths", () => {
+    const parsed = parseTsConfigForModuleResolution(JSON.stringify({
+      compilerOptions: {
+        baseUrl: "./src",
+      },
+    }));
+
+    expect(parsed).toBeUndefined();
+  });
+
   it("ignores invalid module-resolution config with unsupported structures", () => {
     expect(parseTsConfigForModuleResolution("{}")).toBeUndefined();
     expect(parseTsConfigForModuleResolution("not-json")).toBeUndefined();

--- a/tests/local-module-resolution.test.ts
+++ b/tests/local-module-resolution.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { LocalModuleCallResolver, type LocalModuleData } from "../src/indexer/local-module-resolution.js";
+import {
+  LocalModuleCallResolver,
+  parseTsConfigForModuleResolution,
+  type LocalModuleData,
+} from "../src/indexer/local-module-resolution.js";
 import type { CallSiteData, SymbolData } from "../src/native/index.js";
 
 function symbol(id: string, filePath: string, name: string, kind = "function_declaration"): SymbolData {
@@ -207,5 +211,28 @@ describe("LocalModuleCallResolver", () => {
     const second = await instance.resolveCallTarget("src/main.ts", main, site);
     expect(first).toEqual(classSymbol);
     expect(second).toEqual(first);
+  });
+
+  it("parses TypeScript module-resolution config and supports path aliases", () => {
+    const parsed = parseTsConfigForModuleResolution(JSON.stringify({
+      compilerOptions: {
+        baseUrl: "./src",
+        paths: {
+          "@/*": ["./*/index"],
+        },
+      },
+    }));
+
+    expect(parsed).toEqual({
+      baseUrl: "src",
+      aliases: [{ pattern: "@/*", targets: ["*/index"] }],
+    });
+  });
+
+  it("ignores invalid module-resolution config with unsupported structures", () => {
+    expect(parseTsConfigForModuleResolution("{}")).toBeUndefined();
+    expect(parseTsConfigForModuleResolution("not-json")).toBeUndefined();
+    expect(parseTsConfigForModuleResolution(JSON.stringify({ compilerOptions: { paths: { "bad*path*here": ["./x"] } } })))
+      .toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- resolve deterministic project-local TypeScript and JavaScript `paths` aliases from `tsconfig.json` or `jsconfig.json`
- support common JSONC comments and trailing commas without adding a runtime dependency
- preserve conservative abstention for bare external imports, aliases without `paths`, ambiguous targets, malformed config, cycles, and type-only imports

## Validation
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run test:run` (105 files, 1,635 tests)