### PR TITLE
feat: resolve local workspace package imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Source-backed architecture context**: Added the portable `architecture_context` tool across OpenCode, MCP, and Pi. It produces deterministic, token-bounded repository maps with source-derived responsibility excerpts, cited community and boundary evidence, strict query and directory focus, graph-sparse source-directory fallback, uncertainty notes, precise follow-up tool calls, and optional Git-backed recent activity. Architecture planning evaluation now measures graded evidence relevance and actual response token cost.
 - **Local JavaScript module graph resolution**: TypeScript and JavaScript call edges now resolve through local relative ES module imports, aliases, default and namespace imports, named re-exports, and `export *` chains. Resolution remains conservative for ambiguous or missing modules and exports, existing indexes migrate without re-embedding unchanged chunks, and graph coverage diagnostics report branch-aware resolved and unresolved totals by language.
+- **Workspace package call graph resolution**: TypeScript and JavaScript call edges now follow project-local package imports declared by workspace `package.json` manifests, including exact source-facing `exports` entries and safe package-relative subpaths. External dependencies, unsafe metadata, and duplicate package names remain unresolved rather than being guessed, and manifest changes trigger a graph refresh.
 
 ## [0.25.1] - 2026-08-23
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -147,7 +147,7 @@ Returns recent in-memory debug logs when debug logging is enabled.
 
 ### `call_graph`
 
-Finds direct callers or callees for a function or method. File-path disambiguation is available when names are duplicated. For TypeScript and JavaScript, indexed call targets can follow local relative ES module imports and re-export chains, including aliases. Package imports, tsconfig path aliases, CommonJS-only exports, missing modules, and ambiguous module or star-export targets remain unresolved rather than being guessed.
+Finds direct callers or callees for a function or method. File-path disambiguation is available when names are duplicated. For TypeScript and JavaScript, indexed call targets can follow local relative ES module imports, re-export chains, `tsconfig`/`jsconfig` path aliases, and project-local workspace package imports declared by `package.json` entry points. External packages, CommonJS-only exports, missing modules, malformed or unsafe package metadata, and ambiguous module, package, or star-export targets remain unresolved rather than being guessed.
 
 ### `call_graph_path`
 

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -112,6 +112,8 @@ import { iterateOrderedFileBatches, type FileBatchLimits } from "./file-batches.
 import { canonicalizePathForComparison } from "../utils/canonical-path.js";
 import { summarizeCallGraphCoverage, type CallGraphCoverage } from "./call-graph-coverage.js";
 import {
+  getLocalWorkspacePackageManifestPaths,
+  getLocalWorkspacePackages,
   isJavaScriptFamilyFilePath,
   LocalModuleCallResolver,
   TsConfigPathAliasCache,
@@ -185,7 +187,7 @@ function resolveSameCommunityCandidateIds(
     .map((candidate) => candidate.id));
 }
 // Existing indexes without this metadata are the implicit version 1.
-const CALL_GRAPH_RESOLUTION_VERSION = "5";
+const CALL_GRAPH_RESOLUTION_VERSION = "6";
 const PHP_FUNCTION_SYMBOL_CHUNK_TYPES = new Set([
   "function_declaration",
   "function",
@@ -4301,21 +4303,31 @@ export class Indexer {
       skippedFiles: skipped.length,
     });
 
-    const localModuleResolutionCache = new TsConfigPathAliasCache((configPath) => {
+    const localModuleResolutionFileText = (configPath: string): string | undefined => {
       try {
         return readFileSync(path.join(this.materializedProjectRoot, ...configPath.split("/")), "utf-8");
       } catch {
         return undefined;
       }
-    });
+    };
+    const localModuleResolutionCache = new TsConfigPathAliasCache(localModuleResolutionFileText);
     const localModuleImporterPaths = files.flatMap((file) => {
       if (!isPathWithinRoot(file.path, this.materializedProjectRoot)) return [];
       const relativePath = path.relative(this.materializedProjectRoot, file.path).split(path.sep).join("/");
       return isJavaScriptFamilyFilePath(relativePath) ? [relativePath] : [];
     });
-    this.localModuleResolutionConfigHash = hashContent(JSON.stringify(
-      localModuleResolutionCache.getConfigState(localModuleImporterPaths),
-    ));
+    const localWorkspacePackageManifestPaths = getLocalWorkspacePackageManifestPaths(localModuleImporterPaths);
+    const localWorkspacePackages = getLocalWorkspacePackages(
+      localModuleImporterPaths,
+      localModuleResolutionFileText,
+    );
+    this.localModuleResolutionConfigHash = hashContent(JSON.stringify({
+      tsconfig: localModuleResolutionCache.getConfigState(localModuleImporterPaths),
+      packageManifests: localWorkspacePackageManifestPaths.map((manifestPath) => [
+        manifestPath,
+        localModuleResolutionFileText(manifestPath) ?? null,
+      ]),
+    }));
 
     const changedFileDescriptors: ChangedFileDescriptor[] = [];
     const changedFilePathSet = new Set<string>();
@@ -4516,6 +4528,7 @@ export class Indexer {
         }
         return localModuleResolutionCache.getPathAliasesForImporter(filePath);
       },
