### PR TITLE
feat: resolve aliases through local tsconfig extends

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -114,7 +114,7 @@ import { summarizeCallGraphCoverage, type CallGraphCoverage } from "./call-graph
 import {
   isJavaScriptFamilyFilePath,
   LocalModuleCallResolver,
-  parseTsConfigForModuleResolution,
+  resolveTsConfigForModuleResolution,
   type LocalModulePathAliases,
 } from "./local-module-resolution.js";
 
@@ -1243,26 +1243,44 @@ export class Indexer {
   }
 
   private loadTsConfigPathAliases(): LocalModulePathAliases | undefined {
-    const tsConfigPath = path.join(this.materializedProjectRoot, "tsconfig.json");
-    const jsConfigPath = path.join(this.materializedProjectRoot, "jsconfig.json");
-    const configPaths = [tsConfigPath, jsConfigPath].filter((pathToCheck) => existsSync(pathToCheck));
-    if (configPaths.length !== 1) {
+    const configName = this.getLocalModuleResolutionRootConfigName();
+    if (!configName) {
       return undefined;
     }
 
-    let configText: string;
-    try {
-      configText = readFileSync(configPaths[0], "utf-8");
-    } catch {
-      return undefined;
-    }
+    return resolveTsConfigForModuleResolution(configName, (configPath) => {
+      try {
+        return readFileSync(path.join(this.materializedProjectRoot, configPath), "utf-8");
+      } catch {
+        return undefined;
+      }
+    });
+  }
 
-    return parseTsConfigForModuleResolution(configText);
+  private getLocalModuleResolutionRootConfigName(): "tsconfig.json" | "jsconfig.json" | undefined {
+    const configNames = ["tsconfig.json", "jsconfig.json"] as const;
+    const existingConfigs = configNames.filter((name) =>
+      existsSync(path.join(this.materializedProjectRoot, name)),
+    );
+    return existingConfigs.length === 1 ? existingConfigs[0] : undefined;
   }
 
   private getLocalModuleResolutionConfigHash(): string {
     const configNames = ["tsconfig.json", "jsconfig.json"];
-    const configState = configNames.map((name) => {
+    const rootConfigName = this.getLocalModuleResolutionRootConfigName();
+    const configNamesToHash = new Set(configNames);
+    if (rootConfigName) {
+      resolveTsConfigForModuleResolution(rootConfigName, (configPath) => {
+        configNamesToHash.add(configPath);
+        try {
+          return readFileSync(path.join(this.materializedProjectRoot, configPath), "utf-8");
+        } catch {
+          return undefined;
+        }
+      });
+    }
+    const namesToHash = [...configNamesToHash].sort();
+    const configState = namesToHash.map((name) => {
       const configPath = path.join(this.materializedProjectRoot, name);
       try {
         return [name, readFileSync(configPath, "utf-8")] as const;

--- a/src/indexer/local-module-resolution.ts
+++ b/src/indexer/local-module-resolution.ts
@@ -52,6 +52,8 @@ interface ModuleRecord {
 export interface LocalModulePathAlias {
   pattern: string;
   targets: readonly string[];
+  /** Project-relative base directory for aliases inherited from another config. */
+  baseUrl?: string;
 }
 
 export interface LocalModulePathAliases {
@@ -231,7 +233,12 @@ function parseJsonConfig(configText: string): unknown {
   return JSON.parse(sanitizedJson);
 }
 
-export function parseTsConfigForModuleResolution(configText: string): LocalModulePathAliases | undefined {
+interface TsConfigDocument {
+  compilerOptions: Record<string, unknown>;
+  extendsPath?: string;
+}
+
+function parseTsConfigDocument(configText: string): TsConfigDocument | undefined {
   let rawConfig: unknown;
   try {
     rawConfig = parseJsonConfig(configText);
@@ -244,60 +251,76 @@ export function parseTsConfigForModuleResolution(configText: string): LocalModul
   }
 
   const compilerOptions = rawConfig.compilerOptions;
-  if (!validateCompilerOptionsObject(compilerOptions)) {
+  if (compilerOptions !== undefined && !validateCompilerOptionsObject(compilerOptions)) {
     return undefined;
   }
 
-  const normalizedBaseUrl = normalizeBaseUrl(typeof compilerOptions.baseUrl === "string" ? compilerOptions.baseUrl : undefined);
-  const rawPaths = compilerOptions.paths;
-  if (rawPaths === undefined) {
+  if (rawConfig.extends !== undefined && typeof rawConfig.extends !== "string") {
     return undefined;
   }
+
+  return {
+    compilerOptions: compilerOptions ?? {},
+    extendsPath: rawConfig.extends,
+  };
+}
+
+function parsePathAliases(compilerOptions: Record<string, unknown>): LocalModulePathAlias[] | undefined {
+  const rawPaths = compilerOptions.paths;
+  if (rawPaths === undefined) return [];
+  if (!validateCompilerOptionsObject(rawPaths)) return undefined;
 
   const aliases: LocalModulePathAlias[] = [];
-    if (rawPaths !== undefined) {
-      if (!validateCompilerOptionsObject(rawPaths)) {
+  for (const [pattern, targetsValue] of Object.entries(rawPaths)) {
+    const normalizedPattern = normalizePathAliasTarget(pattern);
+    if (normalizedPattern.length === 0 || normalizedPattern === ".") {
+      return undefined;
+    }
+    if (!hasAtMostOneWildcard(normalizedPattern)) {
+      return undefined;
+    }
+
+    if (!Array.isArray(targetsValue)) {
+      return undefined;
+    }
+
+    const targets: string[] = [];
+    for (const target of targetsValue) {
+      if (typeof target !== "string") {
         return undefined;
       }
-
-      for (const [pattern, targetsValue] of Object.entries(rawPaths)) {
-        const normalizedPattern = normalizePathAliasTarget(pattern);
-        if (normalizedPattern.length === 0 || normalizedPattern === ".") {
-          return undefined;
-        }
-        if (!hasAtMostOneWildcard(normalizedPattern)) {
-          return undefined;
-        }
-
-        if (!Array.isArray(targetsValue)) {
-          return undefined;
-        }
-
-        const targets: string[] = [];
-        for (const target of targetsValue) {
-          if (typeof target !== "string") {
-            return undefined;
-          }
-          const normalizedTarget = normalizePathAliasTarget(target);
-          if (!hasAtMostOneWildcard(normalizedTarget)) {
-            return undefined;
-          }
-          if (normalizedTarget.startsWith("/") || normalizedTarget === ".." || normalizedTarget.startsWith("../")) {
-            return undefined;
-          }
-          if (normalizedTarget.length === 0) {
-            return undefined;
-          }
-          targets.push(normalizedTarget);
-        }
-
-        if (targets.length === 0) {
-          return undefined;
-        }
-
-        aliases.push({ pattern: normalizedPattern, targets });
+      const normalizedTarget = normalizePathAliasTarget(target);
+      if (!hasAtMostOneWildcard(normalizedTarget)) {
+        return undefined;
       }
+      if (normalizedTarget.startsWith("/") || normalizedTarget === ".." || normalizedTarget.startsWith("../")) {
+        return undefined;
+      }
+      if (normalizedTarget.length === 0) {
+        return undefined;
+      }
+      targets.push(normalizedTarget);
     }
+
+    if (targets.length === 0) {
+      return undefined;
+    }
+
+    aliases.push({ pattern: normalizedPattern, targets });
+  }
+
+  return aliases;
+}
+
+export function parseTsConfigForModuleResolution(configText: string): LocalModulePathAliases | undefined {
+  const document = parseTsConfigDocument(configText);
+  if (!document) return undefined;
+
+  const normalizedBaseUrl = normalizeBaseUrl(
+    typeof document.compilerOptions.baseUrl === "string" ? document.compilerOptions.baseUrl : undefined,
+  );
+  const aliases = parsePathAliases(document.compilerOptions);
+  if (!aliases) return undefined;
 
   if (aliases.length === 0) {
     return undefined;
@@ -307,6 +330,93 @@ export function parseTsConfigForModuleResolution(configText: string): LocalModul
     baseUrl: normalizedBaseUrl ?? ".",
     aliases,
   };
+}
+
+function resolveLocalExtendsPath(configPath: string, extendsPath: string): string | undefined {
+  const trimmed = extendsPath.trim();
+  if (!trimmed.startsWith(".") || path.posix.isAbsolute(trimmed)) return undefined;
+
+  const withExtension = path.posix.extname(trimmed) === "" ? `${trimmed}.json` : trimmed;
+  if (!withExtension.endsWith(".json")) return undefined;
+  const resolved = normalizeFilePath(path.posix.join(path.posix.dirname(configPath), withExtension));
+  return isProjectLocalPath(resolved) ? trimLeadingCurrentDir(resolved) : undefined;
+}
+
+function resolveConfigBaseUrl(configPath: string, rawBaseUrl: string): string | undefined {
+  const normalizedBaseUrl = normalizeFilePath(rawBaseUrl.trim());
+  if (normalizedBaseUrl === "" || path.posix.isAbsolute(normalizedBaseUrl)) return undefined;
+  const resolved = trimLeadingCurrentDir(normalizeFilePath(
+    path.posix.join(path.posix.dirname(configPath), normalizedBaseUrl),
+  ));
+  return isProjectLocalPath(resolved) ? resolved : undefined;
+}
+
+/**
+ * Lists a root config and its local relative `extends` chain. Package-based
+ * configs deliberately return undefined: resolving those would make graph
+ * construction depend on node_modules and TypeScript's full resolver.
+ */
+export function getTsConfigModuleResolutionConfigPaths(
+  configPath: string,
+  loadConfig: (configPath: string) => string | undefined,
+): readonly string[] | undefined {
+  const chain: string[] = [];
+  const visiting = new Set<string>();
+
+  const visit = (candidate: string): boolean => {
+    const normalized = trimLeadingCurrentDir(normalizeFilePath(candidate));
+    if (!isProjectLocalPath(normalized) || visiting.has(normalized)) return false;
+
+    const configText = loadConfig(normalized);
+    if (configText === undefined) return false;
+    const document = parseTsConfigDocument(configText);
+    if (!document) return false;
+
+    visiting.add(normalized);
+    if (document.extendsPath !== undefined) {
+      const parentPath = resolveLocalExtendsPath(normalized, document.extendsPath);
+      if (!parentPath || !visit(parentPath)) return false;
+    }
+    visiting.delete(normalized);
+    chain.push(normalized);
+    return true;
+  };
+
+  return visit(configPath) ? chain : undefined;
+}
+
+/** Resolves aliases through a local relative `extends` chain, parent first. */
+export function resolveTsConfigForModuleResolution(
+  configPath: string,
+  loadConfig: (configPath: string) => string | undefined,
+): LocalModulePathAliases | undefined {
+  const configPaths = getTsConfigModuleResolutionConfigPaths(configPath, loadConfig);
+  if (!configPaths) return undefined;
+
+  let baseUrl = ".";
+  let aliases: LocalModulePathAlias[] | undefined;
+  for (const currentPath of configPaths) {
+    const configText = loadConfig(currentPath);
+    if (configText === undefined) return undefined;
+    const document = parseTsConfigDocument(configText);
+    if (!document) return undefined;
+
+    if (document.compilerOptions.baseUrl !== undefined) {
+      if (typeof document.compilerOptions.baseUrl !== "string") return undefined;
+      const resolvedBaseUrl = resolveConfigBaseUrl(currentPath, document.compilerOptions.baseUrl);
+      if (!resolvedBaseUrl) return undefined;
+      baseUrl = resolvedBaseUrl;
+    }
+
+    if (document.compilerOptions.paths !== undefined) {
+      const currentAliases = parsePathAliases(document.compilerOptions);
+      if (!currentAliases) return undefined;
+      aliases = currentAliases.map((alias) => ({ ...alias, baseUrl }));
+    }
+  }
+
+  if (!aliases || aliases.length === 0) return undefined;
+  return { baseUrl, aliases };
 }
 
 function isProjectLocalPath(candidatePath: string): boolean {
@@ -736,7 +846,7 @@ export class LocalModuleCallResolver {
 
       for (const targetPattern of alias.targets) {
         const target = this.replaceWildcard(targetPattern, wildcard);
-          const rawPath = normalizeFilePath(path.posix.join(this.baseUrl ?? ".", target));
+        const rawPath = normalizeFilePath(path.posix.join(alias.baseUrl ?? this.baseUrl ?? ".", target));
         if (!isProjectLocalPath(rawPath)) continue;
         for (const candidate of this.resolveModuleCandidates(trimLeadingCurrentDir(rawPath))) {
           matchedAliasTargets.add(candidate);

--- a/tests/call-graph.test.ts
+++ b/tests/call-graph.test.ts
@@ -2624,6 +2624,12 @@ main() {
       const projectDir = path.join(tempDir, "local-module-alias-project");
       fs.mkdirSync(projectDir, { recursive: true });
       copyAliasFixture(projectDir);
+      const configDir = path.join(projectDir, "config");
+      fs.mkdirSync(configDir, { recursive: true });
+      const originalAliasConfig = fs.readFileSync(path.join(projectDir, "tsconfig.json"), "utf-8")
+        .replace('"baseUrl": "."', '"baseUrl": ".."');
+      fs.writeFileSync(path.join(configDir, "base.json"), originalAliasConfig);
+      fs.writeFileSync(path.join(projectDir, "tsconfig.json"), JSON.stringify({ extends: "./config/base" }));
       const fetchSpy = mockEmbeddings();
       const indexer = new Indexer(projectDir, createIndexerConfig(), "opencode");
 
@@ -2657,9 +2663,9 @@ main() {
         expect(externalEdge.toSymbolId).toBeUndefined();
 
         const embeddingCallsBeforeConfigChange = fetchSpy.mock.calls.length;
-        fs.writeFileSync(path.join(projectDir, "tsconfig.json"), JSON.stringify({
+        fs.writeFileSync(path.join(configDir, "base.json"), JSON.stringify({
           compilerOptions: {
-            baseUrl: ".",
+            baseUrl: "..",
             paths: {
               "@core/*": ["src/missing/*"],
               "@ambiguous/*": ["src/ambiguous-a/*", "src/ambiguous-b/*"],

--- a/tests/local-module-resolution.test.ts
+++ b/tests/local-module-resolution.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 
 import {
   LocalModuleCallResolver,
+  getTsConfigModuleResolutionConfigPaths,
   parseTsConfigForModuleResolution,
+  resolveTsConfigForModuleResolution,
   type LocalModuleData,
 } from "../src/indexer/local-module-resolution.js";
 import type { CallSiteData, SymbolData } from "../src/native/index.js";
@@ -250,6 +252,55 @@ describe("LocalModuleCallResolver", () => {
         { pattern: "@foo/*", targets: ["foo/*"] },
       ],
     });
+  });
+
+  it("resolves aliases inherited through a local tsconfig extends chain", async () => {
+    const configs = new Map([
+      ["tsconfig.json", JSON.stringify({ extends: "./config/base" })],
+      ["config/base.json", JSON.stringify({
+        compilerOptions: {
+          baseUrl: "../src",
+          paths: { "@core/*": ["core/*"] },
+        },
+      })],
+    ]);
+    const aliases = resolveTsConfigForModuleResolution("tsconfig.json", (configPath) => configs.get(configPath));
+    expect(aliases).toEqual({
+      baseUrl: "src",
+      aliases: [{ pattern: "@core/*", targets: ["core/*"], baseUrl: "src" }],
+    });
+    expect(getTsConfigModuleResolutionConfigPaths("tsconfig.json", (configPath) => configs.get(configPath)))
+      .toEqual(["config/base.json", "tsconfig.json"]);
+
+    const main = [
+      'import { inheritedTarget } from "@core/target";',
+      "export function run() { return inheritedTarget(); }",
+    ].join("\n");
+    const inheritedTarget = symbol("inherited", "src/core/target.ts", "inheritedTarget");
+    const instance = new LocalModuleCallResolver({
+      filePaths: ["src/main.ts", "src/core/target.ts"],
+      loadModule: async (filePath) => ({
+        "src/main.ts": { content: main, symbols: [symbol("run", "src/main.ts", "run")] },
+        "src/core/target.ts": { content: "export function inheritedTarget() {}", symbols: [inheritedTarget] },
+      })[filePath],
+      tsConfigPathAliases: aliases,
+    });
+
+    await expect(instance.resolveCallTarget("src/main.ts", main, callSite("inheritedTarget", 2, 31)))
+      .resolves.toEqual(inheritedTarget);
+  });
+
+  it("rejects cyclic, package-based, and project-escaping tsconfig extends paths", () => {
+    const cyclicConfigs = new Map([
+      ["tsconfig.json", JSON.stringify({ extends: "./config/base" })],
+      ["config/base.json", JSON.stringify({ extends: "../tsconfig" })],
+    ]);
+    expect(resolveTsConfigForModuleResolution("tsconfig.json", (configPath) => cyclicConfigs.get(configPath)))
+      .toBeUndefined();
+    expect(resolveTsConfigForModuleResolution("tsconfig.json", () => JSON.stringify({ extends: "@company/tsconfig" })))
+      .toBeUndefined();
+    expect(resolveTsConfigForModuleResolution("tsconfig.json", () => JSON.stringify({ extends: "../outside" })))
+      .toBeUndefined();
   });
 
   it("abstains when tsconfig does not define paths", () => {


### PR DESCRIPTION
## Summary
- resolve TypeScript and JavaScript path aliases inherited through local relative `tsconfig`/`jsconfig` extends chains
- refresh unchanged JavaScript-family call edges when an inherited configuration changes
- abstain safely for package-based, cyclic, or project-escaping extends paths

## Validation
- `npm run build && npm run typecheck && npm run lint && npm run test:run`
- 105 test files, 1,637 tests passed