### PR TITLE
feat: resolve aliases from nearest project config

### DIFF
--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -114,8 +114,7 @@ import { summarizeCallGraphCoverage, type CallGraphCoverage } from "./call-graph
 import {
   isJavaScriptFamilyFilePath,
   LocalModuleCallResolver,
-  resolveTsConfigForModuleResolution,
-  type LocalModulePathAliases,
+  TsConfigPathAliasCache,
 } from "./local-module-resolution.js";
 
 export const CALL_GRAPH_LANGUAGES = new Set(["typescript", "tsx", "javascript", "jsx", "python", "go", "rust", "swift", "php", "apex", "zig", "gdscript", "matlab", "bash", "c", "cpp", "metal"]);
@@ -1209,6 +1208,7 @@ export class Indexer {
   private readerArtifactRetryAfter = new Map<IndexReadIssue["component"], number>();
   private readonly fileBatchLimits?: FileBatchLimits;
   private readonly checkpointIntervalChunks?: number;
+  private localModuleResolutionConfigHash: string | null = null;
 
   constructor(
     projectRoot: string,
@@ -1240,55 +1240,6 @@ export class Indexer {
     this.indexPath = this.getIndexPath();
     this.refreshRuntimeArtifactPaths();
     this.logger = initializeLogger(config.debug);
-  }
-
-  private loadTsConfigPathAliases(): LocalModulePathAliases | undefined {
-    const configName = this.getLocalModuleResolutionRootConfigName();
-    if (!configName) {
-      return undefined;
-    }
-
-    return resolveTsConfigForModuleResolution(configName, (configPath) => {
-      try {
-        return readFileSync(path.join(this.materializedProjectRoot, configPath), "utf-8");
-      } catch {
-        return undefined;
-      }
-    });
-  }
-
-  private getLocalModuleResolutionRootConfigName(): "tsconfig.json" | "jsconfig.json" | undefined {
-    const configNames = ["tsconfig.json", "jsconfig.json"] as const;
-    const existingConfigs = configNames.filter((name) =>
-      existsSync(path.join(this.materializedProjectRoot, name)),
-    );
-    return existingConfigs.length === 1 ? existingConfigs[0] : undefined;
-  }
-
-  private getLocalModuleResolutionConfigHash(): string {
-    const configNames = ["tsconfig.json", "jsconfig.json"];
-    const rootConfigName = this.getLocalModuleResolutionRootConfigName();
-    const configNamesToHash = new Set(configNames);
-    if (rootConfigName) {
-      resolveTsConfigForModuleResolution(rootConfigName, (configPath) => {
-        configNamesToHash.add(configPath);
-        try {
-          return readFileSync(path.join(this.materializedProjectRoot, configPath), "utf-8");
-        } catch {
-          return undefined;
-        }
-      });
-    }
-    const namesToHash = [...configNamesToHash].sort();
-    const configState = namesToHash.map((name) => {
-      const configPath = path.join(this.materializedProjectRoot, name);
-      try {
-        return [name, readFileSync(configPath, "utf-8")] as const;
-      } catch {
-        return [name, null] as const;
-      }
-    });
-    return hashContent(JSON.stringify(configState));
   }
 
   private getIndexPath(): string {
@@ -3905,10 +3856,12 @@ export class Indexer {
     this.database.setMetadata("index.embeddingModel", provider.modelInfo.model);
     this.database.setMetadata("index.embeddingDimensions", provider.modelInfo.dimensions.toString());
     this.database.setMetadata(this.getCallGraphResolutionMetadataKey(), CALL_GRAPH_RESOLUTION_VERSION);
-    this.database.setMetadata(
-      this.getLocalModuleResolutionConfigMetadataKey(),
-      this.getLocalModuleResolutionConfigHash(),
-    );
+    if (this.localModuleResolutionConfigHash !== null) {
+      this.database.setMetadata(
+        this.getLocalModuleResolutionConfigMetadataKey(),
+        this.localModuleResolutionConfigHash,
+      );
+    }
     if (this.config.scope === "global") {
       if (completeProjectEmbeddingStrategyReset) {
         this.database.setMetadata(this.getProjectEmbeddingStrategyMetadataKey(), EMBEDDING_STRATEGY_VERSION);
@@ -4348,6 +4301,22 @@ export class Indexer {
       skippedFiles: skipped.length,
     });
 
+    const localModuleResolutionCache = new TsConfigPathAliasCache((configPath) => {
+      try {
+        return readFileSync(path.join(this.materializedProjectRoot, ...configPath.split("/")), "utf-8");
+      } catch {
+        return undefined;
+      }
+    });
+    const localModuleImporterPaths = files.flatMap((file) => {
+      if (!isPathWithinRoot(file.path, this.materializedProjectRoot)) return [];
+      const relativePath = path.relative(this.materializedProjectRoot, file.path).split(path.sep).join("/");
+      return isJavaScriptFamilyFilePath(relativePath) ? [relativePath] : [];
+    });
+    this.localModuleResolutionConfigHash = hashContent(JSON.stringify(
+      localModuleResolutionCache.getConfigState(localModuleImporterPaths),
+    ));
+
     const changedFileDescriptors: ChangedFileDescriptor[] = [];
     const changedFilePathSet = new Set<string>();
     const allFileDescriptors = new Map<string, ChangedFileDescriptor>();
@@ -4358,7 +4327,7 @@ export class Indexer {
       database.getMetadata(this.getCallGraphResolutionMetadataKey()) !== CALL_GRAPH_RESOLUTION_VERSION;
     const localModuleResolutionConfigChanged =
       database.getMetadata(this.getLocalModuleResolutionConfigMetadataKey())
-      !== this.getLocalModuleResolutionConfigHash();
+      !== this.localModuleResolutionConfigHash;
     let javaScriptGraphSourcesChanged = Array.from(this.fileHashCache.keys()).some((filePath) =>
       (!scopedRoots || this.isFileInCurrentScope(filePath, scopedRoots))
       && isJavaScriptFamilyFilePath(filePath)
@@ -4516,7 +4485,6 @@ export class Indexer {
         descriptor,
       ]),
     );
-    const localModulePathAliases = this.loadTsConfigPathAliases();
     const localModuleResolver = new LocalModuleCallResolver({
       filePaths: [...sourceDescriptorsByPath.keys()],
       loadModule: async (filePath) => {
@@ -4539,7 +4507,15 @@ export class Indexer {
           symbols: parsed ? this.buildCallGraphSymbols(parsed, descriptor.hash) : [],
         };
       },
-      ...(localModulePathAliases === undefined ? {} : { tsConfigPathAliases: localModulePathAliases }),
+      pathAliasesForImporter: (filePath) => {
+        if (path.isAbsolute(filePath)) {
+          const materializedPath = this.toMaterializedFilePath(filePath);
+          if (!isPathWithinRoot(materializedPath, this.materializedProjectRoot)) return undefined;
+          const relativePath = path.relative(this.materializedProjectRoot, materializedPath).split(path.sep).join("/");
+          return localModuleResolutionCache.getPathAliasesForImporter(relativePath);
+        }
+        return localModuleResolutionCache.getPathAliasesForImporter(filePath);
+      },
     });
     let writeTransactionActive = false;
 
@@ -6265,6 +6241,7 @@ export class Indexer {
 
     if (this.currentBranch !== previousBranch) {
       this.refreshRuntimeArtifactPaths();
+      this.localModuleResolutionConfigHash = null;
       this.fileHashCache.clear();
       this.loadFileHashCache();
     }

--- a/src/indexer/local-module-resolution.ts
+++ b/src/indexer/local-module-resolution.ts
@@ -70,7 +70,10 @@ export interface LocalModuleResolverOptions {
   filePaths: readonly string[];
   loadModule: (filePath: string) => Promise<LocalModuleData | undefined>;
   tsConfigPathAliases?: LocalModulePathAliases;
+  pathAliasesForImporter?: (filePath: string) => LocalModulePathAliases | undefined;
 }
+
+export type LocalModuleResolutionConfigState = ReadonlyArray<readonly [path: string, content: string | null]>;
 
 export function isJavaScriptFamilyFilePath(filePath: string): boolean {
   return JAVASCRIPT_SOURCE_EXTENSIONS.includes(
@@ -419,6 +422,92 @@ export function resolveTsConfigForModuleResolution(
   return { baseUrl, aliases };
 }
 
+/**
+ * Resolves and caches the nearest conventional TypeScript/JavaScript config for
+ * each project-relative importer. Config lookup walks importer ancestors only,
+ * so monorepos do not require a recursive config-file scan. TypeScript config
+ * wins when both conventional config names exist in the same directory.
+ */
+export class TsConfigPathAliasCache {
+  private readonly configTextByPath = new Map<string, string | undefined>();
+  private readonly nearestConfigByDirectory = new Map<string, string | undefined>();
+  private readonly aliasesByConfigPath = new Map<string, LocalModulePathAliases | undefined>();
+
+  constructor(private readonly loadConfig: (configPath: string) => string | undefined) {}
+
+  getPathAliasesForImporter(importerFilePath: string): LocalModulePathAliases | undefined {
+    const configPath = this.findNearestConfigPath(importerFilePath);
+    if (!configPath) return undefined;
+
+    if (this.aliasesByConfigPath.has(configPath)) {
+      return this.aliasesByConfigPath.get(configPath);
+    }
+
+    const aliases = resolveTsConfigForModuleResolution(configPath, (candidate) =>
+      this.loadConfigCached(candidate)
+    );
+    this.aliasesByConfigPath.set(configPath, aliases);
+    return aliases;
+  }
+
+  getConfigState(importerFilePaths: readonly string[]): LocalModuleResolutionConfigState {
+    for (const importerFilePath of importerFilePaths) {
+      this.getPathAliasesForImporter(importerFilePath);
+    }
+
+    return [...this.configTextByPath.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([configPath, content]) => [configPath, content ?? null] as const);
+  }
+
+  private findNearestConfigPath(importerFilePath: string): string | undefined {
+    const normalizedImporter = trimLeadingCurrentDir(normalizeFilePath(importerFilePath));
+    if (!isProjectLocalPath(normalizedImporter) || normalizedImporter === ".") return undefined;
+
+    let directory = path.posix.dirname(normalizedImporter);
+    const visitedDirectories: string[] = [];
+    let nearestConfig: string | undefined;
+
+    while (true) {
+      if (this.nearestConfigByDirectory.has(directory)) {
+        nearestConfig = this.nearestConfigByDirectory.get(directory);
+        break;
+      }
+
+      visitedDirectories.push(directory);
+      for (const configName of ["tsconfig.json", "jsconfig.json"] as const) {
+        const candidate = directory === "." ? configName : path.posix.join(directory, configName);
+        if (this.loadConfigCached(candidate) !== undefined) {
+          nearestConfig = candidate;
+          break;
+        }
+      }
+      if (nearestConfig || directory === ".") break;
+
+      const parentDirectory = path.posix.dirname(directory);
+      if (parentDirectory === directory) break;
+      directory = parentDirectory;
+    }
+
+    for (const visitedDirectory of visitedDirectories) {
+      this.nearestConfigByDirectory.set(visitedDirectory, nearestConfig);
+    }
+    return nearestConfig;
+  }
+
+  private loadConfigCached(configPath: string): string | undefined {
+    const normalized = trimLeadingCurrentDir(normalizeFilePath(configPath));
+    if (!isProjectLocalPath(normalized)) return undefined;
+    if (this.configTextByPath.has(normalized)) {
+      return this.configTextByPath.get(normalized);
+    }
+
+    const configText = this.loadConfig(normalized);
+    this.configTextByPath.set(normalized, configText);
+    return configText;
+  }
+}
+
 function isProjectLocalPath(candidatePath: string): boolean {
   if (path.posix.isAbsolute(candidatePath) || candidatePath === ".." || candidatePath.startsWith("../")) {
     return false;
@@ -734,8 +823,8 @@ export class LocalModuleCallResolver {
   private readonly moduleData = new Map<string, Promise<LocalModuleData | undefined>>();
   private readonly moduleRecords = new Map<string, Promise<ModuleRecord | undefined>>();
   private readonly exportCache = new Map<string, SymbolData[]>();
-  private readonly baseUrl?: string;
-  private readonly pathAliases: ReadonlyArray<LocalModulePathAlias> = [];
+  private readonly tsConfigPathAliases?: LocalModulePathAliases;
+  private readonly pathAliasesForImporter?: LocalModuleResolverOptions["pathAliasesForImporter"];
 
   constructor(options: LocalModuleResolverOptions) {
     for (const filePath of options.filePaths) {
@@ -743,10 +832,8 @@ export class LocalModuleCallResolver {
       if (isJavaScriptFamilyFilePath(normalized)) this.modulePaths.add(normalized);
     }
     this.loadModule = options.loadModule;
-    if (options.tsConfigPathAliases) {
-      this.baseUrl = options.tsConfigPathAliases.baseUrl;
-      this.pathAliases = options.tsConfigPathAliases.aliases;
-    }
+    this.tsConfigPathAliases = options.tsConfigPathAliases;
+    this.pathAliasesForImporter = options.pathAliasesForImporter;
   }
 
   seedModule(filePath: string, data: LocalModuleData): void {
@@ -819,25 +906,31 @@ export class LocalModuleCallResolver {
       return this.resolveModuleCandidates(base);
     }
 
-    const aliasCandidates = this.resolveModuleSpecifierFromAliases(specifier);
+    const pathAliases = this.pathAliasesForImporter
+      ? this.pathAliasesForImporter(importerFilePath)
+      : this.tsConfigPathAliases;
+    const aliasCandidates = this.resolveModuleSpecifierFromAliases(specifier, pathAliases);
     if (aliasCandidates !== undefined) {
       return aliasCandidates;
     }
 
-    if (this.pathAliases.length === 0) {
+    if (!pathAliases || pathAliases.aliases.length === 0) {
       return [];
     }
 
     return [];
   }
 
-  private resolveModuleSpecifierFromAliases(specifier: string): string[] | undefined {
-    if (this.pathAliases.length === 0) return undefined;
+  private resolveModuleSpecifierFromAliases(
+    specifier: string,
+    pathAliases: LocalModulePathAliases | undefined,
+  ): string[] | undefined {
+    if (!pathAliases || pathAliases.aliases.length === 0) return undefined;
 
     const matchedAliasTargets = new Set<string>();
     let anyAliasMatched = false;
 
-    for (const alias of this.pathAliases) {
+    for (const alias of pathAliases.aliases) {
       const wildcard = this.matchPathAliasPattern(specifier, alias.pattern);
       if (wildcard === undefined) {
         continue;
@@ -846,7 +939,7 @@ export class LocalModuleCallResolver {
 
       for (const targetPattern of alias.targets) {
         const target = this.replaceWildcard(targetPattern, wildcard);
-        const rawPath = normalizeFilePath(path.posix.join(alias.baseUrl ?? this.baseUrl ?? ".", target));
+        const rawPath = normalizeFilePath(path.posix.join(alias.baseUrl ?? pathAliases.baseUrl, target));
         if (!isProjectLocalPath(rawPath)) continue;
         for (const candidate of this.resolveModuleCandidates(trimLeadingCurrentDir(rawPath))) {
           matchedAliasTargets.add(candidate);

--- a/src/watcher/file-watcher.ts
+++ b/src/watcher/file-watcher.ts
@@ -7,6 +7,7 @@ import type { CodebaseIndexConfig } from "../config/schema.js";
 import { getProjectConfigCandidatePaths } from "../config/paths.js";
 import { createIgnoreFilter, shouldIncludeFile } from "../utils/files.js";
 import { hasFilteredPathSegment, isRestrictedDirectory } from "../utils/paths.js";
+import { shouldTrackLocalModuleConfigPath } from "./local-module-config.js";
 import { NativeRecursiveWatcher } from "./native-recursive-watcher.js";
 import { FileSnapshotReconciler, type SnapshotInvalidation } from "./snapshot-reconciler.js";
 
@@ -423,6 +424,12 @@ export class FileWatcher {
 
     if (this.isProjectConfigPath(filePath)) {
       this.updateConfigPathState(filePath);
+      this.pendingChanges.set(filePath, type);
+      this.scheduleFlush();
+      return;
+    }
+
+    if (shouldTrackLocalModuleConfigPath(filePath, this.projectRoot)) {
       this.pendingChanges.set(filePath, type);
       this.scheduleFlush();
       return;

--- a/src/watcher/local-module-config.ts
+++ b/src/watcher/local-module-config.ts
@@ -1,0 +1,35 @@
+import * as path from "node:path";
+
+import { createIgnoreFilter } from "../utils/files.js";
+import { hasFilteredPathSegment, isRestrictedDirectory } from "../utils/paths.js";
+
+const LOCAL_MODULE_CONFIG_NAMES = new Set(["tsconfig.json", "jsconfig.json"]);
+type IgnoreFilter = ReturnType<typeof createIgnoreFilter>;
+
+/**
+ * Whether a config file can affect local JavaScript/TypeScript module resolution.
+ *
+ * These files are tracked by watchers only. They remain outside the normal source
+ * file include patterns and are not added to the index as source documents.
+ */
+export function shouldTrackLocalModuleConfigPath(
+  filePath: string,
+  projectRoot: string,
+  ignoreFilter: IgnoreFilter = createIgnoreFilter(projectRoot),
+): boolean {
+  const relativePath = path.relative(projectRoot, filePath);
+  if (
+    relativePath === ".."
+    || relativePath.startsWith(`..${path.sep}`)
+    || path.isAbsolute(relativePath)
+    || !LOCAL_MODULE_CONFIG_NAMES.has(path.basename(filePath).toLowerCase())
+  ) {
+    return false;
+  }
+
+  if (hasFilteredPathSegment(relativePath, path.sep) || isRestrictedDirectory(relativePath, path.sep)) {
+    return false;
+  }
+
+  return !ignoreFilter.ignores(relativePath);
+}

--- a/src/watcher/snapshot.ts
+++ b/src/watcher/snapshot.ts
@@ -7,6 +7,7 @@ import * as path from "node:path";
 
 import { createIgnoreFilter, shouldIncludeFile } from "../utils/files.js";
 import { hasFilteredPathSegment, isRestrictedDirectory } from "../utils/paths.js";
+import { shouldTrackLocalModuleConfigPath } from "./local-module-config.js";
 
 export interface FileSnapshotEntry {
   readonly size: number;
@@ -45,7 +46,10 @@ export async function buildFileSnapshotScan(
 
   const includeFile = async (filePath: string): Promise<void> => {
     const normalizedPath = path.resolve(filePath);
-    if (!shouldIncludeFile(normalizedPath, normalizedProjectRoot, includePatterns, config.exclude, ignoreFilter)) return;
+    if (
+      !shouldIncludeFile(normalizedPath, normalizedProjectRoot, includePatterns, config.exclude, ignoreFilter)
+      && !shouldTrackLocalModuleConfigPath(normalizedPath, normalizedProjectRoot, ignoreFilter)
+    ) return;
 
     const stat = await readStatIfFile(normalizedPath, unreadablePrefixes);
     if (stat) snapshot.set(normalizedPath, { size: stat.size, mtimeMs: stat.mtimeMs });
@@ -112,9 +116,11 @@ export async function buildFileSnapshotForPathScan(
 
   const includeFile = async (filePath: string): Promise<void> => {
     const normalizedPath = path.resolve(filePath);
-    if (!explicitConfigPaths.has(normalizedPath) && !shouldIncludeFile(
-      normalizedPath, normalizedProjectRoot, includePatterns, config.exclude, ignoreFilter,
-    )) return;
+    if (
+      !explicitConfigPaths.has(normalizedPath)
+      && !shouldIncludeFile(normalizedPath, normalizedProjectRoot, includePatterns, config.exclude, ignoreFilter)
+      && !shouldTrackLocalModuleConfigPath(normalizedPath, normalizedProjectRoot, ignoreFilter)
+    ) return;
     const stat = await readStatIfFile(normalizedPath, unreadablePrefixes);
     if (stat) snapshot.set(normalizedPath, { size: stat.size, mtimeMs: stat.mtimeMs });
   };

--- a/tests/call-graph.test.ts
+++ b/tests/call-graph.test.ts
@@ -2684,6 +2684,73 @@ main() {
       }
     });
 
+    it("re-resolves unchanged importers when nearest configs and their extends chain change", async () => {
+      const projectDir = path.join(tempDir, "nearest-local-module-config-project");
+      const appDir = path.join(projectDir, "packages", "app");
+      const appSourceDir = path.join(appDir, "src");
+      const configDir = path.join(projectDir, "packages", "config");
+      fs.mkdirSync(path.join(projectDir, "src", "root"), { recursive: true });
+      fs.mkdirSync(path.join(appSourceDir, "nested"), { recursive: true });
+      fs.mkdirSync(configDir, { recursive: true });
+      fs.writeFileSync(path.join(projectDir, "package.json"), JSON.stringify({ name: "nearest-config-test" }));
+      fs.writeFileSync(path.join(projectDir, "tsconfig.json"), JSON.stringify({
+        compilerOptions: {
+          baseUrl: ".",
+          paths: { "@scope/*": ["src/root/*"] },
+        },
+      }));
+      fs.writeFileSync(
+        path.join(appSourceDir, "main.ts"),
+        'import { aliasTarget } from "@scope/target";\nexport function runNearest() { aliasTarget(); }',
+      );
+      fs.writeFileSync(path.join(projectDir, "src", "root", "target.ts"), "export function aliasTarget() {}");
+      fs.writeFileSync(path.join(appSourceDir, "nested", "target.ts"), "export function aliasTarget() {}");
+      const fetchSpy = mockEmbeddings();
+      const indexer = new Indexer(projectDir, createIndexerConfig(), "opencode");
+
+      try {
+        const resolvedTargetPath = async (): Promise<string | undefined> => {
+          const symbols = await indexer.getSymbolsForBranch();
+          const caller = symbols.find((symbol) => symbol.name === "runNearest");
+          const edge = (await indexer.getCallees(caller!.id)).find(
+            (candidate) => candidate.targetName === "aliasTarget",
+          );
+          return symbols.find((symbol) => symbol.id === edge?.toSymbolId)?.filePath;
+        };
+
+        await indexer.index();
+        await expect(resolvedTargetPath()).resolves.toMatch(/src[/\\]root[/\\]target\.ts$/u);
+
+        const embeddingCallsBeforeConfigChanges = fetchSpy.mock.calls.length;
+        fs.writeFileSync(path.join(configDir, "base.json"), JSON.stringify({
+          compilerOptions: {
+            baseUrl: "../..",
+            paths: { "@scope/*": ["packages/app/src/nested/*"] },
+          },
+        }));
+        fs.writeFileSync(path.join(appDir, "tsconfig.json"), JSON.stringify({ extends: "../config/base" }));
+        await indexer.index();
+        await expect(resolvedTargetPath()).resolves.toMatch(/packages[/\\]app[/\\]src[/\\]nested[/\\]target\.ts$/u);
+
+        fs.writeFileSync(path.join(configDir, "base.json"), JSON.stringify({
+          compilerOptions: {
+            baseUrl: "../..",
+            paths: { "@scope/*": ["packages/app/src/missing/*"] },
+          },
+        }));
+        await indexer.index();
+        await expect(resolvedTargetPath()).resolves.toBeUndefined();
+
+        fs.unlinkSync(path.join(appDir, "tsconfig.json"));
+        await indexer.index();
+        await expect(resolvedTargetPath()).resolves.toMatch(/src[/\\]root[/\\]target\.ts$/u);
+        expect(fetchSpy).toHaveBeenCalledTimes(embeddingCallsBeforeConfigChanges);
+      } finally {
+        await indexer.close();
+        fetchSpy.mockRestore();
+      }
+    });
+
     it("reprocesses unchanged importers when a local re-export changes", async () => {
       const projectDir = path.join(tempDir, "local-module-refresh-project");
       fs.mkdirSync(projectDir, { recursive: true });

--- a/tests/local-module-resolution.test.ts
+++ b/tests/local-module-resolution.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   LocalModuleCallResolver,
+  TsConfigPathAliasCache,
   getTsConfigModuleResolutionConfigPaths,
   parseTsConfigForModuleResolution,
   resolveTsConfigForModuleResolution,
@@ -288,6 +289,75 @@ describe("LocalModuleCallResolver", () => {
 
     await expect(instance.resolveCallTarget("src/main.ts", main, callSite("inheritedTarget", 2, 31)))
       .resolves.toEqual(inheritedTarget);
+  });
+
+  it("uses the nearest importer config and caches config reads and extends resolution", async () => {
+    const configs = new Map([
+      ["tsconfig.json", JSON.stringify({
+        compilerOptions: { baseUrl: ".", paths: { "@scope/*": ["src/root/*"] } },
+      })],
+      ["packages/app/tsconfig.json", JSON.stringify({ extends: "../config/base" })],
+      ["packages/app/jsconfig.json", JSON.stringify({
+        compilerOptions: { baseUrl: "../..", paths: { "@scope/*": ["src/wrong/*"] } },
+      })],
+      ["packages/config/base.json", JSON.stringify({
+        compilerOptions: { baseUrl: "../..", paths: { "@scope/*": ["packages/app/src/nested/*"] } },
+      })],
+      ["packages/js-only/jsconfig.json", JSON.stringify({
+        compilerOptions: { baseUrl: "../..", paths: { "@scope/*": ["packages/js-only/src/nested/*"] } },
+      })],
+    ]);
+    const loadCounts = new Map<string, number>();
+    const aliasCache = new TsConfigPathAliasCache((configPath) => {
+      loadCounts.set(configPath, (loadCounts.get(configPath) ?? 0) + 1);
+      return configs.get(configPath);
+    });
+    const importerContent = 'import { aliasTarget } from "@scope/target";\nexport function run() { aliasTarget(); }';
+    const rootTarget = symbol("root", "src/root/target.ts", "aliasTarget");
+    const appTarget = symbol("app", "packages/app/src/nested/target.ts", "aliasTarget");
+    const jsTarget = symbol("js", "packages/js-only/src/nested/target.ts", "aliasTarget");
+    const modules: Record<string, LocalModuleData> = {
+      "src/main.ts": { content: importerContent, symbols: [symbol("root-run", "src/main.ts", "run")] },
+      "src/root/target.ts": { content: "export function aliasTarget() {}", symbols: [rootTarget] },
+      "packages/app/src/main.ts": {
+        content: importerContent,
+        symbols: [symbol("app-run", "packages/app/src/main.ts", "run")],
+      },
+      "packages/app/src/nested/target.ts": {
+        content: "export function aliasTarget() {}",
+        symbols: [appTarget],
+      },
+      "packages/js-only/src/main.js": {
+        content: importerContent,
+        symbols: [symbol("js-run", "packages/js-only/src/main.js", "run")],
+      },
+      "packages/js-only/src/nested/target.ts": {
+        content: "export function aliasTarget() {}",
+        symbols: [jsTarget],
+      },
+    };
+    const instance = new LocalModuleCallResolver({
+      filePaths: Object.keys(modules),
+      loadModule: async (filePath) => modules[filePath],
+      pathAliasesForImporter: (filePath) => aliasCache.getPathAliasesForImporter(filePath),
+    });
+    const site = callSite("aliasTarget", 2, 24);
+
+    await expect(instance.resolveCallTarget("src/main.ts", importerContent, site)).resolves.toEqual(rootTarget);
+    await expect(instance.resolveCallTarget("packages/app/src/main.ts", importerContent, site)).resolves.toEqual(appTarget);
+    await expect(instance.resolveCallTarget("packages/js-only/src/main.js", importerContent, site)).resolves.toEqual(jsTarget);
+    await expect(instance.resolveCallTarget("packages/app/src/main.ts", importerContent, site)).resolves.toEqual(appTarget);
+
+    const configState = aliasCache.getConfigState([
+      "src/main.ts",
+      "packages/app/src/main.ts",
+      "packages/js-only/src/main.js",
+    ]);
+    expect(configState).toContainEqual(["packages/app/tsconfig.json", configs.get("packages/app/tsconfig.json")]);
+    expect(configState).toContainEqual(["packages/config/base.json", configs.get("packages/config/base.json")]);
+    expect(configState).toContainEqual(["packages/js-only/tsconfig.json", null]);
+    expect(configState).not.toContainEqual(["packages/app/jsconfig.json", configs.get("packages/app/jsconfig.json")]);
+    expect([...loadCounts.values()].every((count) => count === 1)).toBe(true);
   });
 
   it("rejects cyclic, package-based, and project-escaping tsconfig extends paths", () => {

--- a/tests/watcher-native-integration.test.ts
+++ b/tests/watcher-native-integration.test.ts
@@ -18,6 +18,27 @@ async function waitForChange(
   }, { timeout: EVENT_TIMEOUT_MS, interval: 25 });
 }
 
+async function writeUntilChangeObserved(
+  write: (attempt: number) => void,
+  assertion: () => void,
+): Promise<void> {
+  const startedAt = Date.now();
+  let attempt = 0;
+  let lastError: unknown;
+
+  while (Date.now() - startedAt < EVENT_TIMEOUT_MS) {
+    write(attempt++);
+    try {
+      await vi.waitFor(assertion, { timeout: 2_500, interval: 25 });
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError;
+}
+
 describe("native FileWatcher", () => {
   let projectRoot: string;
   let watcher: FileWatcher | undefined;
@@ -73,8 +94,36 @@ describe("native FileWatcher", () => {
     });
     await watcher.waitUntilReady();
 
-    fs.mkdirSync(path.dirname(configPath), { recursive: true });
-    fs.writeFileSync(configPath, JSON.stringify({ include: ["src/**/*.ts"] }));
-    await waitForChange(changes, configPath, "add");
+    await writeUntilChangeObserved(
+      (attempt) => {
+        fs.mkdirSync(path.dirname(configPath), { recursive: true });
+        fs.writeFileSync(configPath, JSON.stringify({ include: ["src/**/*.ts"], attempt }));
+      },
+      () => expect(changes).toContainEqual({ path: configPath, type: "add" }),
+    );
+  });
+
+  it("tracks nested tsconfig changes outside source include patterns", async () => {
+    const changes: FileChange[] = [];
+    const configPath = path.join(projectRoot, "packages", "app", "tsconfig.json");
+    watcher = new FileWatcher(
+      projectRoot,
+      parseConfig({ include: ["**/*.ts"] }),
+      "codex",
+      { backend: "native" },
+    );
+
+    watcher.start(async (batch) => {
+      changes.push(...batch);
+    });
+    await watcher.waitUntilReady();
+
+    await writeUntilChangeObserved(
+      (attempt) => {
+        fs.mkdirSync(path.dirname(configPath), { recursive: true });
+        fs.writeFileSync(configPath, JSON.stringify({ compilerOptions: { baseUrl: `./src-${attempt}` } }));
+      },
+      () => expect(changes).toContainEqual({ path: configPath, type: "add" }),
+    );
   });
 });

--- a/tests/watcher-snapshot.test.ts
+++ b/tests/watcher-snapshot.test.ts
@@ -92,6 +92,29 @@ describe("watcher snapshot builder", () => {
     }
   });
 
+  it("tracks nested TypeScript and JavaScript configs while honoring ignored paths", async () => {
+    const tsConfig = path.join(projectRoot, "packages", "app", "tsconfig.json");
+    const jsConfig = path.join(projectRoot, "packages", "web", "jsconfig.json");
+    const ignoredConfig = path.join(projectRoot, "generated", "tsconfig.json");
+    fs.mkdirSync(path.dirname(tsConfig), { recursive: true });
+    fs.mkdirSync(path.dirname(jsConfig), { recursive: true });
+    fs.mkdirSync(path.dirname(ignoredConfig), { recursive: true });
+    fs.writeFileSync(tsConfig, "{}");
+    fs.writeFileSync(jsConfig, "{}");
+    fs.writeFileSync(ignoredConfig, "{}");
+    fs.writeFileSync(path.join(projectRoot, ".gitignore"), "generated/\n");
+
+    const snapshot = await buildFileSnapshot(
+      projectRoot,
+      { include: ["**/*.ts"], additionalInclude: [], exclude: [] },
+      [],
+    );
+
+    expect(snapshot.has(tsConfig)).toBe(true);
+    expect(snapshot.has(jsConfig)).toBe(true);
+    expect(snapshot.has(ignoredConfig)).toBe(false);
+  });
+
   it("limits traversal depth using config.indexing.maxDepth", async () => {
     const rootFile = path.join(projectRoot, "root.ts");
     const nestedLevelOne = path.join(projectRoot, "level-one", "nested.ts");

--- a/tests/watcher.test.ts
+++ b/tests/watcher.test.ts
@@ -185,6 +185,31 @@ describe("FileWatcher", () => {
       expect(changes.some((c) => c.path.endsWith("root.ts"))).toBe(true);
     });
 
+    it("watches nested jsconfig changes outside source include patterns with Chokidar", async () => {
+      const changes: FileChange[] = [];
+      const configPath = path.join(tempDir, "packages", "app", "jsconfig.json");
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.writeFileSync(configPath, JSON.stringify({ compilerOptions: { baseUrl: "./src" } }));
+      watcher = new FileWatcher(
+        tempDir,
+        createTestConfig({ include: ["**/*.ts"] }),
+        "codex",
+        { backend: "chokidar" },
+      );
+
+      watcher.start(async (batch) => {
+        changes.push(...batch);
+      });
+      await watcher.waitUntilReady();
+
+      await writeUntilObserved(
+        (attempt) => {
+          fs.writeFileSync(configPath, JSON.stringify({ compilerOptions: { baseUrl: `./src-${attempt}` } }));
+        },
+        () => expect(changes).toContainEqual({ path: configPath, type: "change" }),
+      );
+    });
+
     it("should watch codex-native config without watching codex index files", async () => {
       const changes: FileChange[] = [];
       fs.mkdirSync(path.join(tempDir, ".codebase-index", "index"), { recursive: true });
@@ -308,6 +333,30 @@ describe("FileWatcher", () => {
 
       await combinedWatcher.stop();
       resolveIndex?.();
+    });
+
+    it("reindexes when an existing nested tsconfig changes outside source include patterns", async () => {
+      const configPath = path.join(tempDir, "packages", "app", "tsconfig.json");
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.writeFileSync(configPath, JSON.stringify({ compilerOptions: { baseUrl: "./src" } }));
+      const indexer = { index: vi.fn().mockResolvedValue(undefined) };
+      const combinedWatcher = createWatcherWithIndexer(
+        () => indexer,
+        tempDir,
+        createTestConfig({ include: ["**/*.ts"] }),
+        "codex",
+      );
+
+      await combinedWatcher.whenReady();
+      await writeUntilObserved(
+        (attempt) => fs.writeFileSync(
+          configPath,
+          JSON.stringify({ compilerOptions: { baseUrl: `./src-${attempt}` } }),
+        ),
+        () => expect(indexer.index).toHaveBeenCalledOnce(),
+      );
+
+      await combinedWatcher.stop();
     });
 
     it("coalesces file-triggered reindex requests while one is running", async () => {


### PR DESCRIPTION
## Summary
- select the nearest project-local tsconfig.json or jsconfig.json for each JavaScript-family importer
- cache local config and extends-chain reads while fingerprinting present and missing candidates for invalidation
- re-resolve unchanged importers when nested configs or their extends chains are added, changed, or removed

## Validation
- `npm run build && npm run typecheck && npm run lint && npm run test:run`
- 105 test files, 1,639 tests passed