+      workspacePackages: localWorkspacePackages,
     });
     let writeTransactionActive = false;
 

--- a/src/indexer/local-module-resolution.ts
+++ b/src/indexer/local-module-resolution.ts
@@ -61,6 +61,14 @@ export interface LocalModulePathAliases {
   aliases: readonly LocalModulePathAlias[];
 }
 
+/** A project-local package manifest whose source entry points may form graph edges. */
+export interface LocalWorkspacePackage {
+  name: string;
+  rootPath: string;
+  entryPoints: ReadonlyMap<string, readonly string[]>;
+  restrictsSubpaths: boolean;
+}
+
 export interface LocalModuleData {
   content: string;
   symbols: readonly SymbolData[];
@@ -71,6 +79,7 @@ export interface LocalModuleResolverOptions {
   loadModule: (filePath: string) => Promise<LocalModuleData | undefined>;
   tsConfigPathAliases?: LocalModulePathAliases;
   pathAliasesForImporter?: (filePath: string) => LocalModulePathAliases | undefined;
+  workspacePackages?: readonly LocalWorkspacePackage[];
 }
 
 export type LocalModuleResolutionConfigState = ReadonlyArray<readonly [path: string, content: string | null]>;
@@ -554,6 +563,126 @@ function trimLeadingCurrentDir(candidatePath: string): string {
   return candidatePath.startsWith("./") ? candidatePath.slice(2) : candidatePath;
 }
 
+function isPathWithinRoot(candidatePath: string, rootPath: string): boolean {
+  if (rootPath === ".") return isProjectLocalPath(candidatePath);
+  return candidatePath === rootPath || candidatePath.startsWith(`${rootPath}/`);
+}
+
+function resolveWorkspacePackageTarget(rootPath: string, target: string): string | undefined {
+  if (!target.startsWith("./")) return undefined;
+  const resolved = trimLeadingCurrentDir(normalizeFilePath(path.posix.join(rootPath, target)));
+  return isProjectLocalPath(resolved) && isPathWithinRoot(resolved, rootPath) ? resolved : undefined;
+}
+
+function packageExportTargets(value: unknown): string[] | undefined {
+  if (typeof value === "string") return [value];
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+
+  const conditions = value as Record<string, unknown>;
+  const targets: string[] = [];
+  for (const condition of ["types", "import", "default", "require"] as const) {
+    const nested = packageExportTargets(conditions[condition]);
+    if (nested) targets.push(...nested);
+  }
+  return targets.length > 0 ? [...new Set(targets)] : undefined;
+}
+
+/**
+ * Parses only source-facing, project-local package metadata. It deliberately
+ * excludes package-manager lookup and arbitrary export conditions so callers
+ * never resolve a graph edge through node_modules or an unsafe path.
+ */
+export function parseLocalWorkspacePackage(
+  manifestPath: string,
+  manifestText: string | undefined,
+): LocalWorkspacePackage | undefined {
+  if (manifestText === undefined) return undefined;
+
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(manifestText) as unknown;
+  } catch {
+    return undefined;
+  }
+  if (typeof manifest !== "object" || manifest === null || Array.isArray(manifest)) return undefined;
+
+  const document = manifest as Record<string, unknown>;
+  const name = typeof document.name === "string" ? document.name.trim() : "";
+  const normalizedManifestPath = trimLeadingCurrentDir(normalizeFilePath(manifestPath));
+  if (!name || !isProjectLocalPath(normalizedManifestPath) || path.posix.basename(normalizedManifestPath) !== "package.json") {
+    return undefined;
+  }
+
+  const rootPath = path.posix.dirname(normalizedManifestPath);
+  const entryPoints = new Map<string, readonly string[]>();
+  const addEntryPoint = (specifierPath: string, value: unknown): void => {
+    const targets = packageExportTargets(value)
+      ?.map((target) => resolveWorkspacePackageTarget(rootPath, target))
+      .filter((target): target is string => target !== undefined);
+    if (targets && targets.length > 0) entryPoints.set(specifierPath, [...new Set(targets)]);
+  };
+
+  const exportsValue = document.exports;
+  let restrictsSubpaths = false;
+  if (exportsValue !== undefined) {
+    restrictsSubpaths = true;
+    if (typeof exportsValue === "string") {
+      addEntryPoint(".", exportsValue);
+    } else if (typeof exportsValue === "object" && exportsValue !== null && !Array.isArray(exportsValue)) {
+      const exportMap = exportsValue as Record<string, unknown>;
+      const keys = Object.keys(exportMap);
+      if (keys.some((key) => key.startsWith("."))) {
+        for (const [specifierPath, target] of Object.entries(exportMap)) {
+          if (specifierPath === "." || (specifierPath.startsWith("./") && !specifierPath.includes("*"))) {
+            addEntryPoint(specifierPath, target);
+          }
+        }
+      } else {
+        addEntryPoint(".", exportsValue);
+      }
+    }
+  }
+
+  if (!entryPoints.has(".")) {
+    for (const field of ["types", "module", "main"] as const) {
+      if (typeof document[field] === "string") addEntryPoint(".", document[field]);
+    }
+  }
+
+  return { name, rootPath, entryPoints, restrictsSubpaths };
+}
+
+/**
+ * Discovers package manifests only on ancestor paths of indexed source files.
+ * This is bounded by known project sources and never scans node_modules.
+ */
+export function getLocalWorkspacePackageManifestPaths(importerFilePaths: readonly string[]): readonly string[] {
+  const manifestPaths = new Set<string>();
+  for (const importerFilePath of importerFilePaths) {
+    const normalized = trimLeadingCurrentDir(normalizeFilePath(importerFilePath));
+    if (!isProjectLocalPath(normalized) || normalized === ".") continue;
+
+    let directory = path.posix.dirname(normalized);
+    while (true) {
+      manifestPaths.add(directory === "." ? "package.json" : `${directory}/package.json`);
+      if (directory === ".") break;
+      const parent = path.posix.dirname(directory);
+      if (parent === directory) break;
+      directory = parent;
+    }
+  }
+  return [...manifestPaths].sort();
+}
+
+export function getLocalWorkspacePackages(
+  importerFilePaths: readonly string[],
+  loadManifest: (manifestPath: string) => string | undefined,
+): readonly LocalWorkspacePackage[] {
+  return getLocalWorkspacePackageManifestPaths(importerFilePaths)
+    .map((manifestPath) => parseLocalWorkspacePackage(manifestPath, loadManifest(manifestPath)))
+    .filter((workspacePackage): workspacePackage is LocalWorkspacePackage => workspacePackage !== undefined);
+}
+
 function isIdentifierStart(char: string): boolean {
   return /[A-Za-z_$]/u.test(char);
 }
