### PR TITLE
fix: watch local tsconfig extends dependencies

### DIFF
--- a/src/indexer/local-module-resolution.ts
+++ b/src/indexer/local-module-resolution.ts
@@ -388,6 +388,38 @@ export function getTsConfigModuleResolutionConfigPaths(
   return visit(configPath) ? chain : undefined;
 }
 
+/**
+ * Lists project-local config files that can affect a root config, including a
+ * missing or malformed local `extends` target. Unlike the strict resolver,
+ * this is suitable for watch registration: a later create or repair must be
+ * observed so module resolution can be recomputed.
+ */
+export function getTsConfigModuleResolutionConfigDependencyPaths(
+  configPath: string,
+  loadConfig: (configPath: string) => string | undefined,
+): readonly string[] {
+  const dependencies: string[] = [];
+  const visiting = new Set<string>();
+
+  const visit = (candidate: string): void => {
+    const normalized = trimLeadingCurrentDir(normalizeFilePath(candidate));
+    if (!isProjectLocalPath(normalized) || visiting.has(normalized)) return;
+
+    visiting.add(normalized);
+    dependencies.push(normalized);
+    const configText = loadConfig(normalized);
+    const document = configText === undefined ? undefined : parseTsConfigDocument(configText);
+    if (document?.extendsPath !== undefined) {
+      const parentPath = resolveLocalExtendsPath(normalized, document.extendsPath);
+      if (parentPath) visit(parentPath);
+    }
+    visiting.delete(normalized);
+  };
+
+  visit(configPath);
+  return dependencies;
+}
+
 /** Resolves aliases through a local relative `extends` chain, parent first. */
 export function resolveTsConfigForModuleResolution(
   configPath: string,

--- a/src/watcher/file-watcher.ts
+++ b/src/watcher/file-watcher.ts
@@ -7,7 +7,7 @@ import type { CodebaseIndexConfig } from "../config/schema.js";
 import { getProjectConfigCandidatePaths } from "../config/paths.js";
 import { createIgnoreFilter, shouldIncludeFile } from "../utils/files.js";
 import { hasFilteredPathSegment, isRestrictedDirectory } from "../utils/paths.js";
-import { shouldTrackLocalModuleConfigPath } from "./local-module-config.js";
+import { LocalModuleConfigTracker, shouldTrackLocalModuleConfigPath } from "./local-module-config.js";
 import { NativeRecursiveWatcher } from "./native-recursive-watcher.js";
 import { FileSnapshotReconciler, type SnapshotInvalidation } from "./snapshot-reconciler.js";
 
@@ -55,6 +55,7 @@ export class FileWatcher {
   private nativeReconcileTimer: NodeJS.Timeout | null = null;
   private nativeInvalidatedPaths: Map<string | null, boolean> = new Map();
   private configPathStates: Map<string, ConfigPathState> = new Map();
+  private localModuleConfigTracker: LocalModuleConfigTracker;
 
   constructor(projectRoot: string, config: CodebaseIndexConfig, host: HostMode, options: FileWatcherOptions = {}) {
     this.projectRoot = projectRoot;
@@ -64,6 +65,7 @@ export class FileWatcher {
     this.projectConfigPaths = options.configPath
       ? [options.configPath]
       : getProjectConfigCandidatePaths(projectRoot, host);
+    this.localModuleConfigTracker = new LocalModuleConfigTracker(projectRoot, config);
   }
 
   start(handler: ChangeHandler): void {
@@ -72,6 +74,7 @@ export class FileWatcher {
     }
 
     this.onChanges = handler;
+    this.localModuleConfigTracker.refresh();
     this.pollingFallbackAttempted = false;
     this.resetReady();
     if (this.shouldUseNativeWatcher()) {
@@ -125,6 +128,7 @@ export class FileWatcher {
     reportsStartupReady = true,
   ): void {
     let reportedStartupReady = false;
+    this.localModuleConfigTracker.refresh();
     this.configPathStates = this.getConfigPathStates();
     const ignoreFilter = createIgnoreFilter(this.projectRoot);
     const resolvedWatchTargets = watchTargets ?? this.getFullChokidarWatchTargets();
@@ -283,7 +287,11 @@ export class FileWatcher {
 
   private async createNativeWatcher(): Promise<void> {
     const generation = ++this.nativeSetupGeneration;
-    const reconciler = new FileSnapshotReconciler(this.projectRoot, this.config, this.projectConfigPaths);
+    const reconciler = new FileSnapshotReconciler(
+      this.projectRoot,
+      this.config,
+      () => [...this.projectConfigPaths, ...this.localModuleConfigTracker.getPaths()],
+    );
     const watcher = new NativeRecursiveWatcher(
       this.projectRoot,
       (filePath) => this.scheduleNativeReconciliation(generation, filePath),
@@ -336,6 +344,17 @@ export class FileWatcher {
 
   private scheduleNativeReconciliation(generation: number, filePath: string | null): void {
     if (!this.isCurrentNativeSetup(generation)) return;
+
+    if (
+      filePath === null
+      || filePath === path.join(this.projectRoot, ".gitignore")
+      || (filePath !== null && (
+        shouldTrackLocalModuleConfigPath(filePath, this.projectRoot)
+        || this.localModuleConfigTracker.has(filePath)
+      ))
+    ) {
+      this.localModuleConfigTracker.refresh();
+    }
 
     const requiresFullReconciliation = filePath === path.join(this.projectRoot, ".gitignore");
     const invalidatedPath = requiresFullReconciliation ? null : filePath;
@@ -429,7 +448,11 @@ export class FileWatcher {
       return;
     }
 
-    if (shouldTrackLocalModuleConfigPath(filePath, this.projectRoot)) {
+    if (
+      shouldTrackLocalModuleConfigPath(filePath, this.projectRoot)
+      || this.localModuleConfigTracker.has(filePath)
+    ) {
+      this.localModuleConfigTracker.refresh();
       this.pendingChanges.set(filePath, type);
       this.scheduleFlush();
       return;

--- a/src/watcher/local-module-config.ts
+++ b/src/watcher/local-module-config.ts
@@ -1,10 +1,16 @@
+import type { Dirent } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import * as path from "node:path";
 
+import { getTsConfigModuleResolutionConfigDependencyPaths } from "../indexer/local-module-resolution.js";
 import { createIgnoreFilter } from "../utils/files.js";
 import { hasFilteredPathSegment, isRestrictedDirectory } from "../utils/paths.js";
 
 const LOCAL_MODULE_CONFIG_NAMES = new Set(["tsconfig.json", "jsconfig.json"]);
 type IgnoreFilter = ReturnType<typeof createIgnoreFilter>;
+export interface LocalModuleConfigTrackerOptions {
+  indexing?: { maxDepth?: number };
+}
 
 /**
  * Whether a config file can affect local JavaScript/TypeScript module resolution.
@@ -17,12 +23,23 @@ export function shouldTrackLocalModuleConfigPath(
   projectRoot: string,
   ignoreFilter: IgnoreFilter = createIgnoreFilter(projectRoot),
 ): boolean {
+  return (
+    LOCAL_MODULE_CONFIG_NAMES.has(path.basename(filePath).toLowerCase())
+    && shouldTrackProjectLocalJsonConfigPath(filePath, projectRoot, ignoreFilter)
+  );
+}
+
+function shouldTrackProjectLocalJsonConfigPath(
+  filePath: string,
+  projectRoot: string,
+  ignoreFilter: IgnoreFilter,
+): boolean {
   const relativePath = path.relative(projectRoot, filePath);
   if (
     relativePath === ".."
     || relativePath.startsWith(`..${path.sep}`)
     || path.isAbsolute(relativePath)
-    || !LOCAL_MODULE_CONFIG_NAMES.has(path.basename(filePath).toLowerCase())
+    || path.extname(filePath).toLowerCase() !== ".json"
   ) {
     return false;
   }
@@ -32,4 +49,73 @@ export function shouldTrackLocalModuleConfigPath(
   }
 
   return !ignoreFilter.ignores(relativePath);
+}
+
+/** Tracks conventional configs and their safe local relative `extends` dependencies. */
+export class LocalModuleConfigTracker {
+  private trackedPaths = new Set<string>();
+
+  constructor(
+    private readonly projectRoot: string,
+    private readonly options: LocalModuleConfigTrackerOptions,
+  ) {}
+
+  refresh(): void {
+    const root = path.resolve(this.projectRoot);
+    const ignoreFilter = createIgnoreFilter(root);
+    const roots: string[] = [];
+    const maxDepth = this.options.indexing?.maxDepth ?? -1;
+
+    const walk = (directoryPath: string, depth: number): void => {
+      let entries: Dirent[];
+      try {
+        entries = readdirSync(directoryPath, { withFileTypes: true });
+      } catch {
+        return;
+      }
+
+      for (const entry of entries) {
+        const filePath = path.join(directoryPath, entry.name);
+        const relativePath = path.relative(root, filePath);
+        if (entry.isDirectory()) {
+          if (hasFilteredPathSegment(relativePath, path.sep) || isRestrictedDirectory(relativePath, path.sep)) continue;
+          if (ignoreFilter.ignores(relativePath)) continue;
+          if (maxDepth === -1 || depth < maxDepth) walk(filePath, depth + 1);
+          continue;
+        }
+
+        if (entry.isFile() && shouldTrackLocalModuleConfigPath(filePath, root, ignoreFilter)) {
+          roots.push(relativePath.split(path.sep).join("/"));
+        }
+      }
+    };
+
+    walk(root, 0);
+    const nextPaths = new Set<string>();
+    const readConfig = (relativePath: string): string | undefined => {
+      try {
+        return readFileSync(path.join(root, ...relativePath.split("/")), "utf-8");
+      } catch {
+        return undefined;
+      }
+    };
+
+    for (const rootConfig of roots) {
+      for (const dependency of getTsConfigModuleResolutionConfigDependencyPaths(rootConfig, readConfig)) {
+        const dependencyPath = path.resolve(root, ...dependency.split("/"));
+        if (shouldTrackProjectLocalJsonConfigPath(dependencyPath, root, ignoreFilter)) {
+          nextPaths.add(dependencyPath);
+        }
+      }
+    }
+    this.trackedPaths = nextPaths;
+  }
+
+  has(filePath: string): boolean {
+    return this.trackedPaths.has(path.resolve(filePath));
+  }
+
+  getPaths(): readonly string[] {
+    return [...this.trackedPaths];
+  }
 }

--- a/src/watcher/snapshot-reconciler.ts
+++ b/src/watcher/snapshot-reconciler.ts
@@ -17,6 +17,7 @@ export type SnapshotInvalidation = string | null | {
   path: string | null;
   forceChange?: boolean;
 };
+type ConfigPathsProvider = readonly string[] | (() => readonly string[]);
 
 export class FileSnapshotReconciler {
   private snapshot: FileSnapshotMap | null = null;
@@ -25,11 +26,11 @@ export class FileSnapshotReconciler {
   constructor(
     private readonly projectRoot: string,
     private readonly config: SnapshotFilterConfig,
-    private readonly configPaths: string[],
+    private readonly configPaths: ConfigPathsProvider,
   ) {}
 
   async initialize(): Promise<void> {
-    this.snapshot = (await buildFileSnapshotScan(this.projectRoot, this.config, this.configPaths)).entries;
+    this.snapshot = (await buildFileSnapshotScan(this.projectRoot, this.config, this.getConfigPaths())).entries;
   }
 
   async reconcile(invalidations: readonly SnapshotInvalidation[] = []): Promise<FileChange[]> {
@@ -50,7 +51,7 @@ export class FileSnapshotReconciler {
         .map((invalidation) => invalidation.path)
         .filter((filePath): filePath is string => filePath !== null);
       const scan = scopedPaths.length === 0 || scopedPaths.length !== normalizedInvalidations.length
-        ? await buildFileSnapshotScan(this.projectRoot, this.config, this.configPaths)
+        ? await buildFileSnapshotScan(this.projectRoot, this.config, this.getConfigPaths())
         : await this.reconcilePaths(previousSnapshot, scopedPaths);
       const nextSnapshot = completeFileSnapshot(previousSnapshot, scan);
       const forcedChanges = new Set(normalizedInvalidations
@@ -79,7 +80,7 @@ export class FileSnapshotReconciler {
         if (isWithinPath(scope, previousPath)) entries.delete(previousPath);
       }
 
-      const scopedScan = await buildFileSnapshotForPathScan(this.projectRoot, this.config, this.configPaths, scope);
+      const scopedScan = await buildFileSnapshotForPathScan(this.projectRoot, this.config, this.getConfigPaths(), scope);
       for (const [filePath, entry] of scopedScan.entries) entries.set(filePath, entry);
       for (const unreadablePrefix of scopedScan.unreadablePrefixes) unreadablePrefixes.add(unreadablePrefix);
     }
@@ -92,5 +93,9 @@ export class FileSnapshotReconciler {
     return uniquePaths.filter((candidate, index) => !uniquePaths.slice(0, index).some(
       (ancestor) => isWithinPath(ancestor, candidate),
     ));
+  }
+
+  private getConfigPaths(): readonly string[] {
+    return typeof this.configPaths === "function" ? this.configPaths() : this.configPaths;
   }
 }

--- a/src/watcher/snapshot.ts
+++ b/src/watcher/snapshot.ts
@@ -27,7 +27,7 @@ export interface FileSnapshotScan {
 export async function buildFileSnapshot(
   projectRoot: string,
   config: SnapshotFilterConfig,
-  configPaths: string[] = [],
+  configPaths: readonly string[] = [],
 ): Promise<FileSnapshotMap> {
   return (await buildFileSnapshotScan(projectRoot, config, configPaths)).entries;
 }
@@ -35,7 +35,7 @@ export async function buildFileSnapshot(
 export async function buildFileSnapshotScan(
   projectRoot: string,
   config: SnapshotFilterConfig,
-  configPaths: string[] = [],
+  configPaths: readonly string[] = [],
 ): Promise<FileSnapshotScan> {
   const normalizedProjectRoot = path.resolve(projectRoot);
   const ignoreFilter = createIgnoreFilter(normalizedProjectRoot);
@@ -89,7 +89,7 @@ export async function buildFileSnapshotScan(
 export async function buildFileSnapshotForPath(
   projectRoot: string,
   config: SnapshotFilterConfig,
-  configPaths: string[],
+  configPaths: readonly string[],
   targetPath: string,
 ): Promise<FileSnapshotMap> {
   return (await buildFileSnapshotForPathScan(projectRoot, config, configPaths, targetPath)).entries;
@@ -98,7 +98,7 @@ export async function buildFileSnapshotForPath(
 export async function buildFileSnapshotForPathScan(
   projectRoot: string,
   config: SnapshotFilterConfig,
-  configPaths: string[],
+  configPaths: readonly string[],
   targetPath: string,
 ): Promise<FileSnapshotScan> {
   const normalizedProjectRoot = path.resolve(projectRoot);
@@ -170,7 +170,7 @@ export function completeFileSnapshot(previous: FileSnapshotMap, scan: FileSnapsh
 async function includeExplicitConfigPaths(
   snapshot: Map<string, FileSnapshotEntry>,
   unreadablePrefixes: Set<string>,
-  configPaths: string[],
+  configPaths: readonly string[],
 ): Promise<void> {
   for (const configPath of [...new Set(configPaths.map((value) => path.resolve(value)))]) {
     if (snapshot.has(configPath)) continue;
@@ -182,7 +182,7 @@ async function includeExplicitConfigPaths(
 async function includeExplicitConfigPathsInPath(
   snapshot: Map<string, FileSnapshotEntry>,
   unreadablePrefixes: Set<string>,
-  configPaths: string[],
+  configPaths: readonly string[],
   targetPath: string,
 ): Promise<void> {
   await includeExplicitConfigPaths(

--- a/tests/local-module-resolution.test.ts
+++ b/tests/local-module-resolution.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   LocalModuleCallResolver,
   TsConfigPathAliasCache,
+  getTsConfigModuleResolutionConfigDependencyPaths,
   getTsConfigModuleResolutionConfigPaths,
   parseTsConfigForModuleResolution,
   resolveTsConfigForModuleResolution,
@@ -289,6 +290,17 @@ describe("LocalModuleCallResolver", () => {
 
     await expect(instance.resolveCallTarget("src/main.ts", main, callSite("inheritedTarget", 2, 31)))
       .resolves.toEqual(inheritedTarget);
+  });
+
+  it("retains missing local extends targets as watcher dependencies", () => {
+    const configs = new Map([
+      ["packages/app/tsconfig.json", JSON.stringify({ extends: "../config/base" })],
+    ]);
+
+    expect(getTsConfigModuleResolutionConfigDependencyPaths(
+      "packages/app/tsconfig.json",
+      (configPath) => configs.get(configPath),
+    )).toEqual(["packages/app/tsconfig.json", "packages/config/base.json"]);
   });
 
   it("uses the nearest importer config and caches config reads and extends resolution", async () => {

--- a/tests/watcher-native-integration.test.ts
+++ b/tests/watcher-native-integration.test.ts
@@ -126,4 +126,35 @@ describe("native FileWatcher", () => {
       () => expect(changes).toContainEqual({ path: configPath, type: "add" }),
     );
   });
+
+  it("tracks the lifecycle of a missing arbitrary local extends target", async () => {
+    const changes: FileChange[] = [];
+    const appConfig = path.join(projectRoot, "packages", "app", "tsconfig.json");
+    const baseConfig = path.join(projectRoot, "packages", "config", "base.json");
+    fs.mkdirSync(path.dirname(appConfig), { recursive: true });
+    fs.writeFileSync(appConfig, JSON.stringify({ extends: "../config/base" }));
+    watcher = new FileWatcher(
+      projectRoot,
+      parseConfig({ include: ["**/*.ts"] }),
+      "codex",
+      { backend: "native" },
+    );
+
+    watcher.start(async (batch) => {
+      changes.push(...batch);
+    });
+    await watcher.waitUntilReady();
+
+    await writeUntilChangeObserved(
+      (attempt) => {
+        fs.mkdirSync(path.dirname(baseConfig), { recursive: true });
+        fs.writeFileSync(baseConfig, JSON.stringify({ compilerOptions: { baseUrl: `./src-${attempt}` } }));
+      },
+      () => expect(changes).toContainEqual({ path: baseConfig, type: "add" }),
+    );
+
+    changes.length = 0;
+    fs.rmSync(baseConfig);
+    await waitForChange(changes, baseConfig, "unlink");
+  });
 });

--- a/tests/watcher-snapshot.test.ts
+++ b/tests/watcher-snapshot.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 import { buildFileSnapshot } from "../src/watcher/snapshot.js";
+import { LocalModuleConfigTracker } from "../src/watcher/local-module-config.js";
 
 describe("watcher snapshot builder", () => {
   let projectRoot: string;
@@ -113,6 +114,39 @@ describe("watcher snapshot builder", () => {
     expect(snapshot.has(tsConfig)).toBe(true);
     expect(snapshot.has(jsConfig)).toBe(true);
     expect(snapshot.has(ignoredConfig)).toBe(false);
+  });
+
+  it("tracks existing and missing local extends targets with arbitrary JSON names", () => {
+    const appConfig = path.join(projectRoot, "packages", "app", "tsconfig.json");
+    const baseConfig = path.join(projectRoot, "packages", "config", "base.json");
+    const missingConfig = path.join(projectRoot, "packages", "config", "missing.json");
+    fs.mkdirSync(path.dirname(appConfig), { recursive: true });
+    fs.mkdirSync(path.dirname(baseConfig), { recursive: true });
+    fs.writeFileSync(appConfig, JSON.stringify({ extends: "../config/base" }));
+    fs.writeFileSync(baseConfig, JSON.stringify({ extends: "./missing" }));
+
+    const tracker = new LocalModuleConfigTracker(projectRoot, {});
+    tracker.refresh();
+
+    expect(tracker.has(appConfig)).toBe(true);
+    expect(tracker.has(baseConfig)).toBe(true);
+    expect(tracker.has(missingConfig)).toBe(true);
+  });
+
+  it("does not track a local extends target hidden by gitignore", () => {
+    const appConfig = path.join(projectRoot, "packages", "app", "tsconfig.json");
+    const ignoredConfig = path.join(projectRoot, "generated", "base.json");
+    fs.mkdirSync(path.dirname(appConfig), { recursive: true });
+    fs.mkdirSync(path.dirname(ignoredConfig), { recursive: true });
+    fs.writeFileSync(path.join(projectRoot, ".gitignore"), "generated/\n");
+    fs.writeFileSync(appConfig, JSON.stringify({ extends: "../../generated/base" }));
+    fs.writeFileSync(ignoredConfig, "{}");
+
+    const tracker = new LocalModuleConfigTracker(projectRoot, {});
+    tracker.refresh();
+
+    expect(tracker.has(appConfig)).toBe(true);
+    expect(tracker.has(ignoredConfig)).toBe(false);
   });
 
   it("limits traversal depth using config.indexing.maxDepth", async () => {

--- a/tests/watcher.test.ts
+++ b/tests/watcher.test.ts
@@ -210,6 +210,35 @@ describe("FileWatcher", () => {
       );
     });
 
+    it("watches an arbitrary local extends target with Chokidar", async () => {
+      const appConfig = path.join(tempDir, "packages", "app", "tsconfig.json");
+      const baseConfig = path.join(tempDir, "packages", "config", "base.json");
+      fs.mkdirSync(path.dirname(appConfig), { recursive: true });
+      fs.mkdirSync(path.dirname(baseConfig), { recursive: true });
+      fs.writeFileSync(appConfig, JSON.stringify({ extends: "../config/base" }));
+      fs.writeFileSync(baseConfig, JSON.stringify({ compilerOptions: { baseUrl: "./src" } }));
+      const changes: FileChange[] = [];
+      watcher = new FileWatcher(
+        tempDir,
+        createTestConfig({ include: ["**/*.ts"] }),
+        "codex",
+        { backend: "chokidar" },
+      );
+
+      watcher.start(async (batch) => {
+        changes.push(...batch);
+      });
+      await watcher.waitUntilReady();
+
+      await writeUntilObserved(
+        (attempt) => fs.writeFileSync(
+          baseConfig,
+          JSON.stringify({ compilerOptions: { baseUrl: `./src-${attempt}` } }),
+        ),
+        () => expect(changes).toContainEqual({ path: baseConfig, type: "change" }),
+      );
+    });
+
     it("should watch codex-native config without watching codex index files", async () => {
       const changes: FileChange[] = [];
       fs.mkdirSync(path.join(tempDir, ".codebase-index", "index"), { recursive: true });
@@ -351,6 +380,33 @@ describe("FileWatcher", () => {
       await writeUntilObserved(
         (attempt) => fs.writeFileSync(
           configPath,
+          JSON.stringify({ compilerOptions: { baseUrl: `./src-${attempt}` } }),
+        ),
+        () => expect(indexer.index).toHaveBeenCalledOnce(),
+      );
+
+      await combinedWatcher.stop();
+    });
+
+    it("reindexes when an inherited local extends config changes", async () => {
+      const appConfig = path.join(tempDir, "packages", "app", "tsconfig.json");
+      const baseConfig = path.join(tempDir, "packages", "config", "base.json");
+      fs.mkdirSync(path.dirname(appConfig), { recursive: true });
+      fs.mkdirSync(path.dirname(baseConfig), { recursive: true });
+      fs.writeFileSync(appConfig, JSON.stringify({ extends: "../config/base" }));
+      fs.writeFileSync(baseConfig, JSON.stringify({ compilerOptions: { baseUrl: "./src" } }));
+      const indexer = { index: vi.fn().mockResolvedValue(undefined) };
+      const combinedWatcher = createWatcherWithIndexer(
+        () => indexer,
+        tempDir,
+        createTestConfig({ include: ["**/*.ts"] }),
+        "codex",
+      );
+
+      await combinedWatcher.whenReady();
+      await writeUntilObserved(
+        (attempt) => fs.writeFileSync(
+          baseConfig,
           JSON.stringify({ compilerOptions: { baseUrl: `./src-${attempt}` } }),
         ),
         () => expect(indexer.index).toHaveBeenCalledOnce(),


### PR DESCRIPTION
## Summary\n- track safe project-local JSON configs reached through relative tsconfig/jsconfig extends chains\n- trigger native and Chokidar reindexing for inherited config updates, creates, and deletes\n- retain safeguards for ignored, hidden, restricted, and external paths\n\n## Validation\n- npm run build && npm run typecheck && npm run lint && npm run test:run\n- 105 files, 1649 tests passed