@@ -857,6 +986,7 @@ export class LocalModuleCallResolver {
   private readonly exportCache = new Map<string, SymbolData[]>();
   private readonly tsConfigPathAliases?: LocalModulePathAliases;
   private readonly pathAliasesForImporter?: LocalModuleResolverOptions["pathAliasesForImporter"];
+  private readonly workspacePackages = new Map<string, LocalWorkspacePackage | null>();
 
   constructor(options: LocalModuleResolverOptions) {
     for (const filePath of options.filePaths) {
@@ -866,6 +996,10 @@ export class LocalModuleCallResolver {
     this.loadModule = options.loadModule;
     this.tsConfigPathAliases = options.tsConfigPathAliases;
     this.pathAliasesForImporter = options.pathAliasesForImporter;
+    for (const workspacePackage of options.workspacePackages ?? []) {
+      const existing = this.workspacePackages.get(workspacePackage.name);
+      this.workspacePackages.set(workspacePackage.name, existing === undefined ? workspacePackage : null);
+    }
   }
 
   seedModule(filePath: string, data: LocalModuleData): void {
@@ -946,11 +1080,29 @@ export class LocalModuleCallResolver {
       return aliasCandidates;
     }
 
-    if (!pathAliases || pathAliases.aliases.length === 0) {
-      return [];
-    }
+    return this.resolveModuleSpecifierFromWorkspacePackage(specifier);
+  }
 
-    return [];
+  private resolveModuleSpecifierFromWorkspacePackage(specifier: string): string[] {
+    const packageNames = [...this.workspacePackages.keys()]
+      .filter((name) => specifier === name || specifier.startsWith(`${name}/`))
+      .sort((left, right) => right.length - left.length || left.localeCompare(right));
+    const packageName = packageNames[0];
+    if (!packageName) return [];
+
+    const workspacePackage = this.workspacePackages.get(packageName);
+    if (!workspacePackage) return [];
+
+    const suffix = specifier.slice(packageName.length);
+    const exportPath = suffix.length === 0 ? "." : `.${suffix}`;
+    const entryPoints = workspacePackage.entryPoints.get(exportPath);
+    if (entryPoints) {
+      return [...new Set(entryPoints.flatMap((entryPoint) => this.resolveModuleCandidates(entryPoint)))].sort();
+    }
+    if (workspacePackage.restrictsSubpaths) return [];
+    if (suffix.length === 0) return [];
+
+    return this.resolveModuleCandidates(path.posix.join(workspacePackage.rootPath, suffix));
   }
 
   private resolveModuleSpecifierFromAliases(

--- a/src/watcher/file-watcher.ts
+++ b/src/watcher/file-watcher.ts
@@ -7,7 +7,11 @@ import type { CodebaseIndexConfig } from "../config/schema.js";
 import { getProjectConfigCandidatePaths } from "../config/paths.js";
 import { createIgnoreFilter, shouldIncludeFile } from "../utils/files.js";
 import { hasFilteredPathSegment, isRestrictedDirectory } from "../utils/paths.js";
-import { LocalModuleConfigTracker, shouldTrackLocalModuleConfigPath } from "./local-module-config.js";
+import {
+  LocalModuleConfigTracker,
+  shouldTrackLocalModuleConfigPath,
+  shouldTrackLocalModulePackagePath,
+} from "./local-module-config.js";
 import { NativeRecursiveWatcher } from "./native-recursive-watcher.js";
 import { FileSnapshotReconciler, type SnapshotInvalidation } from "./snapshot-reconciler.js";
 
@@ -350,6 +354,7 @@ export class FileWatcher {
       || filePath === path.join(this.projectRoot, ".gitignore")
       || (filePath !== null && (
         shouldTrackLocalModuleConfigPath(filePath, this.projectRoot)
+        || shouldTrackLocalModulePackagePath(filePath, this.projectRoot)
         || this.localModuleConfigTracker.has(filePath)
       ))
     ) {
@@ -450,6 +455,7 @@ export class FileWatcher {
 
     if (
       shouldTrackLocalModuleConfigPath(filePath, this.projectRoot)
+      || shouldTrackLocalModulePackagePath(filePath, this.projectRoot)
       || this.localModuleConfigTracker.has(filePath)
     ) {
       this.localModuleConfigTracker.refresh();

--- a/src/watcher/local-module-config.ts
+++ b/src/watcher/local-module-config.ts
@@ -7,6 +7,7 @@ import { createIgnoreFilter } from "../utils/files.js";
 import { hasFilteredPathSegment, isRestrictedDirectory } from "../utils/paths.js";
 
 const LOCAL_MODULE_CONFIG_NAMES = new Set(["tsconfig.json", "jsconfig.json"]);
+const LOCAL_MODULE_PACKAGE_MANIFEST_NAME = "package.json";
 type IgnoreFilter = ReturnType<typeof createIgnoreFilter>;
 export interface LocalModuleConfigTrackerOptions {
   indexing?: { maxDepth?: number };
@@ -25,6 +26,18 @@ export function shouldTrackLocalModuleConfigPath(
 ): boolean {
   return (
     LOCAL_MODULE_CONFIG_NAMES.has(path.basename(filePath).toLowerCase())
+    && shouldTrackProjectLocalJsonConfigPath(filePath, projectRoot, ignoreFilter)
+  );
+}
+
+/** Whether a project-local package manifest can affect workspace import resolution. */
+export function shouldTrackLocalModulePackagePath(
+  filePath: string,
+  projectRoot: string,
+  ignoreFilter: IgnoreFilter = createIgnoreFilter(projectRoot),
+): boolean {
+  return (
+    path.basename(filePath).toLowerCase() === LOCAL_MODULE_PACKAGE_MANIFEST_NAME
     && shouldTrackProjectLocalJsonConfigPath(filePath, projectRoot, ignoreFilter)
   );
 }
@@ -64,6 +77,7 @@ export class LocalModuleConfigTracker {
     const root = path.resolve(this.projectRoot);
     const ignoreFilter = createIgnoreFilter(root);
     const roots: string[] = [];
+    const nextPaths = new Set<string>();
     const maxDepth = this.options.indexing?.maxDepth ?? -1;
 
     const walk = (directoryPath: string, depth: number): void => {
@@ -84,14 +98,18 @@ export class LocalModuleConfigTracker {
           continue;
         }
 
-        if (entry.isFile() && shouldTrackLocalModuleConfigPath(filePath, root, ignoreFilter)) {
-          roots.push(relativePath.split(path.sep).join("/"));
+        if (entry.isFile()) {
+          if (shouldTrackLocalModuleConfigPath(filePath, root, ignoreFilter)) {
+            roots.push(relativePath.split(path.sep).join("/"));
+          }
+          if (shouldTrackLocalModulePackagePath(filePath, root, ignoreFilter)) {
+            nextPaths.add(filePath);
+          }
         }
       }
     };
 
     walk(root, 0);
-    const nextPaths = new Set<string>();
     const readConfig = (relativePath: string): string | undefined => {
       try {
         return readFileSync(path.join(root, ...relativePath.split("/")), "utf-8");

--- a/tests/automatic-branch-index.test.ts
+++ b/tests/automatic-branch-index.test.ts
@@ -318,7 +318,7 @@ function changed(): number {
       ),
     ).toBe(true);
     for (const [prefix, version] of [
-      ["index.callGraphResolutionVersion", "5"],
+      ["index.callGraphResolutionVersion", "6"],
       [swiftPrefix, "1"],
       ["index.parser.metalVersion", "1"],
     ] as const) {

--- a/tests/call-graph.test.ts
+++ b/tests/call-graph.test.ts
@@ -2684,6 +2684,54 @@ main() {
       }
     });
 
+    it("resolves project-local workspace package imports and reprocesses unchanged importers after manifest changes", async () => {
+      const projectDir = path.join(tempDir, "workspace-package-resolution-project");
+      const appDir = path.join(projectDir, "apps", "web", "src");
+      const packageDir = path.join(projectDir, "packages", "shared", "src");
+      fs.mkdirSync(appDir, { recursive: true });
+      fs.mkdirSync(packageDir, { recursive: true });
+      fs.writeFileSync(path.join(projectDir, "package.json"), JSON.stringify({ name: "workspace-root" }));
+      fs.writeFileSync(
+        path.join(appDir, "main.ts"),
+        'import { packageTarget } from "@scope/shared";\nexport function runWorkspacePackage() { packageTarget(); }',
+      );
+      fs.writeFileSync(path.join(packageDir, "index.ts"), "export function packageTarget() {}");
+      fs.writeFileSync(path.join(packageDir, "alternate.ts"), "export function packageTarget() {}");
+      const packageManifestPath = path.join(projectDir, "packages", "shared", "package.json");
+      fs.writeFileSync(packageManifestPath, JSON.stringify({
+        name: "@scope/shared",
+        exports: { ".": "./src/index.ts" },
+      }));
+      const fetchSpy = mockEmbeddings();
+      const indexer = new Indexer(projectDir, createIndexerConfig(), "opencode");
+
+      try {
+        const resolvedTargetPath = async (): Promise<string | undefined> => {
+          const symbols = await indexer.getSymbolsForBranch();
+          const caller = symbols.find((symbol) => symbol.name === "runWorkspacePackage");
+          const edge = (await indexer.getCallees(caller!.id)).find(
+            (candidate) => candidate.targetName === "packageTarget",
+          );
+          return symbols.find((symbol) => symbol.id === edge?.toSymbolId)?.filePath;
+        };
+
+        await indexer.index();
+        await expect(resolvedTargetPath()).resolves.toMatch(/packages[/\\]shared[/\\]src[/\\]index\.ts$/u);
+
+        const embeddingCallsBeforeManifestChange = fetchSpy.mock.calls.length;
+        fs.writeFileSync(packageManifestPath, JSON.stringify({
+          name: "@scope/shared",
+          exports: { ".": "./src/alternate.ts" },
+        }));
+        await indexer.index();
+        await expect(resolvedTargetPath()).resolves.toMatch(/packages[/\\]shared[/\\]src[/\\]alternate\.ts$/u);
+        expect(fetchSpy).toHaveBeenCalledTimes(embeddingCallsBeforeManifestChange);
+      } finally {
+        await indexer.close();
+        fetchSpy.mockRestore();
+      }
+    });
+
     it("re-resolves unchanged importers when nearest configs and their extends chain change", async () => {
       const projectDir = path.join(tempDir, "nearest-local-module-config-project");
       const appDir = path.join(projectDir, "packages", "app");

--- a/tests/local-module-resolution.test.ts
+++ b/tests/local-module-resolution.test.ts
@@ -5,6 +5,7 @@ import {
   TsConfigPathAliasCache,
   getTsConfigModuleResolutionConfigDependencyPaths,
   getTsConfigModuleResolutionConfigPaths,
+  getLocalWorkspacePackages,
   parseTsConfigForModuleResolution,
   resolveTsConfigForModuleResolution,
   type LocalModuleData,
@@ -29,14 +30,73 @@ function callSite(calleeName: string, line = 2, column = 2, callType: CallSiteDa
   return { calleeName, line, column, callType, confidence: "Direct" };
 }
 
-function resolver(modules: Record<string, LocalModuleData>): LocalModuleCallResolver {
+function resolver(
+  modules: Record<string, LocalModuleData>,
+  workspaceManifestTexts: Record<string, string> = {},
+): LocalModuleCallResolver {
   return new LocalModuleCallResolver({
     filePaths: Object.keys(modules),
     loadModule: async (filePath) => modules[filePath],
+    workspacePackages: getLocalWorkspacePackages(
+      Object.keys(modules),
+      (manifestPath) => workspaceManifestTexts[manifestPath],
+    ),
   });
 }
 
 describe("LocalModuleCallResolver", () => {
+  it("resolves declared project-local workspace package roots and exact exports", async () => {
+    const main = [
+      'import { rootTarget } from "@scope/shared";',
+      'import { featureTarget } from "@scope/shared/feature";',
+      "export function run() { rootTarget(); featureTarget(); }",
+    ].join("\n");
+    const rootTarget = symbol("root", "packages/shared/src/index.ts", "rootTarget");
+    const featureTarget = symbol("feature", "packages/shared/src/feature.ts", "featureTarget");
+    const instance = resolver({
+      "apps/web/src/main.ts": { content: main, symbols: [symbol("run", "apps/web/src/main.ts", "run")] },
+      "packages/shared/src/index.ts": { content: "export function rootTarget() {}", symbols: [rootTarget] },
+      "packages/shared/src/feature.ts": { content: "export function featureTarget() {}", symbols: [featureTarget] },
+    }, {
+      "packages/shared/package.json": JSON.stringify({
+        name: "@scope/shared",
+        exports: { ".": "./src/index.ts", "./feature": "./src/feature.ts" },
+      }),
+    });
+
+    await expect(instance.resolveCallTarget("apps/web/src/main.ts", main, callSite("rootTarget", 3, 24)))
+      .resolves.toEqual(rootTarget);
+    await expect(instance.resolveCallTarget("apps/web/src/main.ts", main, callSite("featureTarget", 3, 38)))
+      .resolves.toEqual(featureTarget);
+  });
+
+  it("uses safe package-relative subpaths without exports and abstains for external or ambiguous packages", async () => {
+    const main = [
+      'import { nestedTarget } from "shared-package/nested";',
+      'import { externalTarget } from "external-package";',
+      'import { duplicateTarget } from "duplicate-package";',
+      "export function run() { nestedTarget(); externalTarget(); duplicateTarget(); }",
+    ].join("\n");
+    const nestedTarget = symbol("nested", "packages/shared/nested.ts", "nestedTarget");
+    const instance = resolver({
+      "apps/web/main.ts": { content: main, symbols: [symbol("run", "apps/web/main.ts", "run")] },
+      "packages/shared/nested.ts": { content: "export function nestedTarget() {}", symbols: [nestedTarget] },
+      "packages/a/index.ts": { content: "export function duplicateTarget() {}", symbols: [] },
+      "packages/b/index.ts": { content: "export function duplicateTarget() {}", symbols: [] },
+    }, {
+      "packages/shared/package.json": JSON.stringify({ name: "shared-package" }),
+      "packages/a/package.json": JSON.stringify({ name: "duplicate-package", main: "./index.ts" }),
+      "packages/b/package.json": JSON.stringify({ name: "duplicate-package", main: "./index.ts" }),
+    });
+
+    await expect(instance.resolveCallTarget("apps/web/main.ts", main, callSite("nestedTarget", 4, 24)))
+      .resolves.toEqual(nestedTarget);
+    await expect(instance.resolveCallTarget("apps/web/main.ts", main, callSite("externalTarget", 4, 40)))
+      .resolves.toBeUndefined();
+    await expect(instance.resolveCallTarget("apps/web/main.ts", main, callSite("duplicateTarget", 4, 58)))
+      .resolves.toBeUndefined();
+  });
+
   it("resolves direct, aliased, default, and namespace imports", async () => {
     const main = [
       'import defaultTarget, { directTarget as localAlias } from "./target.js";',

--- a/tests/pr-impact.test.ts
+++ b/tests/pr-impact.test.ts
@@ -28,7 +28,7 @@ function symbolExtractorMetadataKey(catalogIdentity: string): string {
 
 function setBranchMigrationMetadataCurrent(database: Database, catalogIdentity: string): void {
   const suffix = hashContent(catalogIdentity).slice(0, 24);
-  database.setMetadata(`index.callGraphResolutionVersion.${suffix}`, "5");
+  database.setMetadata(`index.callGraphResolutionVersion.${suffix}`, "6");
   database.setMetadata(`index.parser.swiftVersion.${suffix}`, "1");
   database.setMetadata(`index.parser.metalVersion.${suffix}`, "1");
   database.setMetadata(symbolExtractorMetadataKey(catalogIdentity), "1");
@@ -132,7 +132,6 @@ describe("pr_impact tool", () => {
 
     const indexer = await createIndexer();
     const db = await getDatabase(indexer);
-
     db.upsertSymbol({
       id: "sym_a",
       filePath: "src/a.ts",
@@ -506,6 +505,14 @@ describe("pr_impact tool", () => {
 
     const indexer = await createIndexer();
     const db = await getDatabase(indexer);
+    for (const [catalogIdentity, commit] of [
+      ["feature-branch", "1111111111111111111111111111111111111111"],
+      ["other-branch", "2222222222222222222222222222222222222222"],
+      ["third-branch", "3333333333333333333333333333333333333333"],
+    ] as const) {
+      setBranchMigrationMetadataCurrent(db, catalogIdentity);
+      db.setMetadata(branchCommitMetadataKey(catalogIdentity), commit);
+    }
 
     db.upsertSymbol({
       id: "sym_a",
@@ -602,6 +609,13 @@ describe("pr_impact tool", () => {
 
     const indexer = await createIndexer();
     const db = await getDatabase(indexer);
+    for (const [catalogIdentity, commit] of [
+      ["feature-branch", "1111111111111111111111111111111111111111"],
+      ["other-branch", "2222222222222222222222222222222222222222"],
+    ] as const) {
+      setBranchMigrationMetadataCurrent(db, catalogIdentity);
+      db.setMetadata(branchCommitMetadataKey(catalogIdentity), commit);
+    }
 
     const filePath = "src/a.ts";
 

--- a/tests/watcher-native-integration.test.ts
+++ b/tests/watcher-native-integration.test.ts
@@ -157,4 +157,30 @@ describe("native FileWatcher", () => {
     fs.rmSync(baseConfig);
     await waitForChange(changes, baseConfig, "unlink");
   });
+
+  it("tracks nested package manifest changes outside source include patterns", async () => {
+    const changes: FileChange[] = [];
+    const packageManifest = path.join(projectRoot, "packages", "shared", "package.json");
+    fs.mkdirSync(path.dirname(packageManifest), { recursive: true });
+    fs.writeFileSync(packageManifest, JSON.stringify({ name: "@scope/shared", main: "./src/index.ts" }));
+    watcher = new FileWatcher(
+      projectRoot,
+      parseConfig({ include: ["**/*.ts"] }),
+      "codex",
+      { backend: "native" },
+    );
+
+    watcher.start(async (batch) => {
+      changes.push(...batch);
+    });
+    await watcher.waitUntilReady();
+
+    await writeUntilChangeObserved(
+      (attempt) => fs.writeFileSync(
+        packageManifest,
+        JSON.stringify({ name: "@scope/shared", main: `./src-${attempt}/index.ts` }),
+      ),
+      () => expect(changes).toContainEqual({ path: packageManifest, type: "change" }),
+    );
+  });
 });

--- a/tests/watcher-snapshot.test.ts
+++ b/tests/watcher-snapshot.test.ts
@@ -149,6 +149,17 @@ describe("watcher snapshot builder", () => {
     expect(tracker.has(ignoredConfig)).toBe(false);
   });
 
+  it("tracks project-local package manifests as module-resolution metadata", () => {
+    const packageManifest = path.join(projectRoot, "packages", "shared", "package.json");
+    fs.mkdirSync(path.dirname(packageManifest), { recursive: true });
+    fs.writeFileSync(packageManifest, JSON.stringify({ name: "@scope/shared", main: "./src/index.ts" }));
+
+    const tracker = new LocalModuleConfigTracker(projectRoot, {});
+    tracker.refresh();
+
+    expect(tracker.has(packageManifest)).toBe(true);
+  });
+
   it("limits traversal depth using config.indexing.maxDepth", async () => {
     const rootFile = path.join(projectRoot, "root.ts");
     const nestedLevelOne = path.join(projectRoot, "level-one", "nested.ts");

--- a/tests/watcher.test.ts
+++ b/tests/watcher.test.ts
@@ -239,6 +239,32 @@ describe("FileWatcher", () => {
       );
     });
 
+    it("watches a nested package manifest outside source include patterns with Chokidar", async () => {
+      const packageManifest = path.join(tempDir, "packages", "shared", "package.json");
+      fs.mkdirSync(path.dirname(packageManifest), { recursive: true });
+      fs.writeFileSync(packageManifest, JSON.stringify({ name: "@scope/shared", main: "./src/index.ts" }));
+      const changes: FileChange[] = [];
+      watcher = new FileWatcher(
+        tempDir,
+        createTestConfig({ include: ["**/*.ts"] }),
+        "codex",
+        { backend: "chokidar" },
+      );
+
+      watcher.start(async (batch) => {
+        changes.push(...batch);
+      });
+      await watcher.waitUntilReady();
+
+      await writeUntilObserved(
+        (attempt) => fs.writeFileSync(
+          packageManifest,
+          JSON.stringify({ name: "@scope/shared", main: `./src-${attempt}/index.ts` }),
+        ),
+        () => expect(changes).toContainEqual({ path: packageManifest, type: "change" }),
+      );
+    });
+
     it("should watch codex-native config without watching codex index files", async () => {
       const changes: FileChange[] = [];
       fs.mkdirSync(path.join(tempDir, ".codebase-index", "index"), { recursive: true });


### PR DESCRIPTION
## Summary

- Resolve bare TypeScript and JavaScript imports to project-local workspace packages declared in `package.json`.
- Support safe source-facing root and exact-subpath `exports`, plus package-relative subpaths when `exports` is absent.
- Refresh cached call-graph edges when tracked workspace manifests change, without re-embedding unchanged source.
- Preserve conservative abstention for external packages, unsafe or malformed metadata, and duplicate package names.

## Validation

- `npm run build && npm run typecheck && npm run lint && npm run test:run`
  - 105 test files, 1,655 tests passed
- Public Indexer call-graph, resolver, Chokidar, and native-watcher regression coverage added.