### PR TITLE
fix(mcp): make long-running operations cancellable and diagnosable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Cancellable and diagnosable MCP operations**: Added inactivity-based cancellation, exact-token monotone progress, redacted structured handler errors, and durable per-process phase diagnostics exposed by `index_status`. Shared indexing detaches cancelled callers without stopping work still awaited by another consumer, while exclusively owned cancelled work rolls back and releases its index lease. MCP SDK `1.29.0`, public tool names, package identities, and index formats remain unchanged.
+
 ## [0.26.0] - 2026-08-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ OpenCode project config lives at `.opencode/codebase-index.json`. Codex, Pi, and
     "minScore": 0.1,
     "fusionStrategy": "rrf",
     "rerankTopN": 20
+  },
+  "mcp": {
+    "stallTimeoutMs": 300000
   }
 }
 ```
@@ -204,6 +207,8 @@ Start with:
 4. a forced rebuild only when status reports incompatibility or corruption
 
 Common provider, native module, stale index, branch, and performance issues are covered in [Troubleshooting](TROUBLESHOOTING.md).
+
+MCP operations report structured, redacted failures and durable phase diagnostics through `index_status`. If a client has already lost its stdio transport, start a fresh client session before retrying.
 
 ## Evaluation and performance
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -23,6 +23,31 @@ Then jump to the relevant section below for provider, build, performance, or bra
 - [Slow Indexing Performance](#slow-indexing-performance)
 - [Search Returns No Results](#search-returns-no-results)
 - [Branch-Related Issues](#branch-related-issues)
+- [MCP Operations Stall or Report Transport Errors](#mcp-operations-stall-or-report-transport-errors)
+
+---
+
+## MCP Operations Stall or Report Transport Errors
+
+Start a fresh MCP client session and call `index_status`. Its MCP structured content includes `mcpDiagnostics`:
+
+- `active` means the owning process is still present and the operation is reporting activity within the configured window.
+- `suspected_stall` means no phase or heartbeat has been observed within `mcp.stallTimeoutMs`. It does not prove that the process exited.
+- `latestInterruptedOperation` appears only after ordered shutdown or after a later local process confirms that the recorded PID is absent.
+
+The default inactivity window is five minutes. For diagnosis, lower it no further than `1000` milliseconds:
+
+```json
+{
+  "mcp": {
+    "stallTimeoutMs": 1000
+  }
+}
+```
+
+MCP errors include a stable code, phase, duration, retryability flag, and next action. Use `INDEX_BUSY` and `INDEX_UNAVAILABLE` guidance before rebuilding. For `PROVIDER_ERROR`, retry only when the response marks it retryable. `INTERNAL_ERROR` requires server log inspection.
+
+This server can cancel exclusively owned cooperative work, release its index lease, roll back an active SQLite transaction, and preserve a process diagnostic after a forced exit. When indexing is shared, cancelling one caller detaches only that caller while the remaining consumers keep the underlying work alive. The server cannot reconnect a client that continues using a closed transport or replay the lost request. Codex may therefore require a new session even after the server is healthy. General client reconnection remains outside this repository and is tracked in [openai/codex#35486](https://github.com/openai/codex/issues/35486) and [openai/codex#16899](https://github.com/openai/codex/issues/16899). [openai/codex#34957](https://github.com/openai/codex/pull/34957) is a partial client-side fix, not general transport reconnection.
 
 ---
 
@@ -466,3 +491,4 @@ If none of these solutions work:
 | Slow indexing | Use Ollama locally |
 | No results | Run `/index` first, use descriptive queries |
 | Native module error | Rebuild with Rust toolchain |
+| MCP transport closed | Start a new client session, then inspect `index_status` diagnostics |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -262,6 +262,20 @@ Example:
 
 `communityBoost` is experimental and disabled by default. It activates only when the query contains one unambiguous exact symbol already present in the active branch catalog. Existing branch, directory, file-type, chunk-type, blame, and score filters run first, so community context can reorder only candidates that already passed normal search scope. Missing or ambiguous symbols and unavailable graph data fall back to the existing ranking.
 
+## MCP operation runtime
+
+```json
+{
+  "mcp": {
+    "stallTimeoutMs": 300000
+  }
+}
+```
+
+`mcp.stallTimeoutMs` limits inactivity, not total operation duration. Every phase change, heartbeat, and raw indexing progress event rearms the timer. The default is `300000` milliseconds. Set it to `0` to disable stall detection. Positive values are normalized to the safe timer range from `1000` through `2147483647` milliseconds.
+
+The MCP server writes redacted per-process runtime state below `<indexRoot>/mcp-runtime/`. These records contain operation names, phases, timestamps, process identity, and ordered-shutdown state only. They never contain tool arguments, queries, paths, provider URLs, response bodies, raw exception causes, or secrets. Active records are updated atomically, phase changes are persisted immediately, disk heartbeats are limited to one every five seconds, and records older than seven days are removed during status inspection. Cross-process status checks allow one disk-heartbeat interval before reporting a suspected stall so the persistence throttle does not create a false warning.
+
 ## Include and exclude patterns
 
 ```json
@@ -330,6 +344,9 @@ When reranking is enabled, `topN` defaults to `15` and `timeoutMs` defaults to `
   },
   "effectivenessMetrics": {
     "enabled": false
+  },
+  "mcp": {
+    "stallTimeoutMs": 300000
   }
 }
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -98,6 +98,8 @@ codex plugin add codebase-index@helweg-plugins
 
 Restart or open a new thread in the target workspace. The plugin bundles MCP configuration, session guidance, and the `codebase-search` skill.
 
+If Codex reports `Transport closed`, inspect `index_status` from a new thread or client session. Server-side cancellation and durable diagnostics cannot make a client reuse a stdio transport that it has already closed.
+
 For local plugin development from this checkout:
 
 ```bash

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -127,6 +127,8 @@ Finds code analogous to a supplied snippet. Useful for duplicate detection, patt
 
 Reports readiness, chunk counts, compatibility, current provider/model, and index health information.
 
+MCP responses add `structuredContent.mcpDiagnostics` with schema version `1`. `activeOperations` reports each operation, its current phase, start and last-activity timestamps, and `active` or `suspected_stall` status. The current `index_status` call is excluded. `latestInterruptedOperation` is included only after an ordered shutdown marks an active call or a later local process confirms that the recorded PID is absent. A stale heartbeat alone is never classified as an interruption.
+
 ### `index_codebase`
 
 Creates or updates the index. Incremental indexing is the default. Use `force: true` only for a required full rebuild. `estimateOnly` reports estimated embedding work without indexing. `dryRun` parses the real file set and reports the exact embedding token total (files, source chunks, tokens) without requesting embeddings or writing to the index — a read-only preflight.
@@ -142,6 +144,28 @@ Returns process-lifetime operational metrics and enabled privacy-safe effectiven
 ### `index_logs`
 
 Returns recent in-memory debug logs when debug logging is enabled.
+
+### MCP errors and progress
+
+Every MCP handler failure returns `isError: true`, a concise English instruction, and a redacted structured error:
+
+```json
+{
+  "error": {
+    "schemaVersion": 1,
+    "code": "OPERATION_TIMEOUT",
+    "operation": "index_codebase",
+    "phase": "embedding",
+    "durationMs": 123,
+    "retryable": true,
+    "nextAction": "Check index_status for the stalled phase, then retry the operation."
+  }
+}
+```
+
+Codes are `OPERATION_TIMEOUT`, `OPERATION_CANCELLED`, `PROVIDER_ERROR`, `INDEX_BUSY`, `INDEX_UNAVAILABLE`, and `INTERNAL_ERROR`. Provider timeouts, HTTP 429, and HTTP 5xx failures are retryable. Other HTTP 4xx failures and internal errors are not. Tool arguments, queries, paths, provider URLs, response bodies, raw causes, and secrets are never copied into this structure.
+
+When the caller supplies a progress token, long-running operations reuse that exact token and emit serialized, strictly increasing progress from `0` through `100` with `total: 100`. No progress notification is emitted without a token. Raw progress still refreshes the inactivity deadline even when rounding produces no new percentage.
 
 ## Call graph and impact tools
 

--- a/src/adapters/mcp/cli.ts
+++ b/src/adapters/mcp/cli.ts
@@ -10,7 +10,11 @@ import { parseConfig } from "../../config/schema.js";
 import { parseHostMode, HOST_MODES, type HostMode } from "../../config/host.js";
 import { handleEvalCommand } from "../../eval/cli.js";
 import { Indexer } from "../../indexer/index.js";
-import { attachMcpBackgroundWatcher, createMcpServer } from "../../mcp-server.js";
+import {
+  attachMcpBackgroundWatcher,
+  createMcpServer,
+  markMcpServerOrderedShutdown,
+} from "../../mcp-server.js";
 import { loadConfigFile, loadMergedConfig } from "../../config/merger.js";
 import { getIndexerForProject } from "../../tools/operations.js";
 import { initializeTools } from "../../tools/operation-runtime.js";
@@ -256,10 +260,10 @@ export async function runMcpCli(argv: string[]): Promise<void> {
 
   const server = createMcpServer(args.project, config, args.host);
   const transport = new StdioServerTransport();
-  let shutdownPromise: Promise<void> | undefined;
+  let shutdownPromise: Promise<number> | undefined;
   const onServerClose = server.server.onclose;
 
-  const shutdown = (): Promise<void> => {
+  const shutdown = (): Promise<number> => {
     if (shutdownPromise) return shutdownPromise;
     process.stdin.removeListener("end", requestShutdown);
     process.stdin.removeListener("close", requestShutdown);
@@ -267,10 +271,16 @@ export async function runMcpCli(argv: string[]): Promise<void> {
     process.removeListener("SIGINT", requestShutdown);
     process.removeListener("SIGTERM", requestShutdown);
     server.server.onclose = onServerClose;
-    shutdownPromise = (async (): Promise<void> => {
+    const inFlightShutdown = (async (): Promise<number> => {
       let exitCode = 0;
       try {
-        await stopBackgroundWorker(args.project, args.host);
+        await markMcpServerOrderedShutdown(server);
+      } catch (error: unknown) {
+        exitCode = 1;
+        console.error("Failed to persist MCP shutdown diagnostics:", error);
+      }
+      try {
+        await stopBackgroundWorker(args.project, args.host, true);
       } catch (error) {
         exitCode = 1;
         if (error instanceof BackgroundWorkerStopError) {
@@ -290,13 +300,14 @@ export async function runMcpCli(argv: string[]): Promise<void> {
         exitCode = 1;
         console.error("Failed to close MCP server cleanly:", error);
       }
-      process.exit(exitCode);
+      return exitCode;
     })();
-    return shutdownPromise;
+    shutdownPromise = inFlightShutdown;
+    return inFlightShutdown;
   };
 
   const requestShutdown = (): void => {
-    void shutdown();
+    void shutdown().then((exitCode) => process.exit(exitCode));
   };
 
   server.server.onclose = () => {
@@ -331,17 +342,22 @@ export async function runMcpCli(argv: string[]): Promise<void> {
       )
       : null
   );
-  await server.connect(transport);
-  if (shutdownPromise) return;
+  try {
+    await server.connect(transport);
+    if (shutdownPromise) return;
 
-  await attachMcpBackgroundWatcher(
-    args.project,
-    config,
-    args.host,
-    config.indexing.watchFiles && isValidProject ? watcherFactoryForConfig(config) : null,
-    watcherFactoryForConfig,
-  );
-  if (shutdownPromise) return;
+    await attachMcpBackgroundWatcher(
+      args.project,
+      config,
+      args.host,
+      config.indexing.watchFiles && isValidProject ? watcherFactoryForConfig(config) : null,
+      watcherFactoryForConfig,
+    );
+    if (shutdownPromise) return;
+  } catch (error: unknown) {
+    await shutdown();
+    throw error;
+  }
 }
 
 interface CliIndexCommandDeps {

--- a/src/adapters/mcp/operation-execution.ts
+++ b/src/adapters/mcp/operation-execution.ts
@@ -1,0 +1,410 @@
+import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import type {
+  CallToolResult,
+  ProgressToken,
+  ServerNotification,
+  ServerRequest,
+} from "@modelcontextprotocol/sdk/types.js";
+
+import { isIndexLockContentionError } from "../../indexer/index-lock.js";
+import {
+  AutoIndexRetrievalUnavailableError,
+  getRuntimeConfigForProject,
+} from "../../tools/operation-runtime.js";
+import type { OperationControl } from "../../utils/operation-control.js";
+import {
+  getOperationInterruption,
+  OperationCancelledError,
+  OperationStallTimeoutError,
+  ProviderRequestError,
+  raceWithOperationSignal,
+  throwIfOperationAborted,
+} from "../../utils/operation-control.js";
+import type { McpServerRuntime } from "./shared.js";
+
+export type McpOperationErrorCode =
+  | "OPERATION_TIMEOUT"
+  | "OPERATION_CANCELLED"
+  | "PROVIDER_ERROR"
+  | "INDEX_BUSY"
+  | "INDEX_UNAVAILABLE"
+  | "INTERNAL_ERROR";
+
+export interface McpOperationError {
+  schemaVersion: 1;
+  code: McpOperationErrorCode;
+  operation: string;
+  phase: string;
+  durationMs: number;
+  retryable: boolean;
+  nextAction: string;
+}
+
+export type McpOperationExtra = RequestHandlerExtra<ServerRequest, ServerNotification>;
+type McpOperationHandler = (control: OperationControl) => CallToolResult | Promise<CallToolResult>;
+const DIAGNOSTIC_IO_TIMEOUT_MS = 5_000;
+
+class ReportedToolError extends Error {
+  constructor(
+    readonly kind: "busy" | "unavailable" | "internal",
+    readonly safeText?: string,
+  ) {
+    super("The operation reported an error result.");
+    this.name = "ReportedToolError";
+  }
+}
+
+class ProgressNotificationError extends Error {
+  constructor() {
+    super("An MCP progress notification could not be delivered.");
+    this.name = "ProgressNotificationError";
+  }
+}
+
+function normalizePhase(phase: string): string {
+  const normalized = phase.trim().toLowerCase().replaceAll(/[\s-]+/g, "_");
+  return /^[a-z0-9_:.]{1,64}$/.test(normalized) ? normalized : "working";
+}
+
+function getProgressToken(extra: McpOperationExtra): ProgressToken | undefined {
+  const token = extra._meta?.progressToken;
+  return typeof token === "string" || typeof token === "number" ? token : undefined;
+}
+
+function getText(result: CallToolResult): string {
+  return result.content
+    .filter((content): content is Extract<typeof content, { type: "text" }> => content.type === "text")
+    .map((content) => content.text)
+    .join("\n");
+}
+
+function errorDetails(
+  error: unknown,
+  operation: string,
+  phase: string,
+  durationMs: number,
+): McpOperationError {
+  const interruption = getOperationInterruption(error);
+  let code: McpOperationErrorCode;
+  let retryable: boolean;
+  let nextAction: string;
+
+  if (interruption instanceof OperationStallTimeoutError) {
+    code = "OPERATION_TIMEOUT";
+    retryable = true;
+    nextAction = "Check index_status for the stalled phase, then retry the operation.";
+  } else if (interruption instanceof OperationCancelledError) {
+    code = "OPERATION_CANCELLED";
+    retryable = true;
+    nextAction = "Retry the operation when the client is ready.";
+  } else if (error instanceof ProviderRequestError) {
+    code = "PROVIDER_ERROR";
+    retryable = error.retryable ?? (
+      error.timedOut
+      || error.statusCode === 429
+      || (error.statusCode !== undefined && error.statusCode >= 500)
+    );
+    nextAction = retryable
+      ? "Retry after the provider recovers or reduce the indexing workload."
+      : "Check the embedding or reranking provider configuration before retrying.";
+  } else if (isIndexLockContentionError(error) || (error instanceof ReportedToolError && error.kind === "busy")) {
+    code = "INDEX_BUSY";
+    retryable = true;
+    nextAction = "Wait for the current index operation to finish, then retry.";
+  } else if (error instanceof AutoIndexRetrievalUnavailableError
+    || (error instanceof ReportedToolError && error.kind === "unavailable")) {
+    code = "INDEX_UNAVAILABLE";
+    retryable = true;
+    nextAction = "Call index_status, run index_codebase if needed, then retry.";
+  } else {
+    code = "INTERNAL_ERROR";
+    retryable = false;
+    nextAction = "Inspect the MCP server logs and index_status diagnostics before retrying.";
+  }
+
+  return {
+    schemaVersion: 1,
+    code,
+    operation,
+    phase,
+    durationMs,
+    retryable,
+    nextAction,
+  };
+}
+
+function operationErrorResult(error: McpOperationError, safeText?: string): CallToolResult {
+  return {
+    isError: true,
+    content: [{
+      type: "text",
+      text: safeText ?? `${error.code}: ${error.nextAction}`,
+    }],
+    structuredContent: { error },
+  };
+}
+
+function classifyReportedResult(result: CallToolResult): ReportedToolError {
+  const text = getText(result);
+  if (text.startsWith("INDEX_BUSY:")) return new ReportedToolError("busy", text);
+  if (/index (?:is )?(?:not found|unavailable|not ready)/i.test(text)) {
+    return new ReportedToolError("unavailable");
+  }
+  return new ReportedToolError("internal");
+}
+
+function waitForDiagnosticIo(promise: Promise<void>, stallTimeoutMs: number): Promise<void> {
+  const timeoutMs = stallTimeoutMs > 0
+    ? Math.min(stallTimeoutMs, DIAGNOSTIC_IO_TIMEOUT_MS)
+    : DIAGNOSTIC_IO_TIMEOUT_MS;
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error("MCP operation diagnostics did not settle."));
+    }, timeoutMs);
+    timer.unref?.();
+    promise.then(
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+export async function executeMcpOperation(
+  runtime: McpServerRuntime,
+  operation: string,
+  extra: McpOperationExtra,
+  handler: McpOperationHandler,
+): Promise<CallToolResult> {
+  const startedAt = Date.now();
+  const operationController = new AbortController();
+  const abortForClient = (): void => {
+    if (!operationController.signal.aborted) {
+      operationController.abort(new OperationCancelledError());
+    }
+  };
+  if (extra.signal.aborted) abortForClient();
+  else extra.signal.addEventListener("abort", abortForClient, { once: true });
+
+  let tracked: Awaited<ReturnType<typeof runtime.diagnostics.begin>>;
+  let initializationPromise: ReturnType<typeof runtime.diagnostics.begin> | undefined;
+  let stallTimeoutMs: number;
+  let initializationTimer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    stallTimeoutMs = getRuntimeConfigForProject(runtime.projectRoot, runtime.host).mcp.stallTimeoutMs;
+    if (stallTimeoutMs > 0 && !operationController.signal.aborted) {
+      initializationTimer = setTimeout(() => {
+        operationController.abort(new OperationStallTimeoutError());
+      }, stallTimeoutMs);
+    }
+    initializationPromise = runtime.diagnostics.begin(operation);
+    tracked = await raceWithOperationSignal(
+      initializationPromise,
+      operationController.signal,
+    );
+  } catch (error: unknown) {
+    extra.signal.removeEventListener("abort", abortForClient);
+    if (initializationPromise) {
+      void initializationPromise.then(
+        (lateTracked) => waitForDiagnosticIo(
+          Promise.resolve().then(() => lateTracked.complete()),
+          stallTimeoutMs,
+        ),
+        () => undefined,
+      ).catch(() => undefined);
+    }
+    const classified = operationController.signal.aborted
+      && operationController.signal.reason instanceof Error
+      ? operationController.signal.reason
+      : getOperationInterruption(error) ?? new Error("MCP operation initialization failed.");
+    return operationErrorResult(errorDetails(
+      classified,
+      operation,
+      "starting",
+      Math.max(0, Date.now() - startedAt),
+    ));
+  } finally {
+    if (initializationTimer) clearTimeout(initializationTimer);
+  }
+  let phase = "starting";
+  let stallTimer: ReturnType<typeof setTimeout> | undefined;
+  let executionFailure: Error | undefined;
+  let closed = false;
+  let activityQueue = Promise.resolve();
+  let notificationQueue = Promise.resolve();
+  let lastProgress = -1;
+  const progressToken = getProgressToken(extra);
+
+  const resetStallTimer = (): void => {
+    if (closed) return;
+    if (stallTimer) clearTimeout(stallTimer);
+    if (stallTimeoutMs > 0 && !operationController.signal.aborted) {
+      stallTimer = setTimeout(() => {
+        operationController.abort(new OperationStallTimeoutError());
+      }, stallTimeoutMs);
+    }
+  };
+
+  const failExecution = (error: unknown): void => {
+    executionFailure ??= error instanceof Error ? error : new Error("MCP operation tracking failed.");
+    if (!operationController.signal.aborted) {
+      operationController.abort(new OperationCancelledError());
+    }
+  };
+
+  const scheduleActivity = (task: () => Promise<void>): Promise<void> => {
+    if (closed) return Promise.resolve();
+    resetStallTimer();
+    const scheduled = activityQueue.then(task);
+    const handled = scheduled.catch(failExecution);
+    activityQueue = handled;
+    return handled;
+  };
+
+  const setPhase = (nextPhase: string): Promise<void> => {
+    if (closed) return Promise.resolve();
+    const normalizedPhase = normalizePhase(nextPhase);
+    if (normalizedPhase === phase) return heartbeat();
+    phase = normalizedPhase;
+    return scheduleActivity(() => tracked.setPhase(normalizedPhase));
+  };
+
+  const heartbeat = (): Promise<void> => closed
+    ? Promise.resolve()
+    : scheduleActivity(() => tracked.heartbeat());
+
+  const sendProgress = (progress: number): Promise<void> => {
+    if (closed
+      || executionFailure
+      || operationController.signal.aborted
+      || progressToken === undefined
+      || progress <= lastProgress) {
+      return Promise.resolve();
+    }
+    lastProgress = progress;
+    const notification = Promise.resolve().then(() => extra.sendNotification({
+      method: "notifications/progress",
+      params: {
+        progressToken,
+        progress,
+        total: 100,
+      },
+    }));
+    return notification.catch(() => failExecution(new ProgressNotificationError()));
+  };
+
+  const reportProgress = async (rawProgress: number, nextPhase?: string): Promise<void> => {
+    if (closed || executionFailure || operationController.signal.aborted) return;
+    if (nextPhase) await setPhase(nextPhase);
+    else await heartbeat();
+    if (!Number.isFinite(rawProgress)) return;
+    const progress = Math.min(100, Math.max(0, Math.floor(rawProgress)));
+    const scheduled = notificationQueue.then(() => sendProgress(progress));
+    notificationQueue = scheduled;
+    await scheduled;
+  };
+
+  resetStallTimer();
+  let result: CallToolResult;
+  let operationFailed = false;
+  let handlerPromise: Promise<CallToolResult> | undefined;
+  try {
+    throwIfOperationAborted(operationController.signal);
+    if (progressToken !== undefined) {
+      await raceWithOperationSignal(
+        reportProgress(0, "starting"),
+        operationController.signal,
+      );
+    }
+    if (executionFailure) throw executionFailure;
+    const control: OperationControl = {
+      signal: operationController.signal,
+      setPhase,
+      heartbeat,
+      reportProgress,
+    };
+    throwIfOperationAborted(operationController.signal);
+    handlerPromise = Promise.resolve().then(() => handler(control));
+    result = await raceWithOperationSignal(handlerPromise, operationController.signal);
+    await raceWithOperationSignal(activityQueue, operationController.signal);
+    await raceWithOperationSignal(notificationQueue, operationController.signal);
+    if (executionFailure) throw executionFailure;
+    if (result.isError === true) throw classifyReportedResult(result);
+    if (progressToken !== undefined) {
+      await raceWithOperationSignal(
+        reportProgress(100, "completed"),
+        operationController.signal,
+      );
+      if (executionFailure) throw executionFailure;
+    }
+    if (operation === "index_status") {
+      const diagnostics = await raceWithOperationSignal(
+        runtime.diagnostics.snapshot(tracked.id, stallTimeoutMs),
+        operationController.signal,
+      );
+      result = {
+        ...result,
+        structuredContent: {
+          ...(result.structuredContent ?? {}),
+          mcpDiagnostics: diagnostics,
+        },
+      };
+    }
+  } catch (error: unknown) {
+    operationFailed = true;
+    const classifiedError = executionFailure ?? (
+      operationController.signal.aborted && operationController.signal.reason instanceof Error
+        ? operationController.signal.reason
+        : error
+    );
+    const details = errorDetails(
+      classifiedError,
+      operation,
+      phase,
+      Math.max(0, Date.now() - startedAt),
+    );
+    result = operationErrorResult(
+      details,
+      classifiedError instanceof ReportedToolError ? classifiedError.safeText : undefined,
+    );
+  } finally {
+    closed = true;
+    if (stallTimer) clearTimeout(stallTimer);
+    extra.signal.removeEventListener("abort", abortForClient);
+    if (operationFailed) {
+      const completeTracked = (): Promise<void> => waitForDiagnosticIo(
+        Promise.resolve().then(() => tracked.complete()),
+        stallTimeoutMs,
+      );
+      if (handlerPromise) {
+        void handlerPromise.then(
+          completeTracked,
+          completeTracked,
+        ).catch(() => undefined);
+      } else {
+        void completeTracked().catch(() => undefined);
+      }
+    } else {
+      try {
+        await waitForDiagnosticIo(
+          Promise.resolve().then(() => tracked.complete()),
+          stallTimeoutMs,
+        );
+      } catch {
+        result = operationErrorResult(errorDetails(
+          new Error("MCP operation tracking failed."),
+          operation,
+          phase,
+          Math.max(0, Date.now() - startedAt),
+        ));
+      }
+    }
+  }
+
+  return result;
+}

--- a/src/adapters/mcp/register-tools.ts
+++ b/src/adapters/mcp/register-tools.ts
@@ -1,4 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ShapeOutput, ZodRawShapeCompat } from "@modelcontextprotocol/sdk/server/zod-compat.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 
 import {
@@ -55,24 +57,47 @@ import {
   searchCodebaseWithEffectiveness,
 } from "../../tools/operations.js";
 import type { McpServerRuntime } from "./shared.js";
+import { executeMcpOperation, type McpOperationExtra } from "./operation-execution.js";
 import { TOOL_NAME } from "../../tools/tool-names.js";
+import type { OperationControl } from "../../utils/operation-control.js";
+import { runOperationPhase } from "../../utils/operation-control.js";
 
 function allowNullAsUndefined<T extends z.ZodTypeAny>(schema: T): T {
   return z.preprocess((value) => (value === null ? undefined : value), schema) as unknown as T;
 }
 
 // Knowledge-base operations report failures as plain strings prefixed with "Error: " (for
-// example a missing directory or a blocked sensitive directory) instead of throwing. Surface
-// those to MCP clients as isError so they can distinguish a refusal from success. Informational
-// results such as "Knowledge base already configured" or "Knowledge base not found" do not use
-// the prefix and remain successful results.
+// example a missing directory or a blocked sensitive directory) instead of throwing. Mark those
+// as errors so the central MCP wrapper can replace their potentially sensitive text with the
+// structured redacted envelope. Informational results such as "Knowledge base already configured"
+// or "Knowledge base not found" do not use the prefix and remain successful results.
 function knowledgeBaseResult(text: string): { content: Array<{ type: "text"; text: string }>; isError?: true } {
   const content = [{ type: "text" as const, text }];
   return text.startsWith("Error: ") ? { content, isError: true } : { content };
 }
 
+function registerMcpTool<Shape extends ZodRawShapeCompat>(
+  server: McpServer,
+  runtime: McpServerRuntime,
+  name: string,
+  description: string,
+  schema: Shape,
+  handler: (
+    args: ShapeOutput<Shape>,
+    control: OperationControl,
+  ) => CallToolResult | Promise<CallToolResult>,
+): void {
+  const callback = async (args: ShapeOutput<Shape>, extra: McpOperationExtra): Promise<CallToolResult> => executeMcpOperation(
+    runtime,
+    name,
+    extra,
+    (control) => handler(args, control),
+  );
+  Reflect.apply(server.tool, server, [name, description, schema, callback]);
+}
+
 export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): void {
-  server.tool(
+  registerMcpTool(server, runtime,
     TOOL_NAME.CODEBASE_CONTEXT,
     "PREFERRED FIRST TOOL for any question about this repository. Returns a deduplicated, file-diverse evidence pack within tokenBudget. Use before built-in code search, grep, shell search, or broad file reads. Provide from+to for a dependency path, with optional fromFilePath/toFilePath when names are ambiguous; provide symbol for a definition; or provide only query for low-token conceptual discovery. Use call_graph directly for callers or callees.",
     {
@@ -96,8 +121,8 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
       ).describe(`Maximum response tokens for this context pack (${MIN_CONTEXT_PACK_TOKEN_BUDGET}-${MAX_CONTEXT_PACK_TOKEN_BUDGET})`),
       diagnostic: z.boolean().optional().describe("Collect diagnostic routing and search traces without changing normal text output."),
     },
-    async (args) => {
-      const result = await executeCodebaseContext(runtime.projectRoot, runtime.host, args);
+    async (args, control) => {
+      const result = await executeCodebaseContext(runtime.projectRoot, runtime.host, args, control);
       return {
         content: [{ type: "text", text: result.text }],
         ...(args.diagnostic ? { structuredContent: result.details } : {}),
@@ -105,7 +130,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
     },
   );
 
-  server.tool(
+  registerMcpTool(server, runtime,
     TOOL_NAME.CODEBASE_EDIT_CONTEXT,
     "PRE-EDIT TOOL for a known or suspected symbol. Returns token-bounded target source, direct callers and callees, or a risk-marked conceptual fallback when resolution is unsafe.",
     {
@@ -119,14 +144,14 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
       tokenBudget: allowNullAsUndefined(z.number().int().min(MIN_CONTEXT_PACK_TOKEN_BUDGET).max(MAX_CONTEXT_PACK_TOKEN_BUDGET).optional()
         .default(DEFAULT_CONTEXT_PACK_TOKEN_BUDGET)),
     },
-    async (args) => {
-      const result = await executeCodebaseEditContext(runtime.projectRoot, runtime.host, args);
+    async (args, control) => {
+      const result = await executeCodebaseEditContext(runtime.projectRoot, runtime.host, args, control);
       return { content: [{ type: "text", text: result.text }] };
     },
   );
 
 
-  server.tool(
+  registerMcpTool(server, runtime,
     TOOL_NAME.CODEBASE_SEARCH,
     "FULL-CONTENT semantic retrieval. Use after codebase_peek when you need implementation text, not as the default first step. For exact identifiers or exhaustive matches use grep instead.",
     {
@@ -141,7 +166,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
       blameSince: allowNullAsUndefined(z.string().optional()).describe("Filter to chunks last changed on or after this date"),
       blameUntil: allowNullAsUndefined(z.string().optional()).describe("Filter to chunks last changed on or before this date"),
     },
-    async (args) => {
+    async (args, control) => {
       return searchCodebaseWithEffectiveness(runtime.projectRoot, runtime.host, "search", args.query, {
         limit: args.limit ?? 5,
         fileType: args.fileType,
@@ -157,11 +182,11 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
           ? "No matching code found. Try a different query or run index_codebase first."
           : `Found ${results.length} results for "${args.query}":\n\n${formatSearchResults(results, "score")}`;
         return { output: { content: [{ type: "text" as const, text }] }, text };
-      });
+      }, control);
     },
   );
 
-  server.tool(
+  registerMcpTool(server, runtime,
     TOOL_NAME.CODEBASE_PEEK,
     "DIRECT LOW-TOKEN semantic location lookup for unfamiliar-code discovery. Prefer codebase_context when the request may involve definitions or graph navigation; use this specialized tool when you only need conceptual locations.",
     {
@@ -175,7 +200,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
       blameSince: allowNullAsUndefined(z.string().optional()).describe("Filter to chunks last changed on or after this date"),
       blameUntil: allowNullAsUndefined(z.string().optional()).describe("Filter to chunks last changed on or before this date"),
     },
-    async (args) => {
+    async (args, control) => {
       return searchCodebaseWithEffectiveness(runtime.projectRoot, runtime.host, "peek", args.query, {
         limit: args.limit ?? 10,
         fileType: args.fileType,
@@ -191,11 +216,11 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
           ? "No matching code found. Try a different query or run index_codebase first."
           : `Found ${results.length} locations for "${args.query}":\n\n${formatCodebasePeek(results)}`;
         return { output: { content: [{ type: "text" as const, text }] }, text };
-      });
+      }, control);
     },
   );
 
-  server.tool(
+  registerMcpTool(server, runtime,
     TOOL_NAME.INDEX_CODEBASE,
     "Create or refresh the semantic index. Call index_status first when readiness is unknown, then use this tool only if the index is missing, stale, or incompatible. Incremental by default; force=true rebuilds everything.",
     {
@@ -204,45 +229,46 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
       dryRun: allowNullAsUndefined(z.boolean().optional().default(false)).describe("Parse the file set and report the exact embedding token total without indexing. Read-only; the index is not changed. The total is the value 'Tokens used' climbs to for a force index (and an upper bound for an incremental)."),
       verbose: allowNullAsUndefined(z.boolean().optional().default(false)).describe("Show detailed info about skipped files and parsing failures"),
     },
-    async (args) => {
-      const result = await executeIndexCodebase(runtime.projectRoot, runtime.host, args);
+    async (args, control) => {
+      const result = await executeIndexCodebase(runtime.projectRoot, runtime.host, args, undefined, control);
+      if (result.error !== undefined) throw result.error;
       return { content: [{ type: "text", text: result.text }], ...(result.isError ? { isError: true } : {}) };
     },
   );
 
-  server.tool(
+  registerMcpTool(server, runtime,
     TOOL_NAME.INDEX_STATUS,
     "START HERE once per repository task when index readiness or freshness is unknown. Reports whether semantic retrieval is ready, chunk counts, compatibility, and the embedding provider. If ready, continue with codebase_peek or implementation_lookup; otherwise run index_codebase.",
     {},
-    async () => {
-      const result = await executeIndexStatus(runtime.projectRoot, runtime.host);
+    async (_args, control) => {
+      const result = await executeIndexStatus(runtime.projectRoot, runtime.host, control);
       return { content: [{ type: "text", text: result.text }] };
     },
   );
 
-  server.tool(
+  registerMcpTool(server, runtime,
     TOOL_NAME.INDEX_HEALTH_CHECK,
     "Check index health and remove stale entries from deleted files. Run this to clean up the index after files have been deleted.",
     {},
-    async () => {
-      const result = await executeIndexHealthCheck(runtime.projectRoot, runtime.host);
+    async (_args, control) => {
+      const result = await executeIndexHealthCheck(runtime.projectRoot, runtime.host, control);
       return { content: [{ type: "text" as const, text: result.text }], ...(result.isError ? { isError: true } : {}) };
     },
   );
 
-  server.tool(
+  registerMcpTool(server, runtime,
     TOOL_NAME.INDEX_METRICS,
     "Get operational metrics plus opt-in privacy-safe repository-tool effectiveness counters. Metrics are memory-only. Set reset=true to clear them before reading. Operational metrics require debug.enabled=true and debug.metrics=true. Privacy-safe aggregates require only effectivenessMetrics.enabled=true.",
     {
       reset: z.boolean().optional().default(false).describe("Reset in-memory operational and effectiveness metrics before returning the snapshot"),
     },
-    async (args) => {
-      const result = await executeIndexMetrics(runtime.projectRoot, runtime.host, args);
+    async (args, control) => {
+      const result = await executeIndexMetrics(runtime.projectRoot, runtime.host, args, control);
       return { content: [{ type: "text", text: result.text }] };
     },
   );
 
-  server.tool(
+  registerMcpTool(server, runtime,
     TOOL_NAME.INDEX_LOGS,
     "Get recent debug logs from the codebase indexer. Requires debug.enabled=true in config.",
     {
@@ -254,13 +280,13 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
         z.enum(INDEX_LOG_LEVELS).optional(),
       ).describe("Filter by minimum log level"),
     },
-    async (args) => {
-      const result = await executeIndexLogs(runtime.projectRoot, runtime.host, args);
+    async (args, control) => {
+      const result = await executeIndexLogs(runtime.projectRoot, runtime.host, args, control);
       return { content: [{ type: "text", text: result.text }] };
     },
   );
 
-  server.tool(
+  registerMcpTool(server, runtime,
     TOOL_NAME.FIND_SIMILAR,
     "Use when you already have a code snippet and need analogous implementations, duplicates, patterns, or refactoring candidates. For a natural-language concept without example code, start with codebase_peek instead.",
     {
@@ -273,7 +299,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
       blameSince: allowNullAsUndefined(z.string().optional()).describe("Filter to chunks last changed on or after this date"),
       blameUntil: allowNullAsUndefined(z.string().optional()).describe("Filter to chunks last changed on or before this date"),
     },
-    async (args) => {
+    async (args, control) => {
       const results = await findSimilarCode(runtime.projectRoot, runtime.host, args.code, {
         limit: args.limit ?? 10,
         fileType: args.fileType,
@@ -282,7 +308,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
         excludeFile: args.excludeFile,
         blameSince: args.blameSince,
         blameUntil: args.blameUntil,
-      });
+      }, control);
 
       if (results.length === 0) {
         return { content: [{ type: "text", text: "No similar code found. Try a different snippet or run index_codebase first." }] };
@@ -292,7 +318,7 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
     },
   );
 
-  server.tool(
+  registerMcpTool(server, runtime,
     TOOL_NAME.IMPLEMENTATION_LOOKUP,
     "FIRST TOOL only for known-symbol definition questions. Returns authoritative source locations and prefers implementations over tests, docs, examples, and fixtures. Do not use for callers, callees, dependency paths, or code flow; use codebase_context with direction or from/to for those questions.",
     {
@@ -301,13 +327,13 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
       fileType: allowNullAsUndefined(z.string().optional()).describe("Filter by file extension (e.g., 'ts', 'py')"),
       directory: allowNullAsUndefined(z.string().optional()).describe("Filter by directory path (e.g., 'src/utils')"),
     },
-    async (args) => {
-      const result = await executeImplementationLookup(runtime.projectRoot, runtime.host, args);
+    async (args, control) => {
+      const result = await executeImplementationLookup(runtime.projectRoot, runtime.host, args, control);
       return { content: [{ type: "text", text: result.text }], structuredContent: result.details };
     },
   );
 
-  server.tool(
+  registerMcpTool(server, runtime,
     TOOL_NAME.CALL_GRAPH,
     "Find direct callers or callees by function or method name. Unique names resolve automatically; when duplicate names are reported, retry with filePath."
       + " Supports relationship types: Call, MethodCall, Constructor, Import, Inherits, Implements.",
@@ -322,13 +348,13 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
         z.enum(RELATIONSHIP_TYPES).optional(),
       ).describe("Filter by relationship type. Omit to show all."),
     },
-    async (args) => {
-      const result = await executeCallGraph(runtime.projectRoot, runtime.host, args);
+    async (args, control) => {
+      const result = await executeCallGraph(runtime.projectRoot, runtime.host, args, control);
       return { content: [{ type: "text", text: result.text }], structuredContent: result.details };
     },
   );
 
-  server.tool(
+  registerMcpTool(server, runtime,
     TOOL_NAME.CALL_GRAPH_PATH,
     "Find the shortest known call path between two named functions or methods. Unique names resolve automatically; when duplicate endpoints are reported, retry with fromFilePath or toFilePath.",
     {
@@ -338,12 +364,12 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
       toFilePath: allowNullAsUndefined(z.string().optional()).describe("Optional target file path used to disambiguate duplicate target names"),
       maxDepth: allowNullAsUndefined(z.number().optional().default(10)).describe("Maximum traversal depth (default: 10)"),
     },
-    async (args) => {
-      const result = await executeCallGraphPath(runtime.projectRoot, runtime.host, args);
+    async (args, control) => {
+      const result = await executeCallGraphPath(runtime.projectRoot, runtime.host, args, control);
       return { content: [{ type: "text", text: result.text }], structuredContent: result.details };
     },
   );
-  server.tool(
+  registerMcpTool(server, runtime,
     TOOL_NAME.PR_IMPACT,
     "FIRST TOOL for pull-request or branch blast-radius questions. Analyzes changed files, affected symbols, transitive dependencies, communities, hub nodes, conflicts, and risk before merging.",
     {
@@ -356,25 +382,20 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
         z.enum(["callers", "callees", "both"]).optional().default("both"),
       ).describe("Call-graph traversal direction: 'callers' for upstream, 'callees' for downstream, 'both' for union (default: both)"),
     },
-    async (args) => {
-      try {
-        const result = await getPrImpact(runtime.projectRoot, runtime.host, {
-          pr: args.pr,
-          branch: args.branch,
-          maxDepth: args.maxDepth,
-          hubThreshold: args.hubThreshold,
-          checkConflicts: args.checkConflicts,
-          direction: args.direction,
-        });
-        return { content: [{ type: "text", text: formatPrImpact(result) }] };
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        return { content: [{ type: "text", text: `Error analyzing PR impact: ${message}` }] };
-      }
+    async (args, control) => {
+      const result = await getPrImpact(runtime.projectRoot, runtime.host, {
+        pr: args.pr,
+        branch: args.branch,
+        maxDepth: args.maxDepth,
+        hubThreshold: args.hubThreshold,
+        checkConflicts: args.checkConflicts,
+        direction: args.direction,
+      }, control);
+      return { content: [{ type: "text", text: formatPrImpact(result) }] };
     },
   );
 
-  server.tool(
+  registerMcpTool(server, runtime,
     TOOL_NAME.ARCHITECTURE_CONTEXT,
     "Repository-scale architecture map backed by cited graph symbols and relationships. Use before focused retrieval when module boundaries or entry points are needed.",
     {
@@ -384,13 +405,13 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
       includeRecentActivity: allowNullAsUndefined(z.boolean().optional().default(false)).describe("Include recent activity when available"),
       tokenBudget: allowNullAsUndefined(z.number().int().min(128).max(4000).optional().default(1200)).describe("Maximum response token budget"),
     },
-    async (args) => {
-      const result = await executeArchitectureContext(runtime.projectRoot, runtime.host, args);
+    async (args, control) => {
+      const result = await executeArchitectureContext(runtime.projectRoot, runtime.host, args, control);
       return { content: [{ type: "text", text: result.text }] };
     },
   );
 
-  server.tool(
+  registerMcpTool(server, runtime,
     TOOL_NAME.CODE_COMMUNITIES,
     "Discover natural module boundaries and hub symbols using graph community detection. " +
     "Clusters symbols by call-graph connectivity, reports community memberships, identifies " +
@@ -403,13 +424,13 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
       minCoupling: allowNullAsUndefined(z.number().int().min(CODE_COMMUNITIES_MIN_COUPLING).optional().default(CODE_COMMUNITIES_MIN_COUPLING)).describe("Minimum distinct cross-community connection count to report a coupling (default: 1)"),
       couplingLimit: allowNullAsUndefined(z.number().int().min(1).max(CODE_COMMUNITIES_MAX_COUPLING_LIMIT).optional().default(CODE_COMMUNITIES_DEFAULT_COUPLING_LIMIT)).describe("Maximum number of couplings to return (default: 20)"),
     },
-    async (args) => {
-      const result = await executeCodeCommunities(runtime.projectRoot, runtime.host, args);
+    async (args, control) => {
+      const result = await executeCodeCommunities(runtime.projectRoot, runtime.host, args, control);
       return { content: [{ type: "text", text: result.text }] };
     },
   );
 
-  server.tool(
+  registerMcpTool(server, runtime,
     TOOL_NAME.ADD_KNOWLEDGE_BASE,
     "Add a folder as a knowledge base to the semantic search index. The folder is indexed "
       + "alongside the project code on the next index run. Provide an absolute path or a path "
@@ -422,25 +443,27 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
     {
       path: z.string().describe("Path to the folder to add as a knowledge base (absolute or relative to the project root)"),
     },
-    async (args) => {
+    async (args, control) => {
+      await runOperationPhase(control, "updating_config");
       const result = addKnowledgeBase(runtime.projectRoot, runtime.host, args.path);
       return knowledgeBaseResult(result);
     },
   );
 
-  server.tool(
+  registerMcpTool(server, runtime,
     TOOL_NAME.LIST_KNOWLEDGE_BASES,
     "List the configured knowledge base folders that the index includes alongside the project "
       + "code. The list is the union of project-local and user-global knowledge bases; each entry "
       + "shows the resolved path and whether it exists.",
     {},
-    async () => {
+    async (_args, control) => {
+      await runOperationPhase(control, "reading_config");
       const result = listKnowledgeBases(runtime.projectRoot, runtime.host);
       return knowledgeBaseResult(result);
     },
   );
 
-  server.tool(
+  registerMcpTool(server, runtime,
     TOOL_NAME.REMOVE_KNOWLEDGE_BASE,
     "Remove a knowledge base folder from the semantic search index and refresh the index. The "
       + "path must match a project-local configured path exactly. Knowledge bases inherited from "
@@ -448,7 +471,8 @@ export function registerMcpTools(server: McpServer, runtime: McpServerRuntime): 
     {
       path: z.string().describe("Path of the knowledge base to remove (must match a project-local configured path exactly)"),
     },
-    async (args) => {
+    async (args, control) => {
+      await runOperationPhase(control, "updating_config");
       const result = removeKnowledgeBase(runtime.projectRoot, runtime.host, args.path.trim());
       return knowledgeBaseResult(result);
     },

--- a/src/adapters/mcp/runtime-diagnostics.ts
+++ b/src/adapters/mcp/runtime-diagnostics.ts
@@ -403,24 +403,30 @@ function getProcessStore(indexRoot: string): ProcessRuntimeStore {
 
 export class McpRuntimeDiagnostics {
   private readonly sessionId = randomUUID();
-  private readonly store: ProcessRuntimeStore;
+  private readonly resolveIndexRoot: () => string;
+  private readonly stores = new Set<ProcessRuntimeStore>();
   private orderedShutdownPromise: Promise<void> | null = null;
 
-  constructor(indexRoot: string) {
-    this.store = getProcessStore(indexRoot);
+  constructor(indexRoot: string | (() => string)) {
+    this.resolveIndexRoot = typeof indexRoot === "function"
+      ? indexRoot
+      : () => indexRoot;
   }
 
   begin(operation: string): Promise<McpTrackedOperation> {
-    return this.store.begin(this.sessionId, operation);
+    return this.getCurrentStore().begin(this.sessionId, operation);
   }
 
   snapshot(excludedOperationId: string | undefined, stallTimeoutMs: number): Promise<McpDiagnosticsSnapshot> {
-    return this.store.snapshot(excludedOperationId, stallTimeoutMs);
+    return this.getCurrentStore().snapshot(excludedOperationId, stallTimeoutMs);
   }
 
   async markOrderedShutdown(): Promise<void> {
     if (this.orderedShutdownPromise) return this.orderedShutdownPromise;
-    const attempt = this.store.markSessionInterrupted(this.sessionId);
+    const attempt = Promise.all(Array.from(
+      this.stores,
+      (store) => store.markSessionInterrupted(this.sessionId),
+    )).then(() => undefined);
     this.orderedShutdownPromise = attempt;
     try {
       await attempt;
@@ -428,5 +434,11 @@ export class McpRuntimeDiagnostics {
       if (this.orderedShutdownPromise === attempt) this.orderedShutdownPromise = null;
       throw error;
     }
+  }
+
+  private getCurrentStore(): ProcessRuntimeStore {
+    const store = getProcessStore(this.resolveIndexRoot());
+    this.stores.add(store);
+    return store;
   }
 }

--- a/src/adapters/mcp/runtime-diagnostics.ts
+++ b/src/adapters/mcp/runtime-diagnostics.ts
@@ -65,6 +65,32 @@ export interface McpTrackedOperation {
   complete: () => Promise<void>;
 }
 
+function createUntrackedOperation(): McpTrackedOperation {
+  return {
+    id: randomUUID(),
+    setPhase: async () => undefined,
+    heartbeat: async () => undefined,
+    complete: async () => undefined,
+  };
+}
+
+function bestEffortTrackedOperation(operation: McpTrackedOperation): McpTrackedOperation {
+  const ignorePersistenceFailure = async (action: () => Promise<void>): Promise<void> => {
+    try {
+      await action();
+    } catch {
+      // Persistent diagnostics are optional and must not alter MCP tool behavior.
+      return;
+    }
+  };
+  return {
+    id: operation.id,
+    setPhase: (phase) => ignorePersistenceFailure(() => operation.setPhase(phase)),
+    heartbeat: () => ignorePersistenceFailure(() => operation.heartbeat()),
+    complete: () => ignorePersistenceFailure(() => operation.complete()),
+  };
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -180,6 +206,8 @@ class ProcessRuntimeStore {
   private readonly state: PersistedRuntimeState;
   private writeQueue: Promise<void> = Promise.resolve();
   private lastDiskHeartbeatAt = 0;
+  private persistenceRevision = 0;
+  private persistedRevision = 0;
 
   constructor(indexRoot: string) {
     this.runtimeDirectory = path.join(indexRoot, "mcp-runtime");
@@ -255,7 +283,10 @@ class ProcessRuntimeStore {
         interruptedFromActive(operation, "ordered_shutdown"),
       );
     }
-    if (interrupted.length === 0) return;
+    if (interrupted.length === 0) {
+      if (this.hasPendingPersistence()) await this.persist();
+      return;
+    }
     this.state.activeOperations = this.state.activeOperations.filter((entry) => entry.sessionId !== sessionId);
     try {
       await this.persist();
@@ -268,6 +299,7 @@ class ProcessRuntimeStore {
 
   async snapshot(excludedOperationId: string | undefined, stallTimeoutMs: number): Promise<McpDiagnosticsSnapshot> {
     await this.writeQueue;
+    if (this.hasPendingPersistence()) await this.persist();
     await this.ensureRuntimeDirectory();
 
     const activeOperations: McpActiveOperationDiagnostic[] = [];
@@ -360,11 +392,13 @@ class ProcessRuntimeStore {
   }
 
   private persist(): Promise<void> {
+    const revision = ++this.persistenceRevision;
     const write = this.writeQueue.then(async () => {
       this.state.updatedAt = new Date().toISOString();
       await this.ensureRuntimeDirectory();
       if (this.state.activeOperations.length === 0 && !this.state.latestInterruptedOperation) {
         await fs.rm(this.filePath, { force: true });
+        this.persistedRevision = revision;
         return;
       }
 
@@ -378,9 +412,14 @@ class ProcessRuntimeStore {
       } finally {
         await fs.rm(temporaryPath, { force: true });
       }
+      this.persistedRevision = revision;
     });
     this.writeQueue = write.catch(() => undefined);
     return write;
+  }
+
+  private hasPendingPersistence(): boolean {
+    return this.persistedRevision < this.persistenceRevision;
   }
 
   private async ensureRuntimeDirectory(): Promise<void> {
@@ -413,27 +452,39 @@ export class McpRuntimeDiagnostics {
       : () => indexRoot;
   }
 
-  begin(operation: string): Promise<McpTrackedOperation> {
-    return this.getCurrentStore().begin(this.sessionId, operation);
+  async begin(operation: string): Promise<McpTrackedOperation> {
+    try {
+      const tracked = await this.getCurrentStore().begin(this.sessionId, operation);
+      return bestEffortTrackedOperation(tracked);
+    } catch {
+      return createUntrackedOperation();
+    }
   }
 
-  snapshot(excludedOperationId: string | undefined, stallTimeoutMs: number): Promise<McpDiagnosticsSnapshot> {
-    return this.getCurrentStore().snapshot(excludedOperationId, stallTimeoutMs);
+  async snapshot(excludedOperationId: string | undefined, stallTimeoutMs: number): Promise<McpDiagnosticsSnapshot> {
+    try {
+      return await this.getCurrentStore().snapshot(excludedOperationId, stallTimeoutMs);
+    } catch {
+      return {
+        schemaVersion: DIAGNOSTICS_SCHEMA_VERSION,
+        activeOperations: [],
+      };
+    }
   }
 
   async markOrderedShutdown(): Promise<void> {
     if (this.orderedShutdownPromise) return this.orderedShutdownPromise;
-    const attempt = Promise.all(Array.from(
+    const attempt = Promise.allSettled(Array.from(
       this.stores,
       (store) => store.markSessionInterrupted(this.sessionId),
-    )).then(() => undefined);
+    )).then((results) => {
+      if (results.some((result) => result.status === "rejected")
+        && this.orderedShutdownPromise === attempt) {
+        this.orderedShutdownPromise = null;
+      }
+    });
     this.orderedShutdownPromise = attempt;
-    try {
-      await attempt;
-    } catch (error: unknown) {
-      if (this.orderedShutdownPromise === attempt) this.orderedShutdownPromise = null;
-      throw error;
-    }
+    await attempt;
   }
 
   private getCurrentStore(): ProcessRuntimeStore {

--- a/src/adapters/mcp/runtime-diagnostics.ts
+++ b/src/adapters/mcp/runtime-diagnostics.ts
@@ -1,0 +1,432 @@
+import { createHash, randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const DIAGNOSTICS_SCHEMA_VERSION = 1 as const;
+const DISK_HEARTBEAT_INTERVAL_MS = 5_000;
+const RECORD_RETENTION_MS = 7 * 24 * 60 * 60 * 1_000;
+const STARTUP_TOKEN = randomUUID().replaceAll("-", "");
+const HOSTNAME_HASH = createHash("sha256").update(os.hostname()).digest("hex").slice(0, 16);
+const RECORD_FILE_PATTERN = /^([a-f0-9]{16})-(\d+)-([a-f0-9]{32})\.json$/;
+const TEMPORARY_FILE_PATTERN = /^\.[a-f0-9]{16}-\d+-[a-f0-9]{32}\.json\.[a-f0-9-]+\.tmp$/;
+const SAFE_DIAGNOSTIC_LABEL = /^[a-z0-9_:.]{1,64}$/;
+
+type McpInterruptionCause = "ordered_shutdown" | "process_exit";
+
+export type McpOperationStatus = "active" | "suspected_stall";
+
+export interface McpActiveOperationDiagnostic {
+  operation: string;
+  phase: string;
+  startedAt: string;
+  lastActivityAt: string;
+  status: McpOperationStatus;
+}
+
+export interface McpInterruptedOperationDiagnostic {
+  operation: string;
+  phase: string;
+  startedAt: string;
+  lastActivityAt: string;
+  cause: McpInterruptionCause;
+  nextAction: string;
+}
+
+export interface McpDiagnosticsSnapshot {
+  schemaVersion: typeof DIAGNOSTICS_SCHEMA_VERSION;
+  activeOperations: McpActiveOperationDiagnostic[];
+  latestInterruptedOperation?: McpInterruptedOperationDiagnostic;
+}
+
+interface PersistedActiveOperation {
+  id: string;
+  sessionId: string;
+  operation: string;
+  phase: string;
+  startedAt: string;
+  lastActivityAt: string;
+}
+
+interface PersistedRuntimeState {
+  schemaVersion: typeof DIAGNOSTICS_SCHEMA_VERSION;
+  hostnameHash: string;
+  pid: number;
+  startupToken: string;
+  updatedAt: string;
+  activeOperations: PersistedActiveOperation[];
+  latestInterruptedOperation?: McpInterruptedOperationDiagnostic;
+}
+
+export interface McpTrackedOperation {
+  id: string;
+  setPhase: (phase: string) => Promise<void>;
+  heartbeat: () => Promise<void>;
+  complete: () => Promise<void>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isValidTimestamp(value: unknown): value is string {
+  return typeof value === "string" && Number.isFinite(Date.parse(value));
+}
+
+function isSafeDiagnosticLabel(value: unknown): value is string {
+  return typeof value === "string" && SAFE_DIAGNOSTIC_LABEL.test(value);
+}
+
+function isPersistedActiveOperation(value: unknown): value is PersistedActiveOperation {
+  if (!isRecord(value)) return false;
+  return typeof value.id === "string"
+    && typeof value.sessionId === "string"
+    && isSafeDiagnosticLabel(value.operation)
+    && isSafeDiagnosticLabel(value.phase)
+    && isValidTimestamp(value.startedAt)
+    && isValidTimestamp(value.lastActivityAt);
+}
+
+function parseInterruptedOperation(value: unknown): McpInterruptedOperationDiagnostic | null {
+  if (!isRecord(value)) return null;
+  if (!isSafeDiagnosticLabel(value.operation)
+    || !isSafeDiagnosticLabel(value.phase)
+    || !isValidTimestamp(value.startedAt)
+    || !isValidTimestamp(value.lastActivityAt)
+    || (value.cause !== "ordered_shutdown" && value.cause !== "process_exit")) {
+    return null;
+  }
+  return {
+    operation: value.operation,
+    phase: value.phase,
+    startedAt: value.startedAt,
+    lastActivityAt: value.lastActivityAt,
+    cause: value.cause,
+    nextAction: interruptionNextAction(value.cause),
+  };
+}
+
+function parseRuntimeState(value: unknown): PersistedRuntimeState | null {
+  if (!isRecord(value)
+    || value.schemaVersion !== DIAGNOSTICS_SCHEMA_VERSION
+    || typeof value.hostnameHash !== "string"
+    || !/^[a-f0-9]{16}$/.test(value.hostnameHash)
+    || typeof value.pid !== "number"
+    || !Number.isInteger(value.pid)
+    || value.pid <= 0
+    || typeof value.startupToken !== "string"
+    || !/^[a-f0-9]{32}$/.test(value.startupToken)
+    || !isValidTimestamp(value.updatedAt)
+    || !Array.isArray(value.activeOperations)
+    || !value.activeOperations.every(isPersistedActiveOperation)) {
+    return null;
+  }
+  const latest = value.latestInterruptedOperation === undefined
+    ? undefined
+    : parseInterruptedOperation(value.latestInterruptedOperation);
+  if (value.latestInterruptedOperation !== undefined && !latest) return null;
+  return {
+    schemaVersion: DIAGNOSTICS_SCHEMA_VERSION,
+    hostnameHash: value.hostnameHash,
+    pid: value.pid,
+    startupToken: value.startupToken,
+    updatedAt: value.updatedAt,
+    activeOperations: value.activeOperations,
+    ...(latest ? { latestInterruptedOperation: latest } : {}),
+  };
+}
+
+function latestInterrupted(
+  current: McpInterruptedOperationDiagnostic | undefined,
+  candidate: McpInterruptedOperationDiagnostic | undefined,
+): McpInterruptedOperationDiagnostic | undefined {
+  if (!candidate) return current;
+  if (!current) return candidate;
+  return Date.parse(candidate.lastActivityAt) >= Date.parse(current.lastActivityAt) ? candidate : current;
+}
+
+function isProcessConfirmedAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error: unknown) {
+    return Boolean(isRecord(error) && error.code !== "ESRCH");
+  }
+}
+
+function interruptedFromActive(
+  operation: PersistedActiveOperation,
+  cause: McpInterruptionCause,
+): McpInterruptedOperationDiagnostic {
+  return {
+    operation: operation.operation,
+    phase: operation.phase,
+    startedAt: operation.startedAt,
+    lastActivityAt: operation.lastActivityAt,
+    cause,
+    nextAction: interruptionNextAction(cause),
+  };
+}
+
+function interruptionNextAction(cause: McpInterruptionCause): string {
+  return cause === "ordered_shutdown"
+    ? "Retry the operation from a connected MCP client."
+    : "Start a new MCP client session, inspect index_status, and retry the operation if the index is available.";
+}
+
+class ProcessRuntimeStore {
+  readonly runtimeDirectory: string;
+  readonly filePath: string;
+  private readonly state: PersistedRuntimeState;
+  private writeQueue: Promise<void> = Promise.resolve();
+  private lastDiskHeartbeatAt = 0;
+
+  constructor(indexRoot: string) {
+    this.runtimeDirectory = path.join(indexRoot, "mcp-runtime");
+    this.filePath = path.join(
+      this.runtimeDirectory,
+      `${HOSTNAME_HASH}-${process.pid}-${STARTUP_TOKEN}.json`,
+    );
+    this.state = {
+      schemaVersion: DIAGNOSTICS_SCHEMA_VERSION,
+      hostnameHash: HOSTNAME_HASH,
+      pid: process.pid,
+      startupToken: STARTUP_TOKEN,
+      updatedAt: new Date().toISOString(),
+      activeOperations: [],
+    };
+  }
+
+  async begin(sessionId: string, operation: string): Promise<McpTrackedOperation> {
+    const now = new Date().toISOString();
+    const tracked: PersistedActiveOperation = {
+      id: randomUUID(),
+      sessionId,
+      operation,
+      phase: "starting",
+      startedAt: now,
+      lastActivityAt: now,
+    };
+    this.state.activeOperations.push(tracked);
+    try {
+      await this.persist();
+    } catch (error: unknown) {
+      this.state.activeOperations = this.state.activeOperations.filter((entry) => entry.id !== tracked.id);
+      throw error;
+    }
+
+    let completed = false;
+    return {
+      id: tracked.id,
+      setPhase: async (phase: string): Promise<void> => {
+        if (completed) return;
+        const active = this.state.activeOperations.find((entry) => entry.id === tracked.id);
+        if (!active) return;
+        active.phase = phase;
+        active.lastActivityAt = new Date().toISOString();
+        await this.persist();
+      },
+      heartbeat: async (): Promise<void> => {
+        if (completed) return;
+        const active = this.state.activeOperations.find((entry) => entry.id === tracked.id);
+        if (!active) return;
+        active.lastActivityAt = new Date().toISOString();
+        const nowMs = Date.now();
+        if (nowMs - this.lastDiskHeartbeatAt >= DISK_HEARTBEAT_INTERVAL_MS) {
+          this.lastDiskHeartbeatAt = nowMs;
+          await this.persist();
+        }
+      },
+      complete: async (): Promise<void> => {
+        if (completed) return;
+        completed = true;
+        this.state.activeOperations = this.state.activeOperations.filter((entry) => entry.id !== tracked.id);
+        await this.persist();
+      },
+    };
+  }
+
+  async markSessionInterrupted(sessionId: string): Promise<void> {
+    const interrupted = this.state.activeOperations.filter((entry) => entry.sessionId === sessionId);
+    const previousLatest = this.state.latestInterruptedOperation;
+    for (const operation of interrupted) {
+      this.state.latestInterruptedOperation = latestInterrupted(
+        this.state.latestInterruptedOperation,
+        interruptedFromActive(operation, "ordered_shutdown"),
+      );
+    }
+    if (interrupted.length === 0) return;
+    this.state.activeOperations = this.state.activeOperations.filter((entry) => entry.sessionId !== sessionId);
+    try {
+      await this.persist();
+    } catch (error: unknown) {
+      this.state.activeOperations.push(...interrupted);
+      this.state.latestInterruptedOperation = previousLatest;
+      throw error;
+    }
+  }
+
+  async snapshot(excludedOperationId: string | undefined, stallTimeoutMs: number): Promise<McpDiagnosticsSnapshot> {
+    await this.writeQueue;
+    await this.ensureRuntimeDirectory();
+
+    const activeOperations: McpActiveOperationDiagnostic[] = [];
+    let interrupted = this.state.latestInterruptedOperation;
+    const now = Date.now();
+    const addActive = (operation: PersistedActiveOperation, persistedByOtherProcess = false): void => {
+      if (operation.id === excludedOperationId) return;
+      const lastActivity = Date.parse(operation.lastActivityAt);
+      const inactivityThreshold = stallTimeoutMs + (persistedByOtherProcess ? DISK_HEARTBEAT_INTERVAL_MS : 0);
+      activeOperations.push({
+        operation: operation.operation,
+        phase: operation.phase,
+        startedAt: operation.startedAt,
+        lastActivityAt: operation.lastActivityAt,
+        status: stallTimeoutMs > 0 && Number.isFinite(lastActivity) && now - lastActivity >= inactivityThreshold
+          ? "suspected_stall"
+          : "active",
+      });
+    };
+
+    for (const operation of this.state.activeOperations) addActive(operation);
+
+    const entries = await fs.readdir(this.runtimeDirectory, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      const recordPath = path.join(this.runtimeDirectory, entry.name);
+      const recordMatch = RECORD_FILE_PATTERN.exec(entry.name);
+      if (!recordMatch) {
+        if (TEMPORARY_FILE_PATTERN.test(entry.name)) {
+          try {
+            const temporaryStat = await fs.stat(recordPath);
+            if (now - temporaryStat.mtimeMs > RECORD_RETENTION_MS) {
+              await fs.rm(recordPath, { force: true });
+            }
+          } catch {
+            continue;
+          }
+        }
+        continue;
+      }
+      if (recordPath === this.filePath) continue;
+
+      try {
+        const recordStat = await fs.stat(recordPath);
+        if (now - recordStat.mtimeMs > RECORD_RETENTION_MS) {
+          await fs.rm(recordPath, { force: true });
+          continue;
+        }
+      } catch {
+        continue;
+      }
+
+      let state: PersistedRuntimeState | null = null;
+      try {
+        state = parseRuntimeState(JSON.parse(await fs.readFile(recordPath, "utf8")));
+      } catch {
+        continue;
+      }
+      if (!state) continue;
+      if (state.hostnameHash !== recordMatch[1]
+        || state.pid !== Number(recordMatch[2])
+        || state.startupToken !== recordMatch[3]) {
+        continue;
+      }
+
+      const updatedAt = Date.parse(state.updatedAt);
+      if (Number.isFinite(updatedAt) && now - updatedAt > RECORD_RETENTION_MS) {
+        await fs.rm(recordPath, { force: true });
+        continue;
+      }
+
+      interrupted = latestInterrupted(interrupted, state.latestInterruptedOperation);
+      const localProcess = state.hostnameHash === HOSTNAME_HASH;
+      const confirmedDead = localProcess && !isProcessConfirmedAlive(state.pid);
+      if (confirmedDead) {
+        for (const operation of state.activeOperations) {
+          interrupted = latestInterrupted(interrupted, interruptedFromActive(operation, "process_exit"));
+        }
+        continue;
+      }
+      for (const operation of state.activeOperations) addActive(operation, true);
+    }
+
+    activeOperations.sort((left, right) => left.startedAt.localeCompare(right.startedAt));
+    return {
+      schemaVersion: DIAGNOSTICS_SCHEMA_VERSION,
+      activeOperations,
+      ...(interrupted ? { latestInterruptedOperation: interrupted } : {}),
+    };
+  }
+
+  private persist(): Promise<void> {
+    const write = this.writeQueue.then(async () => {
+      this.state.updatedAt = new Date().toISOString();
+      await this.ensureRuntimeDirectory();
+      if (this.state.activeOperations.length === 0 && !this.state.latestInterruptedOperation) {
+        await fs.rm(this.filePath, { force: true });
+        return;
+      }
+
+      const temporaryPath = path.join(
+        this.runtimeDirectory,
+        `.${path.basename(this.filePath)}.${randomUUID()}.tmp`,
+      );
+      try {
+        await fs.writeFile(temporaryPath, `${JSON.stringify(this.state)}\n`, { encoding: "utf8", mode: 0o600 });
+        await fs.rename(temporaryPath, this.filePath);
+      } finally {
+        await fs.rm(temporaryPath, { force: true });
+      }
+    });
+    this.writeQueue = write.catch(() => undefined);
+    return write;
+  }
+
+  private async ensureRuntimeDirectory(): Promise<void> {
+    await fs.mkdir(this.runtimeDirectory, { recursive: true, mode: 0o700 });
+    await fs.chmod(this.runtimeDirectory, 0o700);
+  }
+}
+
+const processStores = new Map<string, ProcessRuntimeStore>();
+
+function getProcessStore(indexRoot: string): ProcessRuntimeStore {
+  const normalizedRoot = path.resolve(indexRoot);
+  let store = processStores.get(normalizedRoot);
+  if (!store) {
+    store = new ProcessRuntimeStore(normalizedRoot);
+    processStores.set(normalizedRoot, store);
+  }
+  return store;
+}
+
+export class McpRuntimeDiagnostics {
+  private readonly sessionId = randomUUID();
+  private readonly store: ProcessRuntimeStore;
+  private orderedShutdownPromise: Promise<void> | null = null;
+
+  constructor(indexRoot: string) {
+    this.store = getProcessStore(indexRoot);
+  }
+
+  begin(operation: string): Promise<McpTrackedOperation> {
+    return this.store.begin(this.sessionId, operation);
+  }
+
+  snapshot(excludedOperationId: string | undefined, stallTimeoutMs: number): Promise<McpDiagnosticsSnapshot> {
+    return this.store.snapshot(excludedOperationId, stallTimeoutMs);
+  }
+
+  async markOrderedShutdown(): Promise<void> {
+    if (this.orderedShutdownPromise) return this.orderedShutdownPromise;
+    const attempt = this.store.markSessionInterrupted(this.sessionId);
+    this.orderedShutdownPromise = attempt;
+    try {
+      await attempt;
+    } catch (error: unknown) {
+      if (this.orderedShutdownPromise === attempt) this.orderedShutdownPromise = null;
+      throw error;
+    }
+  }
+}

--- a/src/adapters/mcp/server.ts
+++ b/src/adapters/mcp/server.ts
@@ -2,10 +2,12 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import type { ParsedCodebaseIndexConfig } from "../../config/schema.js";
 import type { HostMode } from "../../config/host.js";
+import { resolveProjectIndexPath } from "../../config/paths.js";
 import { MCP_SERVER_CURRENT_NAME } from "../../identity-catalog.js";
 import { getPackageVersion } from "../../package-metadata.js";
 import { registerMcpPrompts } from "./register-prompts.js";
 import { registerMcpTools } from "./register-tools.js";
+import { McpRuntimeDiagnostics } from "./runtime-diagnostics.js";
 import { initializeTools } from "../../tools/operations.js";
 import {
   attachBackgroundWorkerWatcher,
@@ -26,6 +28,11 @@ import {
 
 const mcpWorkerReferences = new Map<string, number>();
 const mcpWorkerTeardowns = new Map<string, Promise<void>>();
+const mcpOrderedShutdownMarkers = new WeakMap<McpServer, () => Promise<void>>();
+
+export function markMcpServerOrderedShutdown(server: McpServer): Promise<void> {
+  return mcpOrderedShutdownMarkers.get(server)?.() ?? Promise.resolve();
+}
 
 function retainMcpBackgroundWorker(projectRoot: string, host: HostMode): void {
   const key = getBackgroundWorkerProjectKey(projectRoot, host);
@@ -126,6 +133,7 @@ export function createMcpServer(
   });
 
   initializeTools(projectRoot, config, host, { preserveManagedWorker: true });
+  const diagnostics = new McpRuntimeDiagnostics(resolveProjectIndexPath(projectRoot, config.scope, host));
   const backgroundWorker = configureMcpBackgroundWorker(projectRoot, config, host);
   if (backgroundWorker.managesWorker) {
     retainMcpBackgroundWorker(projectRoot, host);
@@ -138,27 +146,49 @@ export function createMcpServer(
       : Promise.resolve();
     return stopCoordinationPromise;
   };
+  const markOrderedShutdown = (): Promise<void> => diagnostics.markOrderedShutdown();
+  mcpOrderedShutdownMarkers.set(server, markOrderedShutdown);
   const closeProtocol = server.server.close.bind(server.server);
-  server.server.close = async (): Promise<void> => {
-    await stopCoordination();
-    await closeProtocol();
+  let closePromise: Promise<void> | null = null;
+  const close = (): Promise<void> => {
+    closePromise ??= (async (): Promise<void> => {
+      const preparationResults = await Promise.allSettled([
+        markOrderedShutdown(),
+        stopCoordination(),
+      ]);
+      let protocolError: unknown;
+      try {
+        await closeProtocol();
+      } catch (error: unknown) {
+        protocolError = error;
+      }
+      const errors = preparationResults
+        .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+        .map((result) => result.reason as unknown);
+      if (protocolError !== undefined) errors.push(protocolError);
+      if (errors.length === 1) throw errors[0];
+      if (errors.length > 1) throw new AggregateError(errors, "Failed to close the MCP server cleanly.");
+    })();
+    return closePromise;
   };
-  const closeServer = server.close.bind(server);
-  server.close = async (): Promise<void> => {
-    await stopCoordination();
-    await closeServer();
-  };
+  server.server.close = close;
+  server.close = close;
   const onServerClose = server.server.onclose;
   server.server.onclose = () => {
     onServerClose?.();
-    void stopCoordination().catch((error: unknown) => {
-      console.error("[codebase-index] Failed to stop MCP background worker after transport close:", error);
+    void Promise.allSettled([markOrderedShutdown(), stopCoordination()]).then((results) => {
+      for (const result of results) {
+        if (result.status === "rejected") {
+          console.error("[codebase-index] Failed to stop MCP background worker after transport close:", result.reason);
+        }
+      }
     });
   };
 
   registerMcpTools(server, {
     projectRoot,
     host,
+    diagnostics,
   });
 
   registerMcpPrompts(server);

--- a/src/adapters/mcp/server.ts
+++ b/src/adapters/mcp/server.ts
@@ -5,6 +5,7 @@ import type { HostMode } from "../../config/host.js";
 import { resolveProjectIndexPath } from "../../config/paths.js";
 import { MCP_SERVER_CURRENT_NAME } from "../../identity-catalog.js";
 import { getPackageVersion } from "../../package-metadata.js";
+import { getRuntimeConfigForProject } from "../../tools/operation-runtime.js";
 import { registerMcpPrompts } from "./register-prompts.js";
 import { registerMcpTools } from "./register-tools.js";
 import { McpRuntimeDiagnostics } from "./runtime-diagnostics.js";
@@ -133,7 +134,11 @@ export function createMcpServer(
   });
 
   initializeTools(projectRoot, config, host, { preserveManagedWorker: true });
-  const diagnostics = new McpRuntimeDiagnostics(resolveProjectIndexPath(projectRoot, config.scope, host));
+  const diagnostics = new McpRuntimeDiagnostics(() => resolveProjectIndexPath(
+    projectRoot,
+    getRuntimeConfigForProject(projectRoot, host).scope,
+    host,
+  ));
   const backgroundWorker = configureMcpBackgroundWorker(projectRoot, config, host);
   if (backgroundWorker.managesWorker) {
     retainMcpBackgroundWorker(projectRoot, host);

--- a/src/adapters/mcp/shared.ts
+++ b/src/adapters/mcp/shared.ts
@@ -1,4 +1,5 @@
 import type { HostMode } from "../../config/host.js";
+import type { McpRuntimeDiagnostics } from "./runtime-diagnostics.js";
 
 export const MAX_CONTENT_LINES = 30;
 
@@ -14,4 +15,5 @@ export function truncateContent(content: string): string {
 export interface McpServerRuntime {
   projectRoot: string;
   host: HostMode;
+  diagnostics: McpRuntimeDiagnostics;
 }

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -1,9 +1,16 @@
 import type {
   DebugConfig,
   IndexingConfig,
+  McpConfig,
   RerankerProvider,
   SearchConfig,
 } from "./schema.js";
+
+export function getDefaultMcpConfig(): McpConfig {
+  return {
+    stallTimeoutMs: 300_000,
+  };
+}
 
 export function getDefaultIndexingConfig(): IndexingConfig {
   return {

--- a/src/config/merger.ts
+++ b/src/config/merger.ts
@@ -16,6 +16,7 @@ const PROJECT_OVERRIDE_KEYS = [
   "search",
   "debug",
   "effectivenessMetrics",
+  "mcp",
   "scope",
 ] as const;
 
@@ -84,7 +85,7 @@ function validateConfigLayerShape(rawConfig: unknown, filePath: string): Record<
     throw new Error(`Config file ${filePath} field 'exclude' must be an array of strings.`);
   }
 
-  for (const section of ["customProvider", "indexing", "search", "debug", "effectivenessMetrics", "reranker"] as const) {
+  for (const section of ["customProvider", "indexing", "search", "debug", "effectivenessMetrics", "reranker", "mcp"] as const) {
     const value = rawConfig[section];
     if (value !== undefined && !isRecord(value)) {
       throw new Error(`Config file ${filePath} field '${section}' must be an object.`);

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -4,6 +4,7 @@ import { AUTO_DETECT_PROVIDER_ORDER, DEFAULT_INCLUDE, DEFAULT_EXCLUDE, EMBEDDING
 import {
   getDefaultDebugConfig,
   getDefaultIndexingConfig,
+  getDefaultMcpConfig,
   getDefaultRerankerBaseUrl,
   getDefaultSearchConfig,
 } from "./defaults.js";
@@ -135,6 +136,16 @@ export interface EffectivenessMetricsConfig {
   enabled: boolean;
 }
 
+export interface McpConfig {
+  /**
+   * Maximum inactivity period for an MCP operation. A value of 0 disables
+   * stall detection. Positive values are normalized to at least 1000 ms.
+   */
+  stallTimeoutMs: number;
+}
+
+export const MAX_MCP_STALL_TIMEOUT_MS = 2_147_483_647;
+
 export interface CustomProviderConfig {
   /** Base URL of the OpenAI-compatible embeddings API. The path /embeddings is appended automatically (e.g. "http://localhost:11434/v1", "https://api.example.com/v1") */
   baseUrl: string;
@@ -187,6 +198,8 @@ export interface CodebaseIndexConfig {
   effectivenessMetrics?: Partial<EffectivenessMetricsConfig>;
   /** Reranking configuration for improving search result quality */
   reranker?: Partial<RerankerConfig>;
+  /** MCP transport and long-running operation behavior. */
+  mcp?: Partial<McpConfig>;
   /** External directories to index as knowledge bases (absolute or relative paths) */
   knowledgeBases?: string[];
   /** Override the default include patterns (replaces defaults) */
@@ -202,6 +215,7 @@ export type ParsedCodebaseIndexConfig = CodebaseIndexConfig & {
   search: SearchConfig;
   debug: DebugConfig;
   effectivenessMetrics: EffectivenessMetricsConfig;
+  mcp: McpConfig;
   reranker?: RerankerConfig;
   knowledgeBases: string[];
   additionalInclude: string[];
@@ -218,6 +232,7 @@ export function parseConfig(raw: unknown): ParsedCodebaseIndexConfig {
   const defaultIndexing = getDefaultIndexingConfig();
   const defaultSearch = getDefaultSearchConfig();
   const defaultDebug = getDefaultDebugConfig();
+  const defaultMcp = getDefaultMcpConfig();
 
   const rawIndexing = (input.indexing && typeof input.indexing === "object" ? input.indexing : {}) as Record<string, unknown>;
   const indexing: IndexingConfig = {
@@ -294,6 +309,21 @@ export function parseConfig(raw: unknown): ParsedCodebaseIndexConfig {
   ) as Record<string, unknown>;
   const effectivenessMetrics: EffectivenessMetricsConfig = {
     enabled: rawEffectivenessMetrics.enabled === true,
+  };
+
+  const rawMcp = (input.mcp && typeof input.mcp === "object" ? input.mcp : {}) as Record<string, unknown>;
+  const configuredStallTimeout = rawMcp.stallTimeoutMs;
+  const mcp: McpConfig = {
+    stallTimeoutMs: typeof configuredStallTimeout === "number"
+      && Number.isFinite(configuredStallTimeout)
+      && configuredStallTimeout >= 0
+      ? configuredStallTimeout === 0
+        ? 0
+        : Math.min(
+          MAX_MCP_STALL_TIMEOUT_MS,
+          Math.max(1000, Math.floor(configuredStallTimeout)),
+        )
+      : defaultMcp.stallTimeoutMs,
   };
 
   const rawKnowledgeBases = input.knowledgeBases;
@@ -438,6 +468,7 @@ export function parseConfig(raw: unknown): ParsedCodebaseIndexConfig {
     search,
     debug,
     effectivenessMetrics,
+    mcp,
     reranker,
     knowledgeBases,
   };

--- a/src/embeddings/provider-types.ts
+++ b/src/embeddings/provider-types.ts
@@ -1,6 +1,32 @@
 import { type BaseModelInfo } from "../config/schema.js";
 
 import { type ProviderCredentials } from "./detector.js";
+import { ProviderRequestError } from "../utils/operation-control.js";
+
+export interface EmbeddingRequestOptions {
+  signal?: AbortSignal;
+  setPhase?: (phase: string) => void | Promise<void>;
+  heartbeat?: () => void | Promise<void>;
+}
+
+export function validateEmbeddingVectors(
+  value: unknown,
+  expectedCount: number,
+  expectedDimensions: number,
+): number[][] {
+  if (!Array.isArray(value)
+    || value.length !== expectedCount
+    || value.some((embedding) => !Array.isArray(embedding)
+      || embedding.length !== expectedDimensions
+      || embedding.some((component) => typeof component !== "number" || !Number.isFinite(component)))) {
+    throw new ProviderRequestError({
+      kind: "malformed_response",
+      retryable: false,
+      message: "The embedding provider returned vectors that do not match the configured contract.",
+    });
+  }
+  return value as number[][];
+}
 
 export interface EmbeddingResult {
   embedding: number[];
@@ -13,9 +39,9 @@ export interface EmbeddingBatchResult {
 }
 
 export interface EmbeddingProviderInterface {
-  embedQuery(query: string): Promise<EmbeddingResult>;
-  embedDocument(document: string): Promise<EmbeddingResult>;
-  embedBatch(texts: string[]): Promise<EmbeddingBatchResult>;
+  embedQuery(query: string, options?: EmbeddingRequestOptions): Promise<EmbeddingResult>;
+  embedDocument(document: string, options?: EmbeddingRequestOptions): Promise<EmbeddingResult>;
+  embedBatch(texts: string[], options?: EmbeddingRequestOptions): Promise<EmbeddingBatchResult>;
   getModelInfo(): BaseModelInfo;
 }
 
@@ -26,16 +52,16 @@ export abstract class BaseEmbeddingProvider<TModelInfo extends BaseModelInfo>
     protected readonly modelInfo: TModelInfo
   ) { }
 
-  public async embedQuery(query: string): Promise<EmbeddingResult> {
-    const result = await this.embedBatch([query]);
+  public async embedQuery(query: string, options?: EmbeddingRequestOptions): Promise<EmbeddingResult> {
+    const result = await this.embedBatch([query], options);
     return {
       embedding: result.embeddings[0],
       tokensUsed: result.totalTokensUsed,
     };
   }
 
-  public async embedDocument(document: string): Promise<EmbeddingResult> {
-    const result = await this.embedBatch([document]);
+  public async embedDocument(document: string, options?: EmbeddingRequestOptions): Promise<EmbeddingResult> {
+    const result = await this.embedBatch([document], options);
     return {
       embedding: result.embeddings[0],
       tokensUsed: result.totalTokensUsed,
@@ -46,7 +72,7 @@ export abstract class BaseEmbeddingProvider<TModelInfo extends BaseModelInfo>
     return this.modelInfo;
   }
 
-  public abstract embedBatch(texts: string[]): Promise<EmbeddingBatchResult>;
+  public abstract embedBatch(texts: string[], options?: EmbeddingRequestOptions): Promise<EmbeddingBatchResult>;
 }
 
 /**
@@ -54,9 +80,9 @@ export abstract class BaseEmbeddingProvider<TModelInfo extends BaseModelInfo>
  * The Indexer's pRetry config uses instanceof to bail immediately on these errors
  * instead of retrying — preventing long retry loops on bad API keys or invalid models.
  */
-export class CustomProviderNonRetryableError extends Error {
-  public constructor(message: string) {
-    super(message);
+export class CustomProviderNonRetryableError extends ProviderRequestError {
+  public constructor(message: string, statusCode?: number) {
+    super({ message, statusCode, retryable: false });
     this.name = "CustomProviderNonRetryableError";
   }
 }

--- a/src/embeddings/providers/custom.ts
+++ b/src/embeddings/providers/custom.ts
@@ -3,8 +3,16 @@ import {
   BaseEmbeddingProvider,
   CustomProviderNonRetryableError,
   type EmbeddingBatchResult,
+  type EmbeddingRequestOptions,
+  validateEmbeddingVectors,
 } from "../provider-types.js";
-import { sanitizeUrlForError, validateExternalUrl } from "../../utils/url-validation.js";
+import { validateExternalUrl } from "../../utils/url-validation.js";
+import {
+  createProviderRequestSignal,
+  ProviderRequestError,
+  raceWithOperationSignal,
+  throwIfOperationAborted,
+} from "../../utils/operation-control.js";
 
 export class CustomEmbeddingProvider extends BaseEmbeddingProvider<CustomModelInfo> {
   public constructor(credentials: ProviderCredentials, modelInfo: CustomModelInfo) {
@@ -25,7 +33,7 @@ export class CustomEmbeddingProvider extends BaseEmbeddingProvider<CustomModelIn
     return batches;
   }
 
-  private async embedRequest(texts: string[]): Promise<EmbeddingBatchResult> {
+  private async embedRequest(texts: string[], options?: EmbeddingRequestOptions): Promise<EmbeddingBatchResult> {
     if (texts.length === 0) {
       return {
         embeddings: [],
@@ -46,82 +54,118 @@ export class CustomEmbeddingProvider extends BaseEmbeddingProvider<CustomModelIn
     const urlCheck = validateExternalUrl(fullUrl);
     if (!urlCheck.valid) {
       throw new CustomProviderNonRetryableError(
-        `Custom embedding provider URL blocked (SSRF protection): ${urlCheck.reason}`
+        "Custom embedding provider URL was rejected by the outbound request policy."
       );
     }
 
     const timeoutMs = this.modelInfo.timeoutMs;
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    const requestSignal = createProviderRequestSignal(options?.signal, timeoutMs);
 
-    let response: Response;
+    let responseReceived = false;
     try {
-      response = await fetch(fullUrl, {
-        method: "POST",
-        headers,
-        body: JSON.stringify({
-          model: this.modelInfo.model,
-          input: texts,
-        }),
-        signal: controller.signal,
-      });
-    } catch (error: unknown) {
-      if (error instanceof Error && error.name === "AbortError") {
-        throw new Error(`Custom embedding API request timed out after ${timeoutMs}ms for ${sanitizeUrlForError(fullUrl)}`);
-      }
-      throw error;
-    } finally {
-      clearTimeout(timeout);
-    }
+      return await raceWithOperationSignal((async () => {
+        const response = await fetch(fullUrl, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            model: this.modelInfo.model,
+            input: texts,
+          }),
+          signal: requestSignal.signal,
+        });
+        responseReceived = true;
 
-    if (!response.ok) {
-      const errorText = (await response.text()).slice(0, 500);
-      if (response.status >= 400 && response.status < 500 && response.status !== 429) {
-        throw new CustomProviderNonRetryableError(`Custom embedding API error (non-retryable): ${response.status} - ${errorText}`);
-      }
-      throw new Error(`Custom embedding API error: ${response.status} - ${errorText}`);
-    }
-
-    const data = await response.json() as {
-      data?: Array<{ embedding: number[] }>;
-      usage?: { total_tokens: number };
-    };
-
-    if (data.data && Array.isArray(data.data)) {
-      if (data.data.length > 0) {
-        const actualDims = data.data[0].embedding.length;
-        if (actualDims !== this.modelInfo.dimensions) {
-          throw new Error(
-            `Dimension mismatch: customProvider.dimensions is ${this.modelInfo.dimensions}, ` +
-            `but the API returned vectors with ${actualDims} dimensions. ` +
-            `Update your config to match the model's actual output dimensions.`
-          );
+        if (!response.ok) {
+          await response.text();
+          if (response.status >= 400 && response.status < 500 && response.status !== 429) {
+            throw new CustomProviderNonRetryableError(
+              `Custom embedding provider returned HTTP ${response.status}.`,
+              response.status,
+            );
+          }
+          throw new ProviderRequestError({
+            statusCode: response.status,
+            message: `Custom embedding provider returned HTTP ${response.status}.`,
+          });
         }
-      }
 
-      if (data.data.length !== texts.length) {
-        throw new Error(
-          `Embedding count mismatch: sent ${texts.length} texts but received ${data.data.length} embeddings. ` +
-          `The custom embedding server may not support batch input.`
+        let data: {
+          data?: Array<{ embedding: number[] }>;
+          usage?: { total_tokens: number };
+        };
+        try {
+          data = await response.json() as typeof data;
+        } catch {
+          throw new ProviderRequestError({
+            kind: "malformed_response",
+            retryable: true,
+            message: "Custom embedding provider returned malformed JSON.",
+          });
+        }
+
+        if (data.data && Array.isArray(data.data)) {
+          const embeddings = validateEmbeddingVectors(
+            data.data.map((entry) => entry?.embedding),
+            texts.length,
+            this.modelInfo.dimensions,
+          );
+
+          return {
+            embeddings,
+            totalTokensUsed: data.usage?.total_tokens ?? texts.reduce((sum, t) => sum + Math.ceil(t.length / 4), 0),
+          };
+        }
+
+        throw new CustomProviderNonRetryableError(
+          "Custom embedding API returned unexpected response format. Expected OpenAI-compatible format with data[].embedding.",
         );
+      })(), requestSignal.signal);
+    } catch (error: unknown) {
+      if (requestSignal.signal.aborted) {
+        if (options?.signal?.aborted) throwIfOperationAborted(options.signal);
+        throw new ProviderRequestError({
+          timedOut: true,
+          retryable: true,
+          message: `Custom embedding provider request timed out after ${timeoutMs}ms.`,
+        });
       }
-
-      return {
-        embeddings: data.data.map((d) => d.embedding),
-        totalTokensUsed: data.usage?.total_tokens ?? texts.reduce((sum, t) => sum + Math.ceil(t.length / 4), 0),
-      };
+      if (error instanceof CustomProviderNonRetryableError || error instanceof ProviderRequestError) {
+        throw error;
+      }
+      if (error instanceof Error && error.name === "AbortError") {
+        throw new ProviderRequestError({
+          timedOut: true,
+          retryable: true,
+          message: `Custom embedding provider request timed out after ${timeoutMs}ms.`,
+        });
+      }
+      if (responseReceived) {
+        throw new ProviderRequestError({
+          kind: "malformed_response",
+          retryable: true,
+          message: "Custom embedding provider returned an invalid response.",
+        });
+      }
+      throw new ProviderRequestError({
+        retryable: true,
+        message: "Custom embedding provider request failed.",
+      });
+    } finally {
+      requestSignal.dispose();
     }
-
-    throw new Error("Custom embedding API returned unexpected response format. Expected OpenAI-compatible format with data[].embedding.");
   }
 
-  public async embedBatch(texts: string[]): Promise<EmbeddingBatchResult> {
+  public async embedBatch(texts: string[], options?: EmbeddingRequestOptions): Promise<EmbeddingBatchResult> {
+    throwIfOperationAborted(options?.signal);
+    await options?.setPhase?.("embedding");
+    throwIfOperationAborted(options?.signal);
     const requestBatches = this.splitIntoRequestBatches(texts);
     const embeddings: number[][] = [];
     let totalTokensUsed = 0;
 
     for (const batch of requestBatches) {
-      const result = await this.embedRequest(batch);
+      throwIfOperationAborted(options?.signal);
+      const result = await this.embedRequest(batch, options);
       embeddings.push(...result.embeddings);
       totalTokensUsed += result.totalTokensUsed;
     }

--- a/src/embeddings/providers/google.ts
+++ b/src/embeddings/providers/google.ts
@@ -4,11 +4,20 @@ import { type ProviderCredentials } from "../detector.js";
 import {
   BaseEmbeddingProvider,
   type EmbeddingBatchResult,
+  type EmbeddingRequestOptions,
   type EmbeddingResult,
+  validateEmbeddingVectors,
 } from "../provider-types.js";
+import {
+  createProviderRequestSignal,
+  ProviderRequestError,
+  raceWithOperationSignal,
+  throwIfOperationAborted,
+} from "../../utils/operation-control.js";
 
 export class GoogleEmbeddingProvider extends BaseEmbeddingProvider<EmbeddingProviderModelInfo["google"]> {
   private static readonly BATCH_SIZE = 20;
+  private static readonly REQUEST_TIMEOUT_MS = 120_000;
 
   public constructor(
     credentials: ProviderCredentials,
@@ -17,7 +26,7 @@ export class GoogleEmbeddingProvider extends BaseEmbeddingProvider<EmbeddingProv
     super(credentials, modelInfo);
   }
 
-  public async embedQuery(query: string): Promise<EmbeddingResult> {
+  public async embedQuery(query: string, options?: EmbeddingRequestOptions): Promise<EmbeddingResult> {
     const taskType = this.modelInfo.model === "gemini-embedding-001" && this.modelInfo.taskAble
       ? "CODE_RETRIEVAL_QUERY"
       : undefined;
@@ -26,27 +35,27 @@ export class GoogleEmbeddingProvider extends BaseEmbeddingProvider<EmbeddingProv
         ? `task: code retrieval | query: ${query}`
         : query,
     ];
-    const result = await this.embedWithTaskType(texts, taskType);
+    const result = await this.embedWithTaskType(texts, taskType, options);
     return {
       embedding: result.embeddings[0],
       tokensUsed: result.totalTokensUsed,
     };
   }
 
-  public async embedDocument(document: string): Promise<EmbeddingResult> {
+  public async embedDocument(document: string, options?: EmbeddingRequestOptions): Promise<EmbeddingResult> {
     const taskType = this.modelInfo.model === "gemini-embedding-001" && this.modelInfo.taskAble
       ? "RETRIEVAL_DOCUMENT"
       : undefined;
     const result = await this.embedWithTaskType([
       this.modelInfo.model === "gemini-embedding-2" ? `title: none | text: ${document}` : document,
-    ], taskType);
+    ], taskType, options);
     return {
       embedding: result.embeddings[0],
       tokensUsed: result.totalTokensUsed,
     };
   }
 
-  public async embedBatch(texts: string[]): Promise<EmbeddingBatchResult> {
+  public async embedBatch(texts: string[], options?: EmbeddingRequestOptions): Promise<EmbeddingBatchResult> {
     const taskType = this.modelInfo.model === "gemini-embedding-001" && this.modelInfo.taskAble
       ? "RETRIEVAL_DOCUMENT"
       : undefined;
@@ -54,13 +63,17 @@ export class GoogleEmbeddingProvider extends BaseEmbeddingProvider<EmbeddingProv
       ? texts.map((text) => `title: none | text: ${text}`)
       : texts;
 
-    return this.embedWithTaskType(formattedTexts, taskType);
+    return this.embedWithTaskType(formattedTexts, taskType, options);
   }
 
   private async embedWithTaskType(
     texts: string[],
-    taskType?: string
+    taskType?: string,
+    options?: EmbeddingRequestOptions,
   ): Promise<EmbeddingBatchResult> {
+    throwIfOperationAborted(options?.signal);
+    await options?.setPhase?.("embedding");
+    throwIfOperationAborted(options?.signal);
     const batches: string[][] = [];
     for (let i = 0; i < texts.length; i += GoogleEmbeddingProvider.BATCH_SIZE) {
       batches.push(texts.slice(i, i + GoogleEmbeddingProvider.BATCH_SIZE));
@@ -77,31 +90,83 @@ export class GoogleEmbeddingProvider extends BaseEmbeddingProvider<EmbeddingProv
           outputDimensionality: this.modelInfo.dimensions,
         }));
 
-        const response = await fetch(
-          `${this.credentials.baseUrl}/models/${this.modelInfo.model}:batchEmbedContents`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              ...(this.credentials.apiKey && { "x-goog-api-key": this.credentials.apiKey }),
-            },
-            body: JSON.stringify({ requests }),
-          }
+        const requestSignal = createProviderRequestSignal(
+          options?.signal,
+          GoogleEmbeddingProvider.REQUEST_TIMEOUT_MS,
         );
+        let responseReceived = false;
+        try {
+          return await raceWithOperationSignal((async () => {
+            const response = await fetch(
+              `${this.credentials.baseUrl}/models/${this.modelInfo.model}:batchEmbedContents`,
+              {
+                method: "POST",
+                headers: {
+                  "Content-Type": "application/json",
+                  ...(this.credentials.apiKey && { "x-goog-api-key": this.credentials.apiKey }),
+                },
+                body: JSON.stringify({ requests }),
+                signal: requestSignal.signal,
+              }
+            );
+            responseReceived = true;
 
-        if (!response.ok) {
-          const error = (await response.text()).slice(0, 500);
-          throw new Error(`Google embedding API error: ${response.status} - ${error}`);
+            if (!response.ok) {
+              await response.text();
+              throw new ProviderRequestError({
+                statusCode: response.status,
+                message: `Google embedding provider returned HTTP ${response.status}.`,
+              });
+            }
+
+            let data: { embeddings: Array<{ values: number[] }> };
+            try {
+              data = (await response.json()) as typeof data;
+            } catch {
+              throw new ProviderRequestError({
+                kind: "malformed_response",
+                retryable: true,
+                message: "Google embedding provider returned malformed JSON.",
+              });
+            }
+            if (!Array.isArray(data.embeddings)) {
+              throw new ProviderRequestError({
+                kind: "malformed_response",
+                retryable: true,
+                message: "Google embedding provider returned an invalid response.",
+              });
+            }
+            const embeddings = validateEmbeddingVectors(
+              data.embeddings.map((embedding) => embedding?.values),
+              batch.length,
+              this.modelInfo.dimensions,
+            );
+
+            return {
+              embeddings,
+              tokensUsed: batch.reduce((sum, text) => sum + Math.ceil(text.length / 4), 0),
+            };
+          })(), requestSignal.signal);
+        } catch (error: unknown) {
+          if (requestSignal.signal.aborted) {
+            if (options?.signal?.aborted) throwIfOperationAborted(options.signal);
+            throw new ProviderRequestError({ timedOut: true, retryable: true });
+          }
+          if (error instanceof ProviderRequestError) throw error;
+          if (responseReceived) {
+            throw new ProviderRequestError({
+              kind: "malformed_response",
+              retryable: true,
+              message: "Google embedding provider returned an invalid response.",
+            });
+          }
+          throw new ProviderRequestError({
+            retryable: true,
+            message: "Google embedding provider request failed.",
+          });
+        } finally {
+          requestSignal.dispose();
         }
-
-        const data = (await response.json()) as {
-          embeddings: Array<{ values: number[] }>;
-        };
-
-        return {
-          embeddings: data.embeddings.map((e) => e.values),
-          tokensUsed: batch.reduce((sum, text) => sum + Math.ceil(text.length / 4), 0),
-        };
       })
     );
 

--- a/src/embeddings/providers/ollama.ts
+++ b/src/embeddings/providers/ollama.ts
@@ -1,7 +1,18 @@
 import { type EmbeddingProviderModelInfo } from "../../config/schema.js";
 
 import { type ProviderCredentials } from "../detector.js";
-import { BaseEmbeddingProvider, type EmbeddingBatchResult } from "../provider-types.js";
+import {
+  BaseEmbeddingProvider,
+  type EmbeddingBatchResult,
+  type EmbeddingRequestOptions,
+} from "../provider-types.js";
+import {
+  createProviderRequestSignal,
+  isOperationInterruption,
+  ProviderRequestError,
+  raceWithOperationSignal,
+  throwIfOperationAborted,
+} from "../../utils/operation-control.js";
 
 export class OllamaEmbeddingProvider extends BaseEmbeddingProvider<EmbeddingProviderModelInfo["ollama"]> {
   private static readonly MIN_TRUNCATION_CHARS = 512;
@@ -32,6 +43,7 @@ export class OllamaEmbeddingProvider extends BaseEmbeddingProvider<EmbeddingProv
   }
 
   private isContextLengthError(error: unknown): boolean {
+    if (error instanceof ProviderRequestError && error.kind === "context_length") return true;
     const message = (error instanceof Error ? error.message : String(error)).toLowerCase();
     return (message.includes("context length") && (message.includes("exceed") || message.includes("exceeded") || message.includes("too long")))
       || message.includes("input length exceeds the context length")
@@ -42,6 +54,7 @@ export class OllamaEmbeddingProvider extends BaseEmbeddingProvider<EmbeddingProv
   // does not provide it. embedBatch uses this to fall back to the legacy per-text
   // /api/embeddings path so old ollama installs do not regress.
   private isBatchEndpointUnavailableError(error: unknown): boolean {
+    if (error instanceof ProviderRequestError) return error.kind === "endpoint_unavailable";
     const message = error instanceof Error ? error.message : String(error);
     return message.includes("Ollama /api/embed not available");
   }
@@ -51,6 +64,7 @@ export class OllamaEmbeddingProvider extends BaseEmbeddingProvider<EmbeddingProv
   // re-embeds each text cleanly. A text that then fails per-text is not isolated
   // here; it is isolated on the recovery run, which re-embeds one text per request.
   private isBatchValidationError(error: unknown): boolean {
+    if (error instanceof ProviderRequestError) return error.kind === "malformed_response";
     const message = error instanceof Error ? error.message : String(error);
     return message.includes("invalid embedding batch");
   }
@@ -100,10 +114,14 @@ export class OllamaEmbeddingProvider extends BaseEmbeddingProvider<EmbeddingProv
     return candidates;
   }
 
-  private async embedSingleWithFallback(text: string): Promise<{ embedding: number[]; tokensUsed: number }> {
+  private async embedSingleWithFallback(
+    text: string,
+    options?: EmbeddingRequestOptions,
+  ): Promise<{ embedding: number[]; tokensUsed: number }> {
     try {
-      return await this.embedSingle(text);
+      return await this.embedSingle(text, options);
     } catch (error) {
+      if (isOperationInterruption(error)) throw error;
       if (!this.isContextLengthError(error)) {
         throw error;
       }
@@ -111,8 +129,10 @@ export class OllamaEmbeddingProvider extends BaseEmbeddingProvider<EmbeddingProv
       let lastError: unknown = error;
       for (const truncated of this.buildTruncationCandidates(text)) {
         try {
-          return await this.embedSingle(truncated);
+          throwIfOperationAborted(options?.signal);
+          return await this.embedSingle(truncated, options);
         } catch (retryError) {
+          if (isOperationInterruption(retryError)) throw retryError;
           if (!this.isContextLengthError(retryError)) {
             throw retryError;
           }
@@ -124,72 +144,109 @@ export class OllamaEmbeddingProvider extends BaseEmbeddingProvider<EmbeddingProv
     }
   }
 
-  private async embedSingle(text: string): Promise<{ embedding: number[]; tokensUsed: number }> {
-    const controller = new AbortController();
-    const timeout = setTimeout(
-      () => controller.abort(),
+  private async embedSingle(
+    text: string,
+    options?: EmbeddingRequestOptions,
+  ): Promise<{ embedding: number[]; tokensUsed: number }> {
+    const requestSignal = createProviderRequestSignal(
+      options?.signal,
       OllamaEmbeddingProvider.REQUEST_TIMEOUT_MS,
     );
-    let response: Response;
+    let responseReceived = false;
     try {
-      response = await fetch(`${this.credentials.baseUrl}/api/embeddings`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          model: this.modelInfo.model,
-          prompt: text,
-          truncate: false,
-        }),
-        signal: controller.signal,
-      });
-    } catch (error) {
-      if (error instanceof Error && error.name === "AbortError") {
-        throw new Error(
-          `Ollama embedding request timed out after ${OllamaEmbeddingProvider.REQUEST_TIMEOUT_MS}ms`,
-        );
+      return await raceWithOperationSignal((async () => {
+        const response = await fetch(`${this.credentials.baseUrl}/api/embeddings`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            model: this.modelInfo.model,
+            prompt: text,
+            truncate: false,
+          }),
+          signal: requestSignal.signal,
+        });
+        responseReceived = true;
+
+        if (!response.ok) {
+          const body = await response.text();
+          const contextLength = body.toLowerCase().includes("context length");
+          throw new ProviderRequestError({
+            statusCode: response.status,
+            kind: contextLength ? "context_length" : undefined,
+            message: contextLength
+              ? "Ollama rejected an embedding because it exceeded the model context length."
+              : `Ollama embedding provider returned HTTP ${response.status}.`,
+          });
+        }
+
+        let data: { embedding?: unknown };
+        try {
+          data = (await response.json()) as { embedding?: unknown };
+        } catch {
+          throw new ProviderRequestError({
+            kind: "malformed_response",
+            retryable: true,
+            message: "Ollama embedding provider returned malformed JSON.",
+          });
+        }
+        if (
+          !Array.isArray(data.embedding)
+          || data.embedding.length !== this.modelInfo.dimensions
+          || data.embedding.some((value) => typeof value !== "number" || !Number.isFinite(value))
+        ) {
+          throw new ProviderRequestError({
+            kind: "malformed_response",
+            retryable: true,
+            message: `Ollama returned an invalid embedding; expected ${this.modelInfo.dimensions} finite dimensions.`,
+          });
+        }
+
+        return {
+          embedding: data.embedding,
+          tokensUsed: this.estimateTokens(text),
+        };
+      })(), requestSignal.signal);
+    } catch (error: unknown) {
+      if (requestSignal.signal.aborted) {
+        if (options?.signal?.aborted) throwIfOperationAborted(options.signal);
+        throw new ProviderRequestError({
+          timedOut: true,
+          retryable: true,
+          message: `Ollama embedding request timed out after ${OllamaEmbeddingProvider.REQUEST_TIMEOUT_MS}ms`,
+        });
       }
-      throw error;
+      if (error instanceof ProviderRequestError) throw error;
+      if (responseReceived) {
+        throw new ProviderRequestError({
+          kind: "malformed_response",
+          retryable: true,
+          message: "Ollama embedding provider returned an invalid response.",
+        });
+      }
+      throw new ProviderRequestError({
+        retryable: true,
+        message: "Ollama embedding provider request failed.",
+      });
     } finally {
-      clearTimeout(timeout);
+      requestSignal.dispose();
     }
-
-    if (!response.ok) {
-      const error = (await response.text()).slice(0, 500);
-      throw new Error(`Ollama embedding API error: ${response.status} - ${error}`);
-    }
-
-    const data = (await response.json()) as { embedding?: unknown };
-    if (
-      !Array.isArray(data.embedding)
-      || data.embedding.length !== this.modelInfo.dimensions
-      || data.embedding.some((value) => typeof value !== "number" || !Number.isFinite(value))
-    ) {
-      throw new Error(
-        `Ollama returned an invalid embedding; expected ${this.modelInfo.dimensions} finite dimensions`,
-      );
-    }
-
-    return {
-      embedding: data.embedding,
-      tokensUsed: this.estimateTokens(text),
-    };
   }
 
   // Embeds many texts in one POST /api/embed request (input: string[]). Ollama
   // encodes each input independently, so the model context length applies per input
   // (the upstream splitter already bounds each input), not over the batch. This
   // amortizes N HTTP round-trips into one.
-  private async embedMany(texts: string[]): Promise<EmbeddingBatchResult> {
-    const controller = new AbortController();
-    const timeout = setTimeout(
-      () => controller.abort(),
+  private async embedMany(texts: string[], options?: EmbeddingRequestOptions): Promise<EmbeddingBatchResult> {
+    const requestSignal = createProviderRequestSignal(
+      options?.signal,
       OllamaEmbeddingProvider.REQUEST_TIMEOUT_MS,
     );
-    let response: Response;
+    let responseReceived = false;
     try {
-      response = await fetch(`${this.credentials.baseUrl}/api/embed`, {
+      return await raceWithOperationSignal((async () => {
+        const response = await fetch(`${this.credentials.baseUrl}/api/embed`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -199,58 +256,86 @@ export class OllamaEmbeddingProvider extends BaseEmbeddingProvider<EmbeddingProv
           input: texts,
           truncate: false,
         }),
-        signal: controller.signal,
+        signal: requestSignal.signal,
+        });
+        responseReceived = true;
+
+        if (!response.ok) {
+          const body = await response.text();
+          if (response.status === 404) {
+            throw new ProviderRequestError({
+              statusCode: response.status,
+              kind: "endpoint_unavailable",
+              message: "Ollama does not expose the batch embedding endpoint.",
+            });
+          }
+          const contextLength = body.toLowerCase().includes("context length");
+          throw new ProviderRequestError({
+            statusCode: response.status,
+            kind: contextLength ? "context_length" : undefined,
+            message: contextLength
+              ? "Ollama rejected an embedding batch because it exceeded the model context length."
+              : `Ollama embedding provider returned HTTP ${response.status}.`,
+          });
+        }
+
+        let parsed: unknown;
+        try {
+          parsed = await response.json();
+        } catch {
+          throw new ProviderRequestError({
+            kind: "malformed_response",
+            retryable: true,
+            message: "Ollama returned a malformed embedding batch.",
+          });
+        }
+        const data = (parsed && typeof parsed === "object" ? parsed : {}) as { embeddings?: unknown };
+        if (
+          !Array.isArray(data.embeddings)
+          || data.embeddings.length !== texts.length
+          || data.embeddings.some(
+            (value) =>
+              !Array.isArray(value)
+              || value.length !== this.modelInfo.dimensions
+              || value.some((v) => typeof v !== "number" || !Number.isFinite(v)),
+          )
+        ) {
+          throw new ProviderRequestError({
+            kind: "malformed_response",
+            retryable: true,
+            message: `Ollama returned an invalid embedding batch; expected ${texts.length} vectors of ${this.modelInfo.dimensions} finite dimensions.`,
+          });
+        }
+
+        return {
+          embeddings: data.embeddings,
+          totalTokensUsed: texts.reduce((sum, text) => sum + this.estimateTokens(text), 0),
+        };
+      })(), requestSignal.signal);
+    } catch (error: unknown) {
+      if (requestSignal.signal.aborted) {
+        if (options?.signal?.aborted) throwIfOperationAborted(options.signal);
+        throw new ProviderRequestError({
+          timedOut: true,
+          retryable: true,
+          message: `Ollama embedding request timed out after ${OllamaEmbeddingProvider.REQUEST_TIMEOUT_MS}ms`,
+        });
+      }
+      if (error instanceof ProviderRequestError) throw error;
+      if (responseReceived) {
+        throw new ProviderRequestError({
+          kind: "malformed_response",
+          retryable: true,
+          message: "Ollama embedding provider returned an invalid response.",
+        });
+      }
+      throw new ProviderRequestError({
+        retryable: true,
+        message: "Ollama embedding provider request failed.",
       });
-    } catch (error) {
-      if (error instanceof Error && error.name === "AbortError") {
-        throw new Error(
-          `Ollama embedding request timed out after ${OllamaEmbeddingProvider.REQUEST_TIMEOUT_MS}ms`,
-        );
-      }
-      throw error;
     } finally {
-      clearTimeout(timeout);
+      requestSignal.dispose();
     }
-
-    if (!response.ok) {
-      const error = (await response.text()).slice(0, 500);
-      if (response.status === 404) {
-        throw new Error(`Ollama /api/embed not available: ${response.status} - ${error}`);
-      }
-      throw new Error(`Ollama embedding API error: ${response.status} - ${error}`);
-    }
-
-    let parsed: unknown;
-    try {
-      parsed = await response.json();
-    } catch {
-      // Invalid JSON (e.g. an empty or truncated 200 body) -> treat as a malformed
-      // batch so embedBatch falls back to the per-text path instead of propagating
-      // a parse error that skips the fallback.
-      throw new Error(
-        `Ollama returned an invalid embedding batch; expected ${texts.length} vectors of ${this.modelInfo.dimensions} finite dimensions`,
-      );
-    }
-    const data = (parsed && typeof parsed === "object" ? parsed : {}) as { embeddings?: unknown };
-    if (
-      !Array.isArray(data.embeddings)
-      || data.embeddings.length !== texts.length
-      || data.embeddings.some(
-        (value) =>
-          !Array.isArray(value)
-          || value.length !== this.modelInfo.dimensions
-          || value.some((v) => typeof v !== "number" || !Number.isFinite(v)),
-      )
-    ) {
-      throw new Error(
-        `Ollama returned an invalid embedding batch; expected ${texts.length} vectors of ${this.modelInfo.dimensions} finite dimensions`,
-      );
-    }
-
-    return {
-      embeddings: data.embeddings,
-      totalTokensUsed: texts.reduce((sum, text) => sum + this.estimateTokens(text), 0),
-    };
   }
 
   // Per-text /api/embeddings path shared by the single-text fast path and the
@@ -258,10 +343,11 @@ export class OllamaEmbeddingProvider extends BaseEmbeddingProvider<EmbeddingProv
   // its own truncation safety net and a vector validated on its own. A text that
   // hard-fails per-text throws here and fails the whole request batch; the recovery
   // run re-embeds one text per request to isolate it.
-  private async embedOneByOne(texts: string[]): Promise<EmbeddingBatchResult> {
+  private async embedOneByOne(texts: string[], options?: EmbeddingRequestOptions): Promise<EmbeddingBatchResult> {
     const results: Array<{ embedding: number[]; tokensUsed: number }> = [];
     for (const text of texts) {
-      results.push(await this.embedSingleWithFallback(text));
+      throwIfOperationAborted(options?.signal);
+      results.push(await this.embedSingleWithFallback(text, options));
     }
 
     return {
@@ -270,7 +356,10 @@ export class OllamaEmbeddingProvider extends BaseEmbeddingProvider<EmbeddingProv
     };
   }
 
-  public async embedBatch(texts: string[]): Promise<EmbeddingBatchResult> {
+  public async embedBatch(texts: string[], options?: EmbeddingRequestOptions): Promise<EmbeddingBatchResult> {
+    throwIfOperationAborted(options?.signal);
+    await options?.setPhase?.("embedding");
+    throwIfOperationAborted(options?.signal);
     if (texts.length === 0) {
       return { embeddings: [], totalTokensUsed: 0 };
     }
@@ -280,12 +369,14 @@ export class OllamaEmbeddingProvider extends BaseEmbeddingProvider<EmbeddingProv
     // /api/embed probe runs. Once /api/embed is known unavailable, multi-text batches
     // also skip the probe (see batchEndpointUnavailable).
     if (texts.length === 1 || this.batchEndpointUnavailable) {
-      return this.embedOneByOne(texts);
+      return this.embedOneByOne(texts, options);
     }
 
     try {
-      return await this.embedMany(texts);
+      return await this.embedMany(texts, options);
     } catch (error) {
+      if (isOperationInterruption(error)) throw error;
+      throwIfOperationAborted(options?.signal);
       // Fall back to the per-text /api/embeddings path when the batched endpoint is
       // unavailable (old ollama, 404), a single input overflowed the model context
       // length (per-text truncation net), or the batch response was malformed (so a
@@ -296,7 +387,7 @@ export class OllamaEmbeddingProvider extends BaseEmbeddingProvider<EmbeddingProv
       if (this.isBatchEndpointUnavailableError(error)) {
         // Old ollama without /api/embed: cache the result so later batches skip the probe.
         this.batchEndpointUnavailable = true;
-        return this.embedOneByOne(texts);
+        return this.embedOneByOne(texts, options);
       }
 
       if (
@@ -306,7 +397,7 @@ export class OllamaEmbeddingProvider extends BaseEmbeddingProvider<EmbeddingProv
         throw error;
       }
 
-      return this.embedOneByOne(texts);
+      return this.embedOneByOne(texts, options);
     }
   }
 }

--- a/src/embeddings/providers/openai.ts
+++ b/src/embeddings/providers/openai.ts
@@ -1,9 +1,22 @@
 import { type EmbeddingProviderModelInfo } from "../../config/schema.js";
 
 import { type ProviderCredentials } from "../detector.js";
-import { BaseEmbeddingProvider, type EmbeddingBatchResult } from "../provider-types.js";
+import {
+  BaseEmbeddingProvider,
+  type EmbeddingBatchResult,
+  type EmbeddingRequestOptions,
+  validateEmbeddingVectors,
+} from "../provider-types.js";
+import {
+  createProviderRequestSignal,
+  ProviderRequestError,
+  raceWithOperationSignal,
+  throwIfOperationAborted,
+} from "../../utils/operation-control.js";
 
 export class OpenAIEmbeddingProvider extends BaseEmbeddingProvider<EmbeddingProviderModelInfo["openai"]> {
+  private static readonly REQUEST_TIMEOUT_MS = 120_000;
+
   public constructor(
     credentials: ProviderCredentials,
     modelInfo: EmbeddingProviderModelInfo["openai"]
@@ -11,32 +24,89 @@ export class OpenAIEmbeddingProvider extends BaseEmbeddingProvider<EmbeddingProv
     super(credentials, modelInfo);
   }
 
-  public async embedBatch(texts: string[]): Promise<EmbeddingBatchResult> {
-    const response = await fetch(`${this.credentials.baseUrl}/embeddings`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${this.credentials.apiKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        model: this.modelInfo.model,
-        input: texts,
-      }),
-    });
+  public async embedBatch(texts: string[], options?: EmbeddingRequestOptions): Promise<EmbeddingBatchResult> {
+    throwIfOperationAborted(options?.signal);
+    await options?.setPhase?.("embedding");
+    throwIfOperationAborted(options?.signal);
+    const requestSignal = createProviderRequestSignal(
+      options?.signal,
+      OpenAIEmbeddingProvider.REQUEST_TIMEOUT_MS,
+    );
+    let responseReceived = false;
+    try {
+      return await raceWithOperationSignal((async () => {
+        const response = await fetch(`${this.credentials.baseUrl}/embeddings`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${this.credentials.apiKey}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            model: this.modelInfo.model,
+            input: texts,
+          }),
+          signal: requestSignal.signal,
+        });
+        responseReceived = true;
 
-    if (!response.ok) {
-      const error = (await response.text()).slice(0, 500);
-      throw new Error(`OpenAI embedding API error: ${response.status} - ${error}`);
+        if (!response.ok) {
+          await response.text();
+          throw new ProviderRequestError({
+            statusCode: response.status,
+            message: `OpenAI embedding provider returned HTTP ${response.status}.`,
+          });
+        }
+
+        let data: {
+          data: Array<{ embedding: number[] }>;
+          usage: { total_tokens: number };
+        };
+        try {
+          data = await response.json() as typeof data;
+        } catch {
+          throw new ProviderRequestError({
+            kind: "malformed_response",
+            retryable: true,
+            message: "OpenAI embedding provider returned malformed JSON.",
+          });
+        }
+        if (!Array.isArray(data.data) || typeof data.usage?.total_tokens !== "number") {
+          throw new ProviderRequestError({
+            kind: "malformed_response",
+            retryable: true,
+            message: "OpenAI embedding provider returned an invalid response.",
+          });
+        }
+        const embeddings = validateEmbeddingVectors(
+          data.data.map((entry) => entry?.embedding),
+          texts.length,
+          this.modelInfo.dimensions,
+        );
+
+        return {
+          embeddings,
+          totalTokensUsed: data.usage.total_tokens,
+        };
+      })(), requestSignal.signal);
+    } catch (error: unknown) {
+      if (requestSignal.signal.aborted) {
+        if (options?.signal?.aborted) throwIfOperationAborted(options.signal);
+        throw new ProviderRequestError({ timedOut: true, retryable: true });
+      }
+      if (error instanceof ProviderRequestError) throw error;
+      if (responseReceived) {
+        throw new ProviderRequestError({
+          kind: "malformed_response",
+          retryable: true,
+          message: "OpenAI embedding provider returned an invalid response.",
+        });
+      }
+      throw new ProviderRequestError({
+        retryable: true,
+        message: "OpenAI embedding provider request failed.",
+      });
+    } finally {
+      requestSignal.dispose();
     }
-
-    const data = await response.json() as {
-      data: Array<{ embedding: number[] }>;
-      usage: { total_tokens: number };
-    };
-
-    return {
-      embeddings: data.data.map((d) => d.embedding),
-      totalTokensUsed: data.usage.total_tokens,
-    };
   }
 }

--- a/src/git/branch-materialization.ts
+++ b/src/git/branch-materialization.ts
@@ -3,6 +3,7 @@ import * as os from "os";
 import * as path from "path";
 
 import { canonicalizePathForComparison } from "../utils/canonical-path.js";
+import { throwIfOperationAborted } from "../utils/operation-control.js";
 
 import type {
   BranchMaterializationInfo,
@@ -190,6 +191,7 @@ export async function withMaterializedBranch<T>(
   request: BranchMaterializationRequest,
   callback: (worktreePath: string, info: BranchMaterializationInfo) => Promise<T>,
 ): Promise<{ value: T; info: BranchMaterializationInfo }> {
+  throwIfOperationAborted(request.signal);
   assertValidGitRefName(request.branch, "Branch name");
   if (request.ref !== undefined) {
     assertValidGitRefName(request.ref, "Git ref");
@@ -202,6 +204,7 @@ export async function withMaterializedBranch<T>(
   }
 
   const resolved = await resolveCommit(request);
+  throwIfOperationAborted(request.signal);
   if (!resolved) {
     throw new Error(
       `Git ref ${JSON.stringify(request.ref ?? request.branch)} is not available locally. `
@@ -212,7 +215,6 @@ export async function withMaterializedBranch<T>(
   const temporaryRoot = await fsPromises.mkdtemp(path.join(os.tmpdir(), "codebase-index-branch-"));
   const worktreePath = path.join(temporaryRoot, "worktree");
   const hooksPath = path.join(temporaryRoot, "hooks");
-  await fsPromises.mkdir(hooksPath);
   const info: BranchMaterializationInfo = {
     branch: request.branch,
     commit: resolved.commit,
@@ -223,6 +225,9 @@ export async function withMaterializedBranch<T>(
   let result: { value: T; info: BranchMaterializationInfo } | undefined;
   let operationError: unknown;
   try {
+    throwIfOperationAborted(request.signal);
+    await fsPromises.mkdir(hooksPath);
+    throwIfOperationAborted(request.signal);
     await runGit(request.projectRoot, [
       "-c",
       `core.hooksPath=${hooksPath}`,
@@ -232,16 +237,18 @@ export async function withMaterializedBranch<T>(
       "--",
       worktreePath,
       resolved.commit,
-    ]);
+    ], { signal: request.signal });
 
-    const materializedHead = await tryResolveCommit(worktreePath, "HEAD");
+    const materializedHead = await tryResolveCommit(worktreePath, "HEAD", request.signal);
     if (materializedHead !== resolved.commit) {
       throw new Error(
         `Materialized worktree HEAD ${materializedHead ?? "did not resolve"}; expected ${resolved.commit}.`,
       );
     }
 
+    throwIfOperationAborted(request.signal);
     const value = await callback(worktreePath, info);
+    throwIfOperationAborted(request.signal);
     result = { value, info };
   } catch (error) {
     operationError = error;
@@ -262,5 +269,6 @@ export async function withMaterializedBranch<T>(
   }
   if (operationError !== undefined) throw operationError;
   if (cleanupError !== undefined) throw cleanupError;
+  throwIfOperationAborted(request.signal);
   return result!;
 }

--- a/src/git/branch-resolution.ts
+++ b/src/git/branch-resolution.ts
@@ -2,6 +2,11 @@ import { execFile } from "child_process";
 import { randomBytes } from "crypto";
 import { promisify } from "util";
 
+import {
+  isOperationInterruption,
+  throwIfOperationAborted,
+} from "../utils/operation-control.js";
+
 const execFileAsync = promisify(execFile);
 const FULL_COMMIT_RE = /^[0-9a-f]{40}$/i;
 const SAFE_REMOTE_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,255}$/;
@@ -20,6 +25,7 @@ export interface BranchMaterializationRequest {
   expectedCommit?: string;
   pr?: number;
   repository?: string;
+  signal?: AbortSignal;
 }
 
 export interface BranchMaterializationInfo {
@@ -107,31 +113,44 @@ function assertValidGitRemoteName(value: string): void {
 export async function runGitRaw(
   projectRoot: string,
   args: string[],
-  options: { timeout?: number } = {},
+  options: { timeout?: number; signal?: AbortSignal } = {},
 ): Promise<string> {
-  const { stdout } = await execFileAsync("git", args, {
-    cwd: projectRoot,
-    timeout: options.timeout ?? 30000,
-    encoding: "utf8",
-    maxBuffer: 10 * 1024 * 1024,
-    env: {
-      ...process.env,
-      GIT_TERMINAL_PROMPT: "0",
-      LC_ALL: "C",
-    },
-  });
-  return stdout;
+  throwIfOperationAborted(options.signal);
+  try {
+    const { stdout } = await execFileAsync("git", args, {
+      cwd: projectRoot,
+      timeout: options.timeout ?? 30000,
+      encoding: "utf8",
+      maxBuffer: 10 * 1024 * 1024,
+      signal: options.signal,
+      env: {
+        ...process.env,
+        GIT_TERMINAL_PROMPT: "0",
+        LC_ALL: "C",
+      },
+    });
+    throwIfOperationAborted(options.signal);
+    return stdout;
+  } catch (error) {
+    throwIfOperationAborted(options.signal);
+    throw error;
+  }
 }
 
 export async function runGit(
   projectRoot: string,
   args: string[],
-  options: { timeout?: number } = {},
+  options: { timeout?: number; signal?: AbortSignal } = {},
 ): Promise<string> {
   return (await runGitRaw(projectRoot, args, options)).trim();
 }
 
-export async function tryResolveCommit(projectRoot: string, ref: string): Promise<string | null> {
+export async function tryResolveCommit(
+  projectRoot: string,
+  ref: string,
+  signal?: AbortSignal,
+): Promise<string | null> {
+  throwIfOperationAborted(signal);
   try {
     const commit = await runGit(projectRoot, [
       "rev-parse",
@@ -139,35 +158,42 @@ export async function tryResolveCommit(projectRoot: string, ref: string): Promis
       "--quiet",
       "--end-of-options",
       `${ref}^{commit}`,
-    ]);
+    ], { signal });
     return isFullGitCommit(commit) ? commit.toLowerCase() : null;
   } catch {
+    throwIfOperationAborted(signal);
     return null;
   }
 }
 
-export async function resolveLocalGitCommit(projectRoot: string, ref: string): Promise<string | null> {
+export async function resolveLocalGitCommit(
+  projectRoot: string,
+  ref: string,
+  signal?: AbortSignal,
+): Promise<string | null> {
   assertValidGitRefName(ref);
-  return tryResolveCommit(projectRoot, ref);
+  return tryResolveCommit(projectRoot, ref, signal);
 }
 
 export async function resolveLocalPullRequestRefs(
   projectRoot: string,
   pr: number,
+  signal?: AbortSignal,
 ): Promise<LocalPullRequestRefs | null> {
+  throwIfOperationAborted(signal);
   if (!Number.isInteger(pr) || pr <= 0) {
     throw new Error(`Pull request number must be a positive integer: ${pr}`);
   }
 
   const headRef = `refs/pull/${pr}/head`;
   const mergeRef = `refs/pull/${pr}/merge`;
-  const headCommit = await tryResolveCommit(projectRoot, headRef);
-  const mergeHeadCommit = await tryResolveCommit(projectRoot, `${mergeRef}^2`);
+  const headCommit = await tryResolveCommit(projectRoot, headRef, signal);
+  const mergeHeadCommit = await tryResolveCommit(projectRoot, `${mergeRef}^2`, signal);
   const resolvedHeadCommit = headCommit ?? mergeHeadCommit;
   if (!resolvedHeadCommit) return null;
 
   const baseCommit = mergeHeadCommit === resolvedHeadCommit
-    ? await tryResolveCommit(projectRoot, `${mergeRef}^1`)
+    ? await tryResolveCommit(projectRoot, `${mergeRef}^1`, signal)
     : null;
   return {
     headCommit: resolvedHeadCommit,
@@ -182,9 +208,14 @@ function localCandidates(ref: string): string[] {
   return [`refs/heads/${ref}`];
 }
 
-async function resolveFirstLocalCommit(projectRoot: string, refs: string[]): Promise<string | null> {
+async function resolveFirstLocalCommit(
+  projectRoot: string,
+  refs: string[],
+  signal?: AbortSignal,
+): Promise<string | null> {
   for (const ref of refs) {
-    const commit = await tryResolveCommit(projectRoot, ref);
+    throwIfOperationAborted(signal);
+    const commit = await tryResolveCommit(projectRoot, ref, signal);
     if (commit) return commit;
   }
   return null;
@@ -205,14 +236,18 @@ function parseRemoteBranch(ref: string): { remote: string; branch: string; expli
   return { remote: ref.slice(0, slash), branch: ref.slice(slash + 1), explicit: false };
 }
 
-async function getRemoteNames(projectRoot: string): Promise<string[]> {
-  const output = await runGitRaw(projectRoot, ["remote"]);
+async function getRemoteNames(projectRoot: string, signal?: AbortSignal): Promise<string[]> {
+  const output = await runGitRaw(projectRoot, ["remote"], { signal });
   return output.split("\n").filter(Boolean);
 }
 
-async function getConfiguredRemote(projectRoot: string, remote: string): Promise<string | null> {
+async function getConfiguredRemote(
+  projectRoot: string,
+  remote: string,
+  signal?: AbortSignal,
+): Promise<string | null> {
   assertValidGitRemoteName(remote);
-  const remotes = await getRemoteNames(projectRoot);
+  const remotes = await getRemoteNames(projectRoot, signal);
   return remotes.includes(remote) ? remote : null;
 }
 
@@ -234,8 +269,10 @@ function normalizeRepository(value: string): string | null {
 async function resolvePullRequestRepository(
   projectRoot: string,
   repository?: string,
+  signal?: AbortSignal,
 ): Promise<string> {
-  const remotes = (await getRemoteNames(projectRoot)).filter(isValidGitRemoteName);
+  throwIfOperationAborted(signal);
+  const remotes = (await getRemoteNames(projectRoot, signal)).filter(isValidGitRemoteName);
   if (repository) {
     const expectedRepository = normalizeRepository(repository);
     if (!expectedRepository) {
@@ -243,7 +280,7 @@ async function resolvePullRequestRepository(
     }
 
     for (const remote of remotes) {
-      const remoteUrl = await runGit(projectRoot, ["remote", "get-url", "--", remote]);
+      const remoteUrl = await runGit(projectRoot, ["remote", "get-url", "--", remote], { signal });
       if (normalizeRepository(remoteUrl) === expectedRepository) {
         return remote;
       }
@@ -277,10 +314,12 @@ async function fetchCommitThroughTemporaryRef(
   repository: string,
   sourceRef: string,
   expectedCommit?: string,
+  signal?: AbortSignal,
 ): Promise<string> {
+  throwIfOperationAborted(signal);
   assertValidGitRefName(sourceRef, "Fetch source ref");
   if (isValidGitRemoteName(repository)) {
-    const configuredRemote = await getConfiguredRemote(projectRoot, repository);
+    const configuredRemote = await getConfiguredRemote(projectRoot, repository, signal);
     if (!configuredRemote) {
       throw new Error(`Git remote is not configured: ${JSON.stringify(repository)}`);
     }
@@ -301,8 +340,8 @@ async function fetchCommitThroughTemporaryRef(
       "--",
       repository,
       `+${sourceRef}:${temporaryRef}`,
-    ]);
-    commit = await tryResolveCommit(projectRoot, temporaryRef);
+    ], { signal });
+    commit = await tryResolveCommit(projectRoot, temporaryRef, signal);
     if (!commit) {
       throw new Error(`Fetched ref ${JSON.stringify(sourceRef)} did not resolve to a commit.`);
     }
@@ -333,37 +372,50 @@ async function fetchCommitThroughTemporaryRef(
   }
   if (fetchError !== undefined) throw fetchError;
   if (cleanupError !== undefined) throw cleanupError;
+  throwIfOperationAborted(signal);
   return commit!;
 }
 
 export async function resolveCommit(
   request: BranchMaterializationRequest,
 ): Promise<ResolvedCommit | null> {
+  throwIfOperationAborted(request.signal);
   const requestedRef = request.ref ?? request.branch;
   const authoritativeCommit = request.expectedCommit?.toLowerCase();
 
   if (request.pr !== undefined) {
     const expectedCommit = authoritativeCommit
       ?? (isFullGitCommit(requestedRef) ? requestedRef.toLowerCase() : undefined);
-    const localPullCommit = await tryResolveCommit(request.projectRoot, `refs/pull/${request.pr}/head`);
+    const localPullCommit = await tryResolveCommit(
+      request.projectRoot,
+      `refs/pull/${request.pr}/head`,
+      request.signal,
+    );
     if (localPullCommit && (!expectedCommit || localPullCommit === expectedCommit)) {
       return { commit: localPullCommit, source: "pull-ref", fetched: false };
     }
 
-    if (expectedCommit && await tryResolveCommit(request.projectRoot, expectedCommit)) {
+    if (expectedCommit && await tryResolveCommit(request.projectRoot, expectedCommit, request.signal)) {
       return { commit: expectedCommit, source: "local", fetched: false };
     }
 
-    const repository = await resolvePullRequestRepository(request.projectRoot, request.repository);
+    const repository = await resolvePullRequestRepository(
+      request.projectRoot,
+      request.repository,
+      request.signal,
+    );
     try {
       const commit = await fetchCommitThroughTemporaryRef(
         request.projectRoot,
         repository,
         `refs/pull/${request.pr}/head`,
         expectedCommit,
+        request.signal,
       );
       return { commit, source: "pull-ref", fetched: true };
     } catch (error) {
+      if (isOperationInterruption(error)) throw error;
+      throwIfOperationAborted(request.signal);
       throw contextualizeError(
         `Could not fetch PR #${request.pr} from ${JSON.stringify(repository)}`,
         error,
@@ -376,7 +428,7 @@ export async function resolveCommit(
     if (!isValidGitRemoteName(remoteBranch.remote)) {
       throw new Error(`Git remote name is unsafe: ${JSON.stringify(remoteBranch.remote)}`);
     }
-    const remote = await getConfiguredRemote(request.projectRoot, remoteBranch.remote);
+    const remote = await getConfiguredRemote(request.projectRoot, remoteBranch.remote, request.signal);
     if (remote) {
       try {
         const commit = await fetchCommitThroughTemporaryRef(
@@ -384,9 +436,12 @@ export async function resolveCommit(
           remote,
           `refs/heads/${remoteBranch.branch}`,
           authoritativeCommit,
+          request.signal,
         );
         return { commit, source: "remote-fetch", fetched: true };
       } catch (error) {
+        if (isOperationInterruption(error)) throw error;
+        throwIfOperationAborted(request.signal);
         throw contextualizeError(
           `Could not fetch branch ${JSON.stringify(requestedRef)} from remote ${JSON.stringify(remote)}`,
           error,
@@ -398,7 +453,11 @@ export async function resolveCommit(
     }
   }
 
-  const localCommit = await resolveFirstLocalCommit(request.projectRoot, localCandidates(requestedRef));
+  const localCommit = await resolveFirstLocalCommit(
+    request.projectRoot,
+    localCandidates(requestedRef),
+    request.signal,
+  );
   if (!localCommit) return null;
   if (authoritativeCommit && localCommit !== authoritativeCommit) {
     throw new Error(
@@ -408,8 +467,12 @@ export async function resolveCommit(
   return { commit: localCommit, source: "local", fetched: false };
 }
 
-export async function resolveGitCommit(projectRoot: string, ref: string): Promise<string | null> {
+export async function resolveGitCommit(
+  projectRoot: string,
+  ref: string,
+  signal?: AbortSignal,
+): Promise<string | null> {
   assertValidGitRefName(ref);
-  const resolved = await resolveCommit({ projectRoot, branch: ref, ref });
+  const resolved = await resolveCommit({ projectRoot, branch: ref, ref, signal });
   return resolved?.commit ?? null;
 }

--- a/src/indexer/git-blame.ts
+++ b/src/indexer/git-blame.ts
@@ -2,6 +2,8 @@ import { execFile } from "child_process";
 import * as path from "path";
 import { promisify } from "util";
 
+import { throwIfOperationAborted } from "../utils/operation-control.js";
+
 const execFileAsync = promisify(execFile);
 
 export interface GitBlameMetadata {
@@ -66,17 +68,21 @@ export async function getChunkGitBlame(
   projectRoot: string,
   filePath: string,
   startLine: number,
-  endLine: number
+  endLine: number,
+  signal?: AbortSignal,
 ): Promise<GitBlameMetadata | undefined> {
+  throwIfOperationAborted(signal);
   const relativePath = path.relative(projectRoot, filePath);
   try {
     const { stdout } = await execFileAsync(
       "git",
       ["blame", "--line-porcelain", "-L", `${startLine},${endLine}`, "--", relativePath],
-      { cwd: projectRoot, timeout: 30000 }
+      { cwd: projectRoot, timeout: 30000, signal }
     );
+    throwIfOperationAborted(signal);
     return parseGitBlamePorcelain(stdout);
   } catch {
+    throwIfOperationAborted(signal);
     return undefined;
   }
 }

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -110,6 +110,13 @@ import {
 } from "./failed-state-persistence.js";
 import { iterateOrderedFileBatches, type FileBatchLimits } from "./file-batches.js";
 import { canonicalizePathForComparison } from "../utils/canonical-path.js";
+import {
+  createProviderRequestSignal,
+  isOperationInterruption,
+  ProviderRequestError,
+  raceWithOperationSignal,
+  throwIfOperationAborted,
+} from "../utils/operation-control.js";
 import { summarizeCallGraphCoverage, type CallGraphCoverage } from "./call-graph-coverage.js";
 import { createGoDirectCallClassifier, isGoFilePath } from "./go-package-resolution.js";
 import {
@@ -121,6 +128,12 @@ import {
 } from "./local-module-resolution.js";
 
 export const CALL_GRAPH_LANGUAGES = new Set(["typescript", "tsx", "javascript", "jsx", "python", "go", "rust", "swift", "php", "apex", "zig", "gdscript", "matlab", "bash", "c", "cpp", "metal"]);
+
+export function shouldRetryEmbeddingRequest(error: unknown): boolean {
+  return !isOperationInterruption(error)
+    && !(error instanceof CustomProviderNonRetryableError)
+    && !(error instanceof ProviderRequestError && error.retryable === false);
+}
 // Languages whose identifiers are case-insensitive at the language level.
 // The Rust call_extractor lowercases callee names for these languages (except
 // constructors and imports), so same-file resolution in this file must use
@@ -433,6 +446,16 @@ interface SearchOptions {
   blameSince?: string;
   blameUntil?: string;
   trace?: (trace: SearchTrace) => void;
+  signal?: AbortSignal;
+  setPhase?: (phase: string) => void | Promise<void>;
+  heartbeat?: () => void | Promise<void>;
+}
+
+export interface IndexOperationOptions {
+  signal?: AbortSignal;
+  setPhase?: (phase: string) => void | Promise<void>;
+  heartbeat?: () => void | Promise<void>;
+  onProviderError?: (error: ProviderRequestError) => void;
 }
 
 export interface HealthCheckResult {
@@ -1459,7 +1482,9 @@ export class Indexer {
   private async withIndexMutationLease<T>(
     operation: IndexMutationOperation,
     callback: (recoveredOwners: readonly IndexLockOwner[]) => Promise<T>,
+    signal?: AbortSignal,
   ): Promise<T> {
+    throwIfOperationAborted(signal);
     this.refreshBranchInfo();
     const lease = acquireIndexLock(this.indexPath, operation, {
       projectRoot: this.projectRoot,
@@ -1474,6 +1499,7 @@ export class Indexer {
     let callbackFailed = false;
     try {
       result = await callback(lease.recoveries.map(({ owner }) => owner));
+      throwIfOperationAborted(signal);
     } catch (error) {
       callbackFailed = true;
       callbackError = error;
@@ -1510,6 +1536,7 @@ export class Indexer {
       throw releaseError;
     }
     if (callbackFailed) throw callbackError;
+    throwIfOperationAborted(signal);
     return result as T;
   }
 
@@ -2606,6 +2633,10 @@ export class Indexer {
       forceSingleItemBatches?: boolean;
       onSucceeded?: (chunks: PendingChunk[]) => void;
       onProgress?: (progress: Readonly<PendingChunkBatchResult>) => void;
+      signal?: AbortSignal;
+      setPhase?: (phase: string) => void | Promise<void>;
+      heartbeat?: () => void | Promise<void>;
+      onProviderError?: (error: ProviderRequestError) => void;
     },
   ): Promise<PendingChunkBatchResult> {
     const result: PendingChunkBatchResult = {
@@ -2617,6 +2648,7 @@ export class Indexer {
     if (chunks.length === 0) {
       return result;
     }
+    throwIfOperationAborted(options.signal);
 
     const chunksNeedingEmbedding: PendingChunk[] = [];
     let cachedChunkCount = 0;
@@ -2674,44 +2706,68 @@ export class Indexer {
     let fatalError: unknown;
 
     for (const requestBatch of requestBatches) {
-      await options.queue.onSizeLessThan(Math.max(1, options.providerRateLimits.concurrency));
+      throwIfOperationAborted(options.signal);
+      try {
+        await raceWithOperationSignal(
+          options.queue.onSizeLessThan(Math.max(1, options.providerRateLimits.concurrency)),
+          options.signal,
+        );
+      } catch (error: unknown) {
+        await options.queue.onIdle();
+        throwIfOperationAborted(options.signal);
+        throw error;
+      }
       const task = options.queue.add(async () => {
+        throwIfOperationAborted(options.signal);
         if (options.rateLimitState.backoffMs > 0) {
-          await new Promise(resolve => setTimeout(resolve, options.rateLimitState.backoffMs));
+          await raceWithOperationSignal(
+            new Promise(resolve => setTimeout(resolve, options.rateLimitState.backoffMs)),
+            options.signal,
+          );
         }
 
         try {
-          const embeddingResult = await pRetry(
-            async () => {
-              const texts = requestBatch.map((request) => request.text);
-              return options.provider.embedBatch(texts);
-            },
-            {
-              retries: this.config.indexing.retries,
-              minTimeout: Math.max(this.config.indexing.retryDelayMs, options.providerRateLimits.minRetryMs),
-              maxTimeout: options.providerRateLimits.maxRetryMs,
-              factor: 2,
-              shouldRetry: (error) => !((error as { error?: Error }).error instanceof CustomProviderNonRetryableError),
-              onFailedAttempt: (error) => {
-                const message = getErrorMessage(error);
-                if (isRateLimitError(error)) {
-                  options.rateLimitState.backoffMs = Math.min(
-                    options.providerRateLimits.maxRetryMs,
-                    (options.rateLimitState.backoffMs || options.providerRateLimits.minRetryMs) * 2,
-                  );
-                  this.logger.embedding("warn", "Rate limited, backing off", {
-                    attempt: error.attemptNumber,
-                    retriesLeft: error.retriesLeft,
-                    backoffMs: options.rateLimitState.backoffMs,
-                  });
-                } else {
-                  this.logger.embedding("error", "Embedding batch failed", {
-                    attempt: error.attemptNumber,
-                    error: message,
-                  });
-                }
+          const embeddingResult = await raceWithOperationSignal(
+            pRetry(
+              async () => {
+                const texts = requestBatch.map((request) => request.text);
+                throwIfOperationAborted(options.signal);
+                return options.provider.embedBatch(texts, {
+                  signal: options.signal,
+                  setPhase: options.setPhase,
+                  heartbeat: options.heartbeat,
+                });
               },
-            },
+              {
+                signal: options.signal,
+                retries: this.config.indexing.retries,
+                minTimeout: Math.max(this.config.indexing.retryDelayMs, options.providerRateLimits.minRetryMs),
+                maxTimeout: options.providerRateLimits.maxRetryMs,
+                factor: 2,
+                shouldRetry: ({ error }) => shouldRetryEmbeddingRequest(error),
+                onFailedAttempt: (attempt) => {
+                  if (isOperationInterruption(attempt.error)) return;
+                  const message = getErrorMessage(attempt.error);
+                  if (isRateLimitError(attempt.error)) {
+                    options.rateLimitState.backoffMs = Math.min(
+                      options.providerRateLimits.maxRetryMs,
+                      (options.rateLimitState.backoffMs || options.providerRateLimits.minRetryMs) * 2,
+                    );
+                    this.logger.embedding("warn", "Rate limited, backing off", {
+                      attempt: attempt.attemptNumber,
+                      retriesLeft: attempt.retriesLeft,
+                      backoffMs: options.rateLimitState.backoffMs,
+                    });
+                  } else {
+                    this.logger.embedding("error", "Embedding batch failed", {
+                      attempt: attempt.attemptNumber,
+                      error: message,
+                    });
+                  }
+                },
+              },
+            ),
+            options.signal,
           );
 
           if (options.rateLimitState.backoffMs > 0) {
@@ -2789,6 +2845,11 @@ export class Indexer {
             tokens: embeddingResult.totalTokensUsed,
           });
         } catch (error) {
+          if (isOperationInterruption(error)) throw error;
+          throwIfOperationAborted(options.signal);
+          if (error instanceof ProviderRequestError) {
+            options.onProviderError?.(error);
+          }
           const failedChunks = getUniquePendingChunksFromRequests(requestBatch)
             .filter((chunk) => !completedChunkIds.has(chunk.id))
             .filter((chunk) => options.incrementRepeatedFailures || !result.failedChunkIds.has(chunk.id));
@@ -2820,13 +2881,14 @@ export class Indexer {
         }
 
         options.onProgress?.(result);
-      });
+      }, { signal: options.signal });
       void task.catch((error: unknown) => {
         fatalError ??= error;
       });
     }
 
     await options.queue.onIdle();
+    throwIfOperationAborted(options.signal);
     if (fatalError !== undefined) {
       throw fatalError;
     }
@@ -2880,6 +2942,9 @@ export class Indexer {
     options?: {
       definitionIntent?: boolean;
       hasIdentifierHints?: boolean;
+      signal?: AbortSignal;
+      setPhase?: (phase: string) => void | Promise<void>;
+      heartbeat?: () => void | Promise<void>;
     }
   ): Promise<RankedCandidate[]> {
     const reranker = this.config.reranker;
@@ -2928,6 +2993,7 @@ export class Indexer {
     try {
       const rerankedHead: RankedCandidate[] = [];
       for (const band of orderedBands) {
+        throwIfOperationAborted(options?.signal);
         const bandCandidates = grouped.get(band) ?? [];
         if (bandCandidates.length <= 1) {
           rerankedHead.push(...bandCandidates);
@@ -2940,7 +3006,13 @@ export class Indexer {
             text: await this.createRerankerDocumentText(candidate),
           }))
         );
-        const rankedIds = await this.callExternalReranker(query, documents, reranker);
+        const rankedIds = await this.callExternalReranker(
+          query,
+          documents,
+          reranker,
+          options?.signal,
+          options?.setPhase,
+        );
         if (rankedIds.length === 0) {
           rerankedHead.push(...bandCandidates);
           continue;
@@ -2971,6 +3043,8 @@ export class Indexer {
 
       return [...rerankedHead, ...tail];
     } catch (error) {
+      if (isOperationInterruption(error)) throw error;
+      throwIfOperationAborted(options?.signal);
       this.logger.search("warn", "External reranker failed; using deterministic order", {
         provider: reranker.provider,
         model: reranker.model,
@@ -2983,7 +3057,9 @@ export class Indexer {
   private async callExternalReranker(
     query: string,
     documents: RerankDocumentPayload[],
-    reranker: RerankerConfig
+    reranker: RerankerConfig,
+    signal?: AbortSignal,
+    setPhase?: (phase: string) => void | Promise<void>,
   ): Promise<string[]> {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
@@ -2992,46 +3068,63 @@ export class Indexer {
       headers.Authorization = `Bearer ${reranker.apiKey}`;
     }
 
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), reranker.timeoutMs);
+    const requestSignal = createProviderRequestSignal(signal, reranker.timeoutMs);
     try {
-      const response = await fetch(`${reranker.baseUrl}/rerank`, {
-        method: "POST",
-        headers,
-        body: JSON.stringify({
-          model: reranker.model,
-          query,
-          documents: documents.map((document) => document.text),
-          top_n: documents.length,
-          return_documents: false,
-        }),
-        signal: controller.signal,
-      });
+      await setPhase?.("reranking");
+      throwIfOperationAborted(signal);
+      return await raceWithOperationSignal((async () => {
+        const response = await fetch(`${reranker.baseUrl}/rerank`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            model: reranker.model,
+            query,
+            documents: documents.map((document) => document.text),
+            top_n: documents.length,
+            return_documents: false,
+          }),
+          signal: requestSignal.signal,
+        });
 
-      if (!response.ok) {
-        throw new Error(`Reranker API error: ${response.status} - ${await response.text()}`);
-      }
+        if (!response.ok) {
+          await response.text();
+          throw new ProviderRequestError({
+            statusCode: response.status,
+            message: `Reranking provider returned HTTP ${response.status}.`,
+          });
+        }
 
-      const body = await response.json() as {
-        results?: Array<{ index?: number; relevance_score?: number }>;
-      };
-      if (!Array.isArray(body.results)) {
-        throw new Error("Reranker API returned unexpected response format.");
-      }
+        let body: { results?: Array<{ index?: number; relevance_score?: number }> };
+        try {
+          body = await response.json() as typeof body;
+        } catch {
+          throw new ProviderRequestError({
+            kind: "malformed_response",
+            retryable: true,
+            message: "Reranking provider returned malformed JSON.",
+          });
+        }
+        if (!Array.isArray(body.results)) {
+          throw new ProviderRequestError({
+            kind: "malformed_response",
+            retryable: true,
+            message: "Reranking provider returned an invalid response.",
+          });
+        }
 
-      return body.results
-        .map((result) => {
-          const index = typeof result.index === "number" ? result.index : -1;
-          return documents[index]?.id;
-        })
-        .filter((id): id is string => typeof id === "string");
+        return body.results
+          .map((result) => {
+            const index = typeof result.index === "number" ? result.index : -1;
+            return documents[index]?.id;
+          })
+          .filter((id): id is string => typeof id === "string");
+      })(), requestSignal.signal);
     } catch (error) {
-      if (error instanceof Error && error.name === "AbortError") {
-        throw new Error(`Reranker request timed out after ${reranker.timeoutMs}ms`);
-      }
-      throw error;
+      throwIfOperationAborted(requestSignal.signal);
+      if (error instanceof ProviderRequestError) throw error;
+      throw new ProviderRequestError({ retryable: true });
     } finally {
-      clearTimeout(timeout);
+      requestSignal.dispose();
     }
   }
 
@@ -4067,7 +4160,8 @@ export class Indexer {
     };
   }
 
-  async estimateCost(): Promise<CostEstimate> {
+  async estimateCost(options: IndexOperationOptions = {}): Promise<CostEstimate> {
+    throwIfOperationAborted(options.signal);
     const { configuredProviderInfo } = await this.ensureInitialized();
 
     const includePatterns = [...this.config.include, ...this.config.additionalInclude];
@@ -4077,7 +4171,12 @@ export class Indexer {
       this.config.exclude,
       this.config.indexing.maxFileSize,
       this.getMaterializedKnowledgeBases(),
-      { maxDepth: this.config.indexing.maxDepth, maxFilesPerDirectory: this.config.indexing.maxFilesPerDirectory }
+      {
+        maxDepth: this.config.indexing.maxDepth,
+        maxFilesPerDirectory: this.config.indexing.maxFilesPerDirectory,
+        signal: options.signal,
+        heartbeat: options.heartbeat,
+      }
     );
 
     return createCostEstimate(files, configuredProviderInfo);
@@ -4091,7 +4190,8 @@ export class Indexer {
   // an upper bound because cached chunks are counted here but not re-embedded.
   // Used by index_codebase(dryRun:true) to give a stable, monotonic progress
   // denominator that matches the live "Tokens used" basis.
-  async dryRunCost(): Promise<DryRunEstimate> {
+  async dryRunCost(options: IndexOperationOptions = {}): Promise<DryRunEstimate> {
+    throwIfOperationAborted(options.signal);
     const { configuredProviderInfo } = await this.ensureInitialized();
     const maxChunkTokens = getSafeEmbeddingChunkTokenLimit(configuredProviderInfo);
     const includePatterns = [...this.config.include, ...this.config.additionalInclude];
@@ -4101,7 +4201,12 @@ export class Indexer {
       this.config.exclude,
       this.config.indexing.maxFileSize,
       this.getMaterializedKnowledgeBases(),
-      { maxDepth: this.config.indexing.maxDepth, maxFilesPerDirectory: this.config.indexing.maxFilesPerDirectory },
+      {
+        maxDepth: this.config.indexing.maxDepth,
+        maxFilesPerDirectory: this.config.indexing.maxFilesPerDirectory,
+        signal: options.signal,
+        heartbeat: options.heartbeat,
+      },
     );
 
     let filesCount = 0;
@@ -4113,6 +4218,7 @@ export class Indexer {
     // then sum estimateTokens over the embedding text (createEmbeddingTexts)
     // — the identical basis the provider reports as "Tokens used".
     for (const batch of iterateOrderedFileBatches(files, (f) => f.size, this.fileBatchLimits)) {
+      throwIfOperationAborted(options.signal);
       const loadedFiles = await Promise.all(batch.map(async (f) => {
         try {
           return {
@@ -4161,10 +4267,20 @@ export class Indexer {
     return { filesCount, chunksCount, tokensToEmbed };
   }
 
-  async index(onProgress?: ProgressCallback): Promise<IndexStats> {
+  async index(onProgress?: ProgressCallback, options: IndexOperationOptions = {}): Promise<IndexStats> {
+    throwIfOperationAborted(options.signal);
     return this.withIndexMutationLease("index", async (recoveredOwners) => {
-      return this.indexUnlocked(onProgress, recoveredOwners);
-    });
+      throwIfOperationAborted(options.signal);
+      return this.indexUnlocked(
+        onProgress,
+        recoveredOwners,
+        false,
+        options.signal,
+        options.setPhase,
+        options.heartbeat,
+        options.onProviderError,
+      );
+    }, options.signal);
   }
 
   private getLocalModuleResolutionState(files: readonly { path: string }[]): LocalModuleResolutionState {
@@ -4198,7 +4314,9 @@ export class Indexer {
     branch: string,
     commit: string,
     onProgress?: ProgressCallback,
+    options: IndexOperationOptions = {},
   ): Promise<BranchIndexResult> {
+    throwIfOperationAborted(options.signal);
     if (!isFullGitCommit(commit)) {
       throw new Error(`Branch commit is invalid: ${JSON.stringify(commit)}`);
     }
@@ -4215,7 +4333,9 @@ export class Indexer {
     }
 
     return this.withIndexMutationLease("index", async (recoveredOwners) => {
+      throwIfOperationAborted(options.signal);
       const { database } = await this.ensureInitializedUnlocked(recoveredOwners);
+      throwIfOperationAborted(options.signal);
       if (branch !== this.currentBranch) {
         throw new Error(
           `Prepared Indexer branch mismatch: expected ${JSON.stringify(branch)}, got ${JSON.stringify(this.currentBranch)}.`,
@@ -4229,21 +4349,35 @@ export class Indexer {
         return { prepared: false };
       }
 
-      const stats = await this.indexUnlocked(onProgress, [], true);
+      const stats = await this.indexUnlocked(
+        onProgress,
+        [],
+        true,
+        options.signal,
+        options.setPhase,
+        options.heartbeat,
+        options.onProviderError,
+      );
       return { prepared: true, stats };
-    });
+    }, options.signal);
   }
 
   private async indexUnlocked(
     onProgress?: ProgressCallback,
     recoveredOwners: readonly IndexLockOwner[] = [],
     stateReady = false,
+    signal?: AbortSignal,
+    setPhase?: (phase: string) => void | Promise<void>,
+    heartbeat?: () => void | Promise<void>,
+    onProviderError?: (error: ProviderRequestError) => void,
   ): Promise<IndexStats> {
+    throwIfOperationAborted(signal);
     const { store, provider, invertedIndex, database, configuredProviderInfo } = stateReady
       ? this.requireLoadedIndexState()
       : await this.ensureInitializedUnlocked(recoveredOwners);
+    throwIfOperationAborted(signal);
     const materializedCommit = isGitRepo(this.materializedProjectRoot)
-      ? await resolveLocalGitCommit(this.materializedProjectRoot, "HEAD")
+      ? await resolveLocalGitCommit(this.materializedProjectRoot, "HEAD", signal)
       : null;
     if (this.expectedCommitOverride && materializedCommit !== this.expectedCommitOverride) {
       throw new Error(
@@ -4323,8 +4457,14 @@ export class Indexer {
       this.config.exclude,
       this.config.indexing.maxFileSize,
       this.getMaterializedKnowledgeBases(),
-      { maxDepth: this.config.indexing.maxDepth, maxFilesPerDirectory: this.config.indexing.maxFilesPerDirectory },
+      {
+        maxDepth: this.config.indexing.maxDepth,
+        maxFilesPerDirectory: this.config.indexing.maxFilesPerDirectory,
+        signal,
+        heartbeat,
+      },
     );
+    throwIfOperationAborted(signal);
 
     stats.totalFiles = files.length;
     stats.skippedFiles = skipped.map((entry) => ({
@@ -4367,12 +4507,18 @@ export class Indexer {
       ),
     );
 
-    for (const file of files) {
+    for (const [fileIndex, file] of files.entries()) {
+      throwIfOperationAborted(signal);
+      if (fileIndex > 0 && fileIndex % 128 === 0) {
+        await heartbeat?.();
+        throwIfOperationAborted(signal);
+      }
       const storedPath = this.toStoredFilePath(file.path);
       let currentHash: string;
       try {
         currentHash = hashFile(file.path);
       } catch (error) {
+        throwIfOperationAborted(signal);
         // A file that is unreadable at the OS level (e.g., an LSM denial that
         // returns EPERM despite readable mode bits, or a permissions error)
         // must not abort the whole index. The hash step opens the file; a bare
@@ -4437,7 +4583,13 @@ export class Indexer {
     }
 
     if (javaScriptGraphSourcesChanged) {
+      let processedDescriptors = 0;
       for (const [storedPath, descriptor] of allFileDescriptors) {
+        if (processedDescriptors > 0 && processedDescriptors % 256 === 0) {
+          await heartbeat?.();
+          throwIfOperationAborted(signal);
+        }
+        processedDescriptors += 1;
         if (!isJavaScriptFamilyFilePath(storedPath) || changedFilePathSet.has(storedPath)) continue;
         unchangedFilePaths.delete(storedPath);
         changedFileDescriptors.push(descriptor);
@@ -4446,7 +4598,13 @@ export class Indexer {
     }
 
     if (changedGoPackageDirectories.size > 0) {
+      let processedDescriptors = 0;
       for (const [storedPath, descriptor] of allFileDescriptors) {
+        if (processedDescriptors > 0 && processedDescriptors % 256 === 0) {
+          await heartbeat?.();
+          throwIfOperationAborted(signal);
+        }
+        processedDescriptors += 1;
         const normalizedStoredPath = storedPath.split(path.sep).join("/");
         if (
           !isGoFilePath(normalizedStoredPath)
@@ -4461,7 +4619,13 @@ export class Indexer {
       }
     }
 
+    let processedCacheEntries = 0;
     for (const storedPath of allFileDescriptors.keys()) {
+      if (processedCacheEntries > 0 && processedCacheEntries % 256 === 0) {
+        await heartbeat?.();
+        throwIfOperationAborted(signal);
+      }
+      processedCacheEntries += 1;
       if (changedFilePathSet.has(storedPath)) {
         this.logger.recordCacheMiss();
       } else {
@@ -4485,7 +4649,13 @@ export class Indexer {
     const existingChunks = new Map<string, string>();
     const existingChunksByFile = new Map<string, Set<string>>();
     const existingMetadataById = new Map<string, ChunkMetadata>();
+    let processedMetadata = 0;
     for (const { key, metadata } of store.getAllMetadata()) {
+      if (processedMetadata > 0 && processedMetadata % 256 === 0) {
+        await heartbeat?.();
+        throwIfOperationAborted(signal);
+      }
+      processedMetadata += 1;
       if (scopedRoots && !this.isFileInCurrentScope(metadata.filePath, scopedRoots)) {
         continue;
       }
@@ -4545,9 +4715,11 @@ export class Indexer {
     const localModuleResolver = new LocalModuleCallResolver({
       filePaths: [...sourceDescriptorsByPath.keys()],
       loadModule: async (filePath) => {
+        throwIfOperationAborted(signal);
         const descriptor = sourceDescriptorsByPath.get(filePath);
         if (!descriptor) return undefined;
         const content = await fsPromises.readFile(descriptor.materializedPath, "utf-8");
+        throwIfOperationAborted(signal);
         if (unchangedFilePaths.has(descriptor.storedPath)) {
           const symbols = database.getSymbolsByFile(descriptor.storedPath).filter((symbol) =>
             !restrictExistingChunksToBranch || previousBranchSymbolIdSet.has(symbol.id)
@@ -4599,7 +4771,10 @@ export class Indexer {
             this.toMaterializedFilePath(chunk.filePath),
             chunk.startLine,
             chunk.endLine,
+            signal,
           );
+          await heartbeat?.();
+          throwIfOperationAborted(signal);
           const blameMetadata = metadataFromBlame(blame);
           if (!blameMetadata.blameSha) {
             continue;
@@ -4649,11 +4824,13 @@ export class Indexer {
         (descriptor) => descriptor.sourceBytes,
         this.fileBatchLimits,
       )) {
+        throwIfOperationAborted(signal);
         const loadedFiles = await Promise.all(descriptorBatch.map(async (descriptor) => ({
           path: descriptor.storedPath,
           content: await fsPromises.readFile(descriptor.materializedPath, "utf-8"),
           hash: descriptor.hash,
         })));
+        throwIfOperationAborted(signal);
         const loadedByPath = new Map(loadedFiles.map((file) => [file.path, file]));
         const descriptorByPath = new Map(descriptorBatch.map((descriptor) => [descriptor.storedPath, descriptor]));
         const parseStartTime = performance.now();
@@ -4709,8 +4886,13 @@ export class Indexer {
                   descriptor.materializedPath,
                   chunk.startLine,
                   chunk.endLine,
+                  signal,
                 )
               : blameFromChunkData(existingChunk);
+            if (gitBlameEnabled && existingContentHash !== contentHash) {
+              await heartbeat?.();
+              throwIfOperationAborted(signal);
+            }
             const blameMetadata = metadataFromBlame(blame);
             currentChunkIds.add(id);
 
@@ -4890,6 +5072,10 @@ export class Indexer {
             forceReembed: forceScopedReembed,
             reuseCachedEmbeddings: true,
             incrementRepeatedFailures: true,
+            signal,
+            setPhase,
+            heartbeat,
+            onProviderError,
             onSucceeded: (succeededChunks) => {
               database.addChunksToBranchBatch(
                 this.getBranchCatalogKey(),
@@ -4949,6 +5135,7 @@ export class Indexer {
         ({ chunk }) => Buffer.byteLength(chunk.content, "utf-8"),
         this.fileBatchLimits,
       )) {
+        throwIfOperationAborted(signal);
         const pendingChunks = retryBatch.map(({ chunk }) => chunk);
         const attemptCounts = new Map(retryBatch.map(({ chunk, attemptCount }) => [chunk.id, attemptCount]));
         for (const chunk of pendingChunks) {
@@ -4986,6 +5173,10 @@ export class Indexer {
           reuseCachedEmbeddings: true,
           incrementRepeatedFailures: true,
           forceSingleItemBatches: true,
+          signal,
+          setPhase,
+          heartbeat,
+          onProviderError,
           onSucceeded: (succeededChunks) => {
             database.addChunksToBranchBatch(
               this.getBranchCatalogKey(),
@@ -5074,6 +5265,7 @@ export class Indexer {
         this.saveBranchCommit(database, indexedCommit);
         this.saveIndexMetadata(configuredProviderInfo);
         this.indexCompatibility = { compatible: true };
+        throwIfOperationAborted(signal);
         database.commitWriteTransaction();
         writeTransactionActive = false;
         this.finalizeFailedBatchWriteState(failedProcessing.state, resolvedRetryChunkIds);
@@ -5113,6 +5305,7 @@ export class Indexer {
         this.saveBranchCommit(database, indexedCommit);
         this.saveIndexMetadata(configuredProviderInfo);
         this.indexCompatibility = { compatible: true };
+        throwIfOperationAborted(signal);
         database.commitWriteTransaction();
         writeTransactionActive = false;
         this.finalizeFailedBatchWriteState(failedProcessing.state, resolvedRetryChunkIds);
@@ -5159,6 +5352,7 @@ export class Indexer {
 
       store.save();
       this.saveInvertedIndex(invertedIndex);
+      throwIfOperationAborted(signal);
       database.commitWriteTransaction();
       writeTransactionActive = false;
       this.finalizeFailedBatchWriteState(failedProcessing.state, resolvedRetryChunkIds);
@@ -5240,7 +5434,14 @@ export class Indexer {
     }
   }
 
-  private async getQueryEmbedding(query: string, provider: EmbeddingProviderInterface): Promise<number[]> {
+  private async getQueryEmbedding(
+    query: string,
+    provider: EmbeddingProviderInterface,
+    signal?: AbortSignal,
+    setPhase?: (phase: string) => void | Promise<void>,
+    heartbeat?: () => void | Promise<void>,
+  ): Promise<number[]> {
+    throwIfOperationAborted(signal);
     const now = Date.now();
     const cached = this.queryEmbeddingCache.get(query);
 
@@ -5263,7 +5464,8 @@ export class Indexer {
 
     this.logger.cache("debug", "Query embedding cache miss", { query: query.slice(0, 50) });
     this.logger.recordQueryCacheMiss();
-    const { embedding, tokensUsed } = await provider.embedQuery(query);
+    const { embedding, tokensUsed } = await provider.embedQuery(query, { signal, setPhase, heartbeat });
+    throwIfOperationAborted(signal);
     this.logger.recordEmbeddingApiCall(tokensUsed);
 
     if (this.queryEmbeddingCache.size >= this.maxQueryCacheSize) {
@@ -5443,7 +5645,9 @@ export class Indexer {
     limit?: number,
     options?: SearchOptions
   ): Promise<SearchResult[]> {
+    throwIfOperationAborted(options?.signal);
     const { store, provider, invertedIndex, database, readIssues, compatibility } = await this.ensureInitialized();
+    throwIfOperationAborted(options?.signal);
     this.requireReadableComponents(readIssues, "vectors", "database");
 
     if (!compatibility.compatible) {
@@ -5489,8 +5693,16 @@ export class Indexer {
     const embeddingQuery = stripFilePathHint(query);
     let embedding: number[] | undefined;
     try {
-      embedding = await this.getQueryEmbedding(embeddingQuery, provider);
+      embedding = await this.getQueryEmbedding(
+        embeddingQuery,
+        provider,
+        options?.signal,
+        options?.setPhase,
+        options?.heartbeat,
+      );
     } catch (error) {
+      if (isOperationInterruption(error)) throw error;
+      throwIfOperationAborted(options?.signal);
       this.logger.warn("Query embedding failed; falling back to keyword-only search", {
         query,
         error: getErrorMessage(error),
@@ -5565,7 +5777,11 @@ export class Indexer {
     const rerankedCombined = await this.rerankCandidatesWithApi(query, combined, {
       definitionIntent: options?.definitionIntent === true,
       hasIdentifierHints: identifierHints.length > 0,
+      signal: options?.signal,
+      setPhase: options?.setPhase,
+      heartbeat: options?.heartbeat,
     });
+    throwIfOperationAborted(options?.signal);
     const fusionMs = performance.now() - fusionStartTime;
 
     const rescued = promoteIdentifierMatches(
@@ -5899,14 +6115,26 @@ export class Indexer {
     return { readable: true, current: true, reason: "current" };
   }
 
-  async forceIndex(onProgress?: ProgressCallback): Promise<IndexStats> {
+  async forceIndex(onProgress?: ProgressCallback, options: IndexOperationOptions = {}): Promise<IndexStats> {
+    throwIfOperationAborted(options.signal);
     return this.withIndexMutationLease("force-index", async (recoveredOwners) => {
+      throwIfOperationAborted(options.signal);
       await this.ensureInitializedUnlocked(recoveredOwners);
+      throwIfOperationAborted(options.signal);
       const recovery = this.beginClearRecoveryState();
-      await this.clearIndexUnlocked(recovery.compatibilityDecision);
+      await this.clearIndexUnlocked(recovery.compatibilityDecision, options.signal);
+      throwIfOperationAborted(options.signal);
       this.finishClearRecoveryState();
-      return this.indexUnlocked(onProgress, [], true);
-    });
+      return this.indexUnlocked(
+        onProgress,
+        [],
+        true,
+        options.signal,
+        options.setPhase,
+        options.heartbeat,
+        options.onProviderError,
+      );
+    }, options.signal);
   }
 
   async clearIndex(): Promise<void> {
@@ -6009,11 +6237,15 @@ export class Indexer {
 
   private async clearIndexUnlocked(
     recoveryDecision?: IndexLockClearRecoveryState["compatibilityDecision"],
+    signal?: AbortSignal,
   ): Promise<void> {
+    throwIfOperationAborted(signal);
     const { store, invertedIndex, database } = this.requireLoadedIndexState();
 
     if (this.config.scope === "global") {
+      throwIfOperationAborted(signal);
       this.clearGlobalIndexUnlocked(this.projectRoot, this.getScopedRoots(), recoveryDecision);
+      throwIfOperationAborted(signal);
       return;
     }
 
@@ -6031,7 +6263,9 @@ export class Indexer {
     this.saveInvertedIndex(invertedIndex);
 
     this.fileHashCache.clear();
+    throwIfOperationAborted(signal);
     await this.removeProjectRuntimeStateArtifacts();
+    throwIfOperationAborted(signal);
 
     // cannot reuse stale chunks, symbols, or embeddings from a prior provider.
     database.clearAllIndexedData();
@@ -6050,34 +6284,45 @@ export class Indexer {
     database.deleteMetadata("index.updatedAt");
 
     this.indexCompatibility = this.validateIndexCompatibility(this.configuredProviderInfo!);
+    throwIfOperationAborted(signal);
   }
 
-  async healthCheck(): Promise<HealthCheckResult> {
+  async healthCheck(options: IndexOperationOptions = {}): Promise<HealthCheckResult> {
+    throwIfOperationAborted(options.signal);
     return this.withIndexMutationLease("health-check", async (recoveredOwners) => {
+      throwIfOperationAborted(options.signal);
       await this.ensureInitializedUnlocked(recoveredOwners);
-      return this.healthCheckUnlocked();
-    });
+      throwIfOperationAborted(options.signal);
+      return this.healthCheckUnlocked(options);
+    }, options.signal);
   }
 
-  private async healthCheckUnlocked(): Promise<HealthCheckResult> {
+  private async healthCheckUnlocked(options: IndexOperationOptions = {}): Promise<HealthCheckResult> {
+    throwIfOperationAborted(options.signal);
     const { store, invertedIndex, database } = this.requireLoadedIndexState();
 
     this.logger.gc("info", "Starting health check");
 
     const allMetadata = store.getAllMetadata();
+    throwIfOperationAborted(options.signal);
     const filePathsToChunkKeys = new Map<string, string[]>();
 
-    for (const { key, metadata } of allMetadata) {
+    for (const [index, { key, metadata }] of allMetadata.entries()) {
+      throwIfOperationAborted(options.signal);
       const existing = filePathsToChunkKeys.get(metadata.filePath) || [];
       existing.push(key);
       filePathsToChunkKeys.set(metadata.filePath, existing);
+      if ((index + 1) % 256 === 0) await options.heartbeat?.();
     }
+    await options.heartbeat?.();
+    throwIfOperationAborted(options.signal);
 
     const missingStoredFilePaths: string[] = [];
     const missingChunkKeys: string[] = [];
     const chunkKeysByRemovedFile = new Map<string, string[]>();
 
     for (const [filePath, chunkKeys] of filePathsToChunkKeys) {
+      throwIfOperationAborted(options.signal);
       if (!existsSync(this.toMaterializedFilePath(filePath))) {
         chunkKeysByRemovedFile.set(filePath, chunkKeys);
         for (const key of chunkKeys) {
@@ -6086,12 +6331,16 @@ export class Indexer {
         missingStoredFilePaths.push(filePath);
       }
     }
+    throwIfOperationAborted(options.signal);
 
     const branchCatalogKeys = this.getBranchCatalogKeys();
     for (const branchKey of branchCatalogKeys) {
+      throwIfOperationAborted(options.signal);
       database.deleteBranchChunksForBranch(branchKey, missingChunkKeys);
+      await options.heartbeat?.();
     }
     const referencedChunkKeys = new Set(database.getReferencedChunkIds(missingChunkKeys));
+    throwIfOperationAborted(options.signal);
     const removedChunkKeys = missingChunkKeys.filter((key) => !referencedChunkKeys.has(key));
 
     if (removedChunkKeys.length > 0) {
@@ -6100,6 +6349,7 @@ export class Indexer {
         invertedIndex.removeChunk(key);
       }
       database.deleteChunksByIds(removedChunkKeys);
+      throwIfOperationAborted(options.signal);
     }
 
     const missingSymbolIds = Array.from(new Set(
@@ -6108,9 +6358,12 @@ export class Indexer {
       )
     ));
     for (const branchKey of branchCatalogKeys) {
+      throwIfOperationAborted(options.signal);
       database.deleteBranchSymbolsForBranch(branchKey, missingSymbolIds);
+      await options.heartbeat?.();
     }
     const referencedSymbolIds = new Set(database.getReferencedSymbolIds(missingSymbolIds));
+    throwIfOperationAborted(options.signal);
     const removedSymbolIds = missingSymbolIds.filter((symbolId) => !referencedSymbolIds.has(symbolId));
     database.clearCallEdgeTargetsForSymbols(removedSymbolIds);
 
@@ -6124,6 +6377,7 @@ export class Indexer {
     if (removedCount > 0) {
       store.save();
       this.saveInvertedIndex(invertedIndex);
+      throwIfOperationAborted(options.signal);
     }
 
     let gcOrphanEmbeddings: number;
@@ -6132,11 +6386,18 @@ export class Indexer {
     let gcOrphanCallEdges: number;
 
     try {
+      throwIfOperationAborted(options.signal);
       gcOrphanEmbeddings = database.gcOrphanEmbeddings();
+      throwIfOperationAborted(options.signal);
       gcOrphanChunks = database.gcOrphanChunks();
+      throwIfOperationAborted(options.signal);
       gcOrphanSymbols = database.gcOrphanSymbols();
+      throwIfOperationAborted(options.signal);
       gcOrphanCallEdges = database.gcOrphanCallEdges();
+      throwIfOperationAborted(options.signal);
     } catch (error) {
+      if (isOperationInterruption(error)) throw error;
+      throwIfOperationAborted(options.signal);
       if (!(await this.tryResetCorruptedIndex("running index health check", error))) {
         throw error;
       }
@@ -6342,9 +6603,14 @@ export class Indexer {
       filterByBranch?: boolean;
       blameSince?: string;
       blameUntil?: string;
+      signal?: AbortSignal;
+      setPhase?: (phase: string) => void | Promise<void>;
+      heartbeat?: () => void | Promise<void>;
     }
   ): Promise<SearchResult[]> {
+    throwIfOperationAborted(options?.signal);
     const { store, provider, database, readIssues, compatibility } = await this.ensureInitialized();
+    throwIfOperationAborted(options?.signal);
     this.requireReadableComponents(readIssues, "vectors", "database");
 
     if (!compatibility.compatible) {
@@ -6373,7 +6639,12 @@ export class Indexer {
     });
 
     const embeddingStartTime = performance.now();
-    const { embedding, tokensUsed } = await provider.embedDocument(code);
+    const { embedding, tokensUsed } = await provider.embedDocument(code, {
+      signal: options?.signal,
+      setPhase: options?.setPhase,
+      heartbeat: options?.heartbeat,
+    });
+    throwIfOperationAborted(options?.signal);
     const embeddingMs = performance.now() - embeddingStartTime;
     this.logger.recordEmbeddingApiCall(tokensUsed);
 
@@ -6497,17 +6768,22 @@ export class Indexer {
     targetName: string,
     includeUnresolved: boolean,
     callTypeFilter?: string,
+    options: IndexOperationOptions = {},
   ): Promise<CallEdgeData[]> {
+    throwIfOperationAborted(options.signal);
     const { database, readIssues } = await this.ensureInitialized();
+    throwIfOperationAborted(options.signal);
     this.requireReadableComponents(readIssues, "database");
     const seen = new Set<string>();
     const results: CallEdgeData[] = [];
 
     for (const branchKey of this.getBranchCatalogKeys()) {
+      throwIfOperationAborted(options.signal);
       const branchSymbolIds = new Set(database.getBranchSymbolIds(branchKey));
       if (!branchSymbolIds.has(symbolId)) continue;
 
       for (const edge of database.getCallersWithContext(targetName, branchKey, callTypeFilter)) {
+        throwIfOperationAborted(options.signal);
         const matchesResolvedSymbol = edge.toSymbolId === symbolId;
         const safelyMatchesUnresolvedSymbol = includeUnresolved && !edge.toSymbolId;
         if ((!matchesResolvedSymbol && !safelyMatchesUnresolvedSymbol) || seen.has(edge.id)) continue;
@@ -6515,24 +6791,34 @@ export class Indexer {
         seen.add(edge.id);
         results.push(this.resolveCallEdgeFilePath(edge));
       }
+      await options.heartbeat?.();
     }
 
     return results;
   }
 
-  async getCallees(symbolId: string, callTypeFilter?: string): Promise<CallEdgeData[]> {
+  async getCallees(
+    symbolId: string,
+    callTypeFilter?: string,
+    options: IndexOperationOptions = {},
+  ): Promise<CallEdgeData[]> {
+    throwIfOperationAborted(options.signal);
     const { database, readIssues } = await this.ensureInitialized();
+    throwIfOperationAborted(options.signal);
     this.requireReadableComponents(readIssues, "database");
     const seen = new Set<string>();
     const results: CallEdgeData[] = [];
 
     for (const branchKey of this.getBranchCatalogKeys()) {
+      throwIfOperationAborted(options.signal);
       for (const edge of database.getCallees(symbolId, branchKey, callTypeFilter)) {
+        throwIfOperationAborted(options.signal);
         if (!seen.has(edge.id)) {
           seen.add(edge.id);
           results.push(this.resolveCallEdgeFilePath(edge));
         }
       }
+      await options.heartbeat?.();
     }
 
     return results;
@@ -6557,12 +6843,16 @@ export class Indexer {
     fromSymbolId: string,
     toSymbolId: string,
     maxDepth = 10,
+    options: IndexOperationOptions = {},
   ): Promise<PathHopData[]> {
+    throwIfOperationAborted(options.signal);
     const { database, readIssues } = await this.ensureInitialized();
+    throwIfOperationAborted(options.signal);
     this.requireReadableComponents(readIssues, "database");
     let shortest: PathHopData[] = [];
 
     for (const branchKey of this.getBranchCatalogKeys()) {
+      throwIfOperationAborted(options.signal);
       const symbols = database.getSymbolsForBranch(branchKey);
       const symbolsById = new Map(symbols.map((symbol) => [symbol.id, symbol]));
       if (!symbolsById.has(fromSymbolId) || !symbolsById.has(toSymbolId)) continue;
@@ -6574,12 +6864,14 @@ export class Indexer {
       let found = fromSymbolId === toSymbolId;
 
       while (!found && queueIndex < queue.length) {
+        throwIfOperationAborted(options.signal);
         const current = queue[queueIndex++];
         if (current.depth >= maxDepth) continue;
 
         const currentSymbol = symbolsById.get(current.symbolId);
         if (!currentSymbol) continue;
         for (const edge of database.getCallees(current.symbolId, branchKey)) {
+          throwIfOperationAborted(options.signal);
           let nextSymbolId: string | undefined;
 
           if (edge.toSymbolId && symbolsById.has(edge.toSymbolId)) {
@@ -6608,6 +6900,7 @@ export class Indexer {
 
           queue.push({ symbolId: nextSymbolId, depth: current.depth + 1 });
         }
+        if (queueIndex % 128 === 0) await options.heartbeat?.();
       }
 
       if (!found) continue;
@@ -6633,20 +6926,26 @@ export class Indexer {
       if (path.length > 0 && (shortest.length === 0 || path.length < shortest.length)) {
         shortest = path;
       }
+      await options.heartbeat?.();
     }
 
     return shortest.map((hop) => this.resolveFilePathRecord(hop));
   }
 
-  async getCallGraphSymbols(): Promise<SymbolData[]> {
+  async getCallGraphSymbols(options: IndexOperationOptions = {}): Promise<SymbolData[]> {
+    throwIfOperationAborted(options.signal);
     const { database, readIssues } = await this.ensureInitialized();
+    throwIfOperationAborted(options.signal);
     this.requireReadableComponents(readIssues, "database");
     const symbols = new Map<string, SymbolData>();
 
     for (const branchKey of this.getBranchCatalogKeys()) {
+      throwIfOperationAborted(options.signal);
       for (const symbol of database.getSymbolsForBranch(branchKey)) {
+        throwIfOperationAborted(options.signal);
         symbols.set(symbol.id, this.resolveFilePathRecord(symbol));
       }
+      await options.heartbeat?.();
     }
 
     return [...symbols.values()];
@@ -6681,34 +6980,84 @@ export class Indexer {
       .map((entry) => this.resolveFilePathRecord(entry));
   }
 
-  async detectCommunities(branch?: string, symbolIds?: string[]): Promise<CommunityData[]> {
+  async detectCommunities(
+    branch?: string,
+    symbolIds?: string[],
+    options: IndexOperationOptions = {},
+  ): Promise<CommunityData[]> {
+    throwIfOperationAborted(options.signal);
     const { database, readIssues } = await this.ensureInitialized();
+    throwIfOperationAborted(options.signal);
     this.requireReadableComponents(readIssues, "database");
     const resolvedBranch = this.resolveBranchCatalogKey(branch);
-    return database.detectCommunities(resolvedBranch, symbolIds)
-      .map((entry) => this.resolveFilePathRecord(entry));
+    const communities = database.detectCommunities(resolvedBranch, symbolIds);
+    throwIfOperationAborted(options.signal);
+    await options.heartbeat?.();
+    throwIfOperationAborted(options.signal);
+    const result: CommunityData[] = [];
+    for (const [index, entry] of communities.entries()) {
+      result.push(this.resolveFilePathRecord(entry));
+      if ((index + 1) % 256 === 0) {
+        await options.heartbeat?.();
+        throwIfOperationAborted(options.signal);
+      }
+    }
+    return result;
   }
 
-  async detectCommunityCouplings(branch?: string): Promise<CommunityCouplingData[]> {
+  async detectCommunityCouplings(
+    branch?: string,
+    options: IndexOperationOptions = {},
+  ): Promise<CommunityCouplingData[]> {
+    throwIfOperationAborted(options.signal);
     const { database, readIssues } = await this.ensureInitialized();
+    throwIfOperationAborted(options.signal);
     this.requireReadableComponents(readIssues, "database");
     const resolvedBranch = this.resolveBranchCatalogKey(branch);
-    return database.detectCommunityCouplings(resolvedBranch).map((entry) => ({
+    const couplings = database.detectCommunityCouplings(resolvedBranch);
+    throwIfOperationAborted(options.signal);
+    await options.heartbeat?.();
+    throwIfOperationAborted(options.signal);
+    const result: CommunityCouplingData[] = [];
+    for (const [index, entry] of couplings.entries()) {
+      result.push({
       ...entry,
       relationships: (entry.relationships ?? entry.representativeRelationships ?? []).map((relationship) => ({
         ...relationship,
         fromFilePath: this.resolveStoredFilePath(relationship.fromFilePath),
         toFilePath: this.resolveStoredFilePath(relationship.toFilePath),
       })),
-    }));
+      });
+      if ((index + 1) % 256 === 0) {
+        await options.heartbeat?.();
+        throwIfOperationAborted(options.signal);
+      }
+    }
+    return result;
   }
 
-  async computeCentrality(branch?: string): Promise<CentralityData[]> {
+  async computeCentrality(
+    branch?: string,
+    options: IndexOperationOptions = {},
+  ): Promise<CentralityData[]> {
+    throwIfOperationAborted(options.signal);
     const { database, readIssues } = await this.ensureInitialized();
+    throwIfOperationAborted(options.signal);
     this.requireReadableComponents(readIssues, "database");
     const resolvedBranch = this.resolveBranchCatalogKey(branch);
-    return database.computeCentrality(resolvedBranch)
-      .map((entry) => this.resolveFilePathRecord(entry));
+    const centrality = database.computeCentrality(resolvedBranch);
+    throwIfOperationAborted(options.signal);
+    await options.heartbeat?.();
+    throwIfOperationAborted(options.signal);
+    const result: CentralityData[] = [];
+    for (const [index, entry] of centrality.entries()) {
+      result.push(this.resolveFilePathRecord(entry));
+      if ((index + 1) % 256 === 0) {
+        await options.heartbeat?.();
+        throwIfOperationAborted(options.signal);
+      }
+    }
+    return result;
   }
 
   async getPrImpact(opts: {
@@ -6718,8 +7067,10 @@ export class Indexer {
     hubThreshold?: number;
     checkConflicts?: boolean;
     direction?: "callers" | "callees" | "both";
-  }, onPreparationProgress?: ProgressCallback): Promise<PrImpactResult> {
+  }, onPreparationProgress?: ProgressCallback, options: IndexOperationOptions = {}): Promise<PrImpactResult> {
+    throwIfOperationAborted(options.signal);
     const initialState = await this.ensureInitialized();
+    throwIfOperationAborted(options.signal);
     let database = initialState.database;
     const { readIssues } = initialState;
     this.requireReadableComponents(readIssues, "database");
@@ -6730,10 +7081,12 @@ export class Indexer {
       branch: opts.branch,
       projectRoot: this.projectRoot,
       baseBranch: this.baseBranch,
+      signal: options.signal,
     });
     const changedFiles = changedFilesResult.files;
     const headRefName = changedFilesResult.headRefName;
     const expectedCommit = changedFilesResult.headRef;
+    throwIfOperationAborted(options.signal);
 
     if (opts.pr !== undefined && headRefName === undefined) {
       throw new Error(
@@ -6776,6 +7129,7 @@ export class Indexer {
         totalChunks: 0,
       });
       this.resetLoadedIndexState();
+      throwIfOperationAborted(options.signal);
       const materialized = await withMaterializedBranch(
         {
           projectRoot: this.projectRoot,
@@ -6784,6 +7138,7 @@ export class Indexer {
           expectedCommit,
           pr: opts.pr,
           repository: changedFilesResult.baseRepository,
+          signal: options.signal,
         },
         async (worktreePath, info) => {
           const branchIndexer = new Indexer(this.projectRoot, this.config, this.host, {
@@ -6798,6 +7153,7 @@ export class Indexer {
               resolvedBranch,
               info.commit,
               onPreparationProgress,
+              options,
             );
           } finally {
             await branchIndexer.close();
@@ -6813,6 +7169,7 @@ export class Indexer {
       };
 
       const refreshedState = await this.ensureInitialized();
+      throwIfOperationAborted(options.signal);
       this.requireReadableComponents(refreshedState.readIssues, "database");
       database = refreshedState.database;
       branchSymbols = database.getSymbolsForBranch(branchKey);
@@ -6829,7 +7186,9 @@ export class Indexer {
     const toStoredChangedFiles = (filePaths: readonly string[]): string[] =>
       filePaths.map((filePath) => this.toStoredFilePath(path.resolve(this.projectRoot, filePath)));
     const storedChangedFiles = toStoredChangedFiles(changedFiles);
+    throwIfOperationAborted(options.signal);
     const directSymbols = database.getSymbolsForFiles(storedChangedFiles, branchKey);
+    throwIfOperationAborted(options.signal);
     const directIds = directSymbols.map((s) => s.id);
 
     const direction = opts.direction ?? "both";
@@ -6840,16 +7199,22 @@ export class Indexer {
       direction,
       maxDepth
     );
+    throwIfOperationAborted(options.signal);
 
     const affectedIdsSet = new Set<string>(directIds);
-    for (const caller of transitiveCallers) {
+    for (const [index, caller] of transitiveCallers.entries()) {
       affectedIdsSet.add(caller.symbolId);
+      if ((index + 1) % 256 === 0) {
+        await options.heartbeat?.();
+        throwIfOperationAborted(options.signal);
+      }
     }
     const allAffectedIds = Array.from(affectedIdsSet);
 
     const communitiesData = database.detectCommunities(branchKey, allAffectedIds);
+    throwIfOperationAborted(options.signal);
     const communityMap = new Map<string, { label: string; symbolCount: number; directSymbols: Set<string> }>();
-    for (const c of communitiesData) {
+    for (const [index, c] of communitiesData.entries()) {
       if (!communityMap.has(c.communityLabel)) {
         communityMap.set(c.communityLabel, {
           label: c.communityLabel,
@@ -6862,6 +7227,10 @@ export class Indexer {
       if (directIds.includes(c.symbolId)) {
         entry.directSymbols.add(c.symbolId);
       }
+      if ((index + 1) % 256 === 0) {
+        await options.heartbeat?.();
+        throwIfOperationAborted(options.signal);
+      }
     }
     const communities = Array.from(communityMap.values()).map((c) => ({
       label: c.label,
@@ -6870,15 +7239,23 @@ export class Indexer {
     }));
 
     const centralityData = database.computeCentrality(branchKey);
+    throwIfOperationAborted(options.signal);
     const hubThreshold = opts.hubThreshold ?? 10;
-    const hubNodes = centralityData
-      .filter((c) => directIds.includes(c.symbolId) && c.callerCount >= hubThreshold)
-      .map((c) => ({
-        id: c.symbolId,
-        name: c.symbolName,
-        callerCount: c.callerCount,
-        filePath: this.resolveStoredFilePath(c.filePath),
-      }));
+    const hubNodes: PrImpactResult["hubNodes"] = [];
+    for (const [index, centrality] of centralityData.entries()) {
+      if (directIds.includes(centrality.symbolId) && centrality.callerCount >= hubThreshold) {
+        hubNodes.push({
+          id: centrality.symbolId,
+          name: centrality.symbolName,
+          callerCount: centrality.callerCount,
+          filePath: this.resolveStoredFilePath(centrality.filePath),
+        });
+      }
+      if ((index + 1) % 256 === 0) {
+        await options.heartbeat?.();
+        throwIfOperationAborted(options.signal);
+      }
+    }
 
     const totalAffected = allAffectedIds.length;
     let riskLevel: "LOW" | "MEDIUM" | "HIGH";
@@ -6899,23 +7276,31 @@ export class Indexer {
     if (opts.checkConflicts) {
       conflictingPRs = [];
       try {
+        throwIfOperationAborted(options.signal);
         const { stdout } = await execFileAsync(
           "gh",
           ["pr", "list", "--state", "open", "--json", "number,headRefName", "--limit", "10000"],
-          { cwd: this.projectRoot, timeout: 30000 }
+          { cwd: this.projectRoot, timeout: 30000, signal: options.signal }
         );
+        throwIfOperationAborted(options.signal);
         const openPRs = JSON.parse(stdout) as Array<{ number: number; headRefName: string }>;
 
         const currentCommunityLabels = new Set(communities.map((c) => c.label));
         const allCommunitiesData = database.detectCommunities(branchKey);
+        throwIfOperationAborted(options.signal);
         const symbolToCommunity = new Map<string, string>();
         const structuralKey = (filePath: string, name: string): string =>
           `${filePath.toLowerCase()}:${name.toLowerCase()}`;
-        for (const c of allCommunitiesData) {
+        for (const [index, c] of allCommunitiesData.entries()) {
           symbolToCommunity.set(structuralKey(c.filePath, c.symbolName), c.communityLabel);
+          if ((index + 1) % 256 === 0) {
+            await options.heartbeat?.();
+            throwIfOperationAborted(options.signal);
+          }
         }
 
         for (const openPr of openPRs) {
+          throwIfOperationAborted(options.signal);
           if (openPr.number === opts.pr) continue;
 
           try {
@@ -6923,15 +7308,23 @@ export class Indexer {
               pr: openPr.number,
               projectRoot: this.projectRoot,
               baseBranch: this.baseBranch,
+              signal: options.signal,
             });
+            await options.heartbeat?.();
+            throwIfOperationAborted(options.signal);
             const otherStored = toStoredChangedFiles(otherChanged.files);
             const prBranchKey = this.getBranchCatalogKeyFor(otherChanged.catalogIdentity);
             const otherSymbols = database.getSymbolsForFiles(otherStored, prBranchKey);
+            throwIfOperationAborted(options.signal);
             const otherLabels = new Set<string>();
-            for (const sym of otherSymbols) {
+            for (const [index, sym] of otherSymbols.entries()) {
               const label = symbolToCommunity.get(structuralKey(sym.filePath, sym.name));
               if (label) {
                 otherLabels.add(label);
+              }
+              if ((index + 1) % 256 === 0) {
+                await options.heartbeat?.();
+                throwIfOperationAborted(options.signal);
               }
             }
             const overlapping = Array.from(otherLabels).filter((l) =>
@@ -6944,15 +7337,21 @@ export class Indexer {
                 overlappingCommunities: overlapping,
               });
             }
-          } catch {
+          } catch (error) {
+            if (isOperationInterruption(error)) throw error;
+            throwIfOperationAborted(options.signal);
             /* skip PRs we can't analyze */
           }
+          await options.heartbeat?.();
         }
-      } catch {
+      } catch (error) {
+        if (isOperationInterruption(error)) throw error;
+        throwIfOperationAborted(options.signal);
         /* gh CLI not available or failed; skip conflict detection */
       }
     }
 
+    throwIfOperationAborted(options.signal);
     return {
       indexPreparation,
       changedFiles,
@@ -6978,16 +7377,24 @@ export class Indexer {
     };
   }
 
-  async getVisualizationData(options?: { directory?: string }): Promise<{
+  async getVisualizationData(options: {
+    directory?: string;
+    signal?: AbortSignal;
+    setPhase?: (phase: string) => void | Promise<void>;
+    heartbeat?: () => void | Promise<void>;
+  } = {}): Promise<{
     symbols: SymbolData[];
     edges: CallEdgeData[];
   }> {
+    throwIfOperationAborted(options.signal);
     const { database, store, readIssues } = await this.ensureInitialized();
+    throwIfOperationAborted(options.signal);
     this.requireReadableComponents(readIssues, "vectors", "database");
     const seenSymbols = new Map<string, SymbolData>();
     const seenEdges = new Map<string, CallEdgeData>();
 
     for (const branchKey of this.getBranchCatalogKeys()) {
+      throwIfOperationAborted(options.signal);
       // Get all symbol IDs on this branch
       const symbolIds = database.getBranchSymbolIds(branchKey);
       const symbolIdSet = new Set(symbolIds);
@@ -6997,6 +7404,7 @@ export class Indexer {
       const metadataMap = chunkIds.length > 0 ? store.getMetadataBatch(chunkIds) : new Map<string, import("../native/index.js").ChunkMetadata>();
       const filePaths = new Set<string>();
       for (const [, meta] of metadataMap) {
+        throwIfOperationAborted(options.signal);
         if (meta.filePath) filePaths.add(meta.filePath);
       }
 
@@ -7007,6 +7415,7 @@ export class Indexer {
 
       // Gather symbols from each file
       for (const filePath of filePaths) {
+        throwIfOperationAborted(options.signal);
         if (directory) {
           const absoluteFilePath = this.resolveStoredFilePath(filePath);
           const matchesRelative = filePath === directory || filePath.startsWith(directory + "/");
@@ -7026,12 +7435,14 @@ export class Indexer {
 
       // Gather edges from each symbol
       for (const symbolId of seenSymbols.keys()) {
+        throwIfOperationAborted(options.signal);
         for (const edge of database.getCallees(symbolId, branchKey)) {
           if (!seenEdges.has(edge.id)) {
             seenEdges.set(edge.id, this.resolveCallEdgeFilePath(edge));
           }
         }
       }
+      await options.heartbeat?.();
     }
 
     const symbols = [...seenSymbols.values()].sort((left, right) =>
@@ -7040,12 +7451,14 @@ export class Indexer {
       || left.startCol - right.startCol
       || left.id.localeCompare(right.id)
     );
+    throwIfOperationAborted(options.signal);
     const edges = [...seenEdges.values()].sort((left, right) =>
       left.fromSymbolId.localeCompare(right.fromSymbolId)
       || left.line - right.line
       || left.col - right.col
       || left.id.localeCompare(right.id)
     );
+    throwIfOperationAborted(options.signal);
     return { symbols, edges };
   }
 

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -6033,8 +6033,13 @@ export class Indexer {
     };
   }
 
-  async getIndexFreshness(): Promise<IndexFreshnessResult> {
+  async getIndexFreshness(options: IndexOperationOptions = {}): Promise<IndexFreshnessResult> {
+    throwIfOperationAborted(options.signal);
+    await options.setPhase?.("scanning");
+    await options.heartbeat?.();
+    throwIfOperationAborted(options.signal);
     const { store, database, readIssues, compatibility } = await this.ensureInitialized();
+    throwIfOperationAborted(options.signal);
     const blockingReadIssue = readIssues.some((issue) => issue.blocking);
     if (blockingReadIssue) {
       return { readable: false, current: false, reason: "unreadable" };
@@ -6051,6 +6056,7 @@ export class Indexer {
 
     this.fileHashCache.clear();
     this.loadFileHashCache();
+    throwIfOperationAborted(options.signal);
     const includePatterns = [...this.config.include, ...this.config.additionalInclude];
     const { files } = await collectFiles(
       this.materializedProjectRoot,
@@ -6061,9 +6067,14 @@ export class Indexer {
       {
         maxDepth: this.config.indexing.maxDepth,
         maxFilesPerDirectory: this.config.indexing.maxFilesPerDirectory,
+        signal: options.signal,
+        heartbeat: options.heartbeat,
       },
     );
+    throwIfOperationAborted(options.signal);
     const localModuleResolutionState = this.getLocalModuleResolutionState(files);
+    await options.heartbeat?.();
+    throwIfOperationAborted(options.signal);
     if (
       database.getMetadata(this.getLocalModuleResolutionConfigMetadataKey())
       !== localModuleResolutionState.configHash
@@ -6072,6 +6083,7 @@ export class Indexer {
     }
     const currentFileHashes = new Map<string, string>();
     for (const file of files) {
+      throwIfOperationAborted(options.signal);
       let hash: string;
       try {
         hash = hashFile(file.path);
@@ -6085,7 +6097,9 @@ export class Indexer {
         });
         return { readable: false, current: false, reason: "unreadable" };
       }
+      throwIfOperationAborted(options.signal);
       currentFileHashes.set(this.toStoredFilePath(file.path), hash);
+      await options.heartbeat?.();
     }
 
     const scopedRoots = this.config.scope === "global" ? this.getScopedRoots() : null;
@@ -6095,18 +6109,30 @@ export class Indexer {
     if (cachedFileHashes.size !== currentFileHashes.size) {
       return { readable: true, current: false, reason: "files-changed" };
     }
+    let comparedHashes = 0;
     for (const [filePath, currentHash] of currentFileHashes) {
+      throwIfOperationAborted(options.signal);
       if (cachedFileHashes.get(filePath) !== currentHash) {
         return { readable: true, current: false, reason: "files-changed" };
       }
+      comparedHashes += 1;
+      if (comparedHashes % 256 === 0) await options.heartbeat?.();
     }
+    await options.heartbeat?.();
+    throwIfOperationAborted(options.signal);
 
     if (!this.areBranchMigrationVersionsCurrent(database)) {
       return { readable: true, current: false, reason: "migration-required" };
     }
 
     if (isGitRepo(this.materializedProjectRoot)) {
-      const currentCommit = await resolveLocalGitCommit(this.materializedProjectRoot, "HEAD");
+      const currentCommit = await resolveLocalGitCommit(
+        this.materializedProjectRoot,
+        "HEAD",
+        options.signal,
+      );
+      await options.heartbeat?.();
+      throwIfOperationAborted(options.signal);
       if (this.getStoredBranchCommit(database) !== currentCommit) {
         return { readable: true, current: false, reason: "branch-changed" };
       }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,1 +1,5 @@
-export { attachMcpBackgroundWatcher, createMcpServer } from "./adapters/mcp/server.js";
+export {
+  attachMcpBackgroundWatcher,
+  createMcpServer,
+  markMcpServerOrderedShutdown,
+} from "./adapters/mcp/server.js";

--- a/src/tools/architecture-context.ts
+++ b/src/tools/architecture-context.ts
@@ -11,6 +11,7 @@ import { readFileSync } from "node:fs";
 import * as path from "node:path";
 
 import { estimateTokens } from "../utils/cost.js";
+import { throwIfOperationAborted } from "../utils/operation-control.js";
 import { formatCallGraphCoverage } from "../indexer/call-graph-coverage.js";
 import { deriveModules } from "./visualize/modules.js";
 
@@ -173,6 +174,7 @@ export function selectArchitectureFocusedSymbols(
   results: ArchitectureSearchEvidence[],
   symbols: SymbolData[],
   depth = ARCHITECTURE_CONTEXT_DEFAULT_DEPTH,
+  signal?: AbortSignal,
 ): SymbolData[] {
   const normalizedDepth = Math.max(1, Math.min(ARCHITECTURE_CONTEXT_MAX_DEPTH, Math.floor(depth)));
   const topScore = results[0]?.score ?? 0;
@@ -180,10 +182,14 @@ export function selectArchitectureFocusedSymbols(
   const selectedIds = new Set<string>();
 
   for (const [index, result] of results.entries()) {
+    throwIfOperationAborted(signal);
     if (index >= normalizedDepth * 3) break;
     if (index >= 2 && topScore > 0 && result.score < topScore * 0.55) continue;
 
-    const fileSymbols = symbols.filter((symbol) => sameFile(symbol.filePath, result.filePath));
+    const fileSymbols = symbols.filter((symbol) => {
+      throwIfOperationAborted(signal);
+      return sameFile(symbol.filePath, result.filePath);
+    });
     const ranked = fileSymbols.slice().sort((left, right) => {
       const leftNameMatch = result.name !== undefined && left.name === result.name ? 1 : 0;
       const rightNameMatch = result.name !== undefined && right.name === result.name ? 1 : 0;

--- a/src/tools/changed-files.ts
+++ b/src/tools/changed-files.ts
@@ -9,6 +9,7 @@ import {
   resolveGitCommit,
   resolveLocalPullRequestRefs,
 } from "../git/branch-materialization.js";
+import { throwIfOperationAborted } from "../utils/operation-control.js";
 
 const execFileAsync = promisify(execFile);
 const GH_PR_VIEW_FIELDS = [
@@ -44,6 +45,7 @@ export interface GetChangedFilesOptions {
   branch?: string;
   projectRoot: string;
   baseBranch?: string;
+  signal?: AbortSignal;
 }
 
 interface GhRepositoryOwner {
@@ -91,19 +93,22 @@ export function createPullRequestCatalogIdentity(
 export async function getChangedFiles(
   opts: GetChangedFilesOptions,
 ): Promise<ChangedFilesResult> {
-  const { pr, branch, projectRoot, baseBranch = "main" } = opts;
+  const { pr, branch, projectRoot, baseBranch = "main", signal } = opts;
+  throwIfOperationAborted(signal);
 
   if (pr !== undefined) {
-    return getChangedFilesForPr(pr, projectRoot);
+    return getChangedFilesForPr(pr, projectRoot, signal);
   }
 
-  return getChangedFilesForBranch(branch, projectRoot, baseBranch);
+  return getChangedFilesForBranch(branch, projectRoot, baseBranch, signal);
 }
 
 async function getChangedFilesForPr(
   pr: number,
   projectRoot: string,
+  signal?: AbortSignal,
 ): Promise<ChangedFilesResult> {
+  throwIfOperationAborted(signal);
   if (!Number.isInteger(pr) || pr <= 0) {
     throw new Error(`Pull request number must be a positive integer: ${pr}`);
   }
@@ -113,8 +118,9 @@ async function getChangedFilesForPr(
     const { stdout } = await execFileAsync(
       "gh",
       ["pr", "view", String(pr), "--json", GH_PR_VIEW_FIELDS],
-      { cwd: projectRoot, timeout: 30000, encoding: "utf8" },
+      { cwd: projectRoot, timeout: 30000, encoding: "utf8", signal },
     );
+    throwIfOperationAborted(signal);
 
     const data = JSON.parse(stdout) as GhPrViewResponse;
     const baseRepository = getRepositoryFromPrUrl(data.url, pr);
@@ -151,10 +157,11 @@ async function getChangedFilesForPr(
       headRepositoryIdentity,
     };
   } catch (error) {
+    throwIfOperationAborted(signal);
     ghError = error;
   }
 
-  const localRefs = await resolveLocalPullRequestRefs(projectRoot, pr);
+  const localRefs = await resolveLocalPullRequestRefs(projectRoot, pr, signal);
   if (!localRefs?.baseCommit) {
     const ghFailure = ghError === undefined
       ? "gh returned incomplete PR head/base metadata"
@@ -168,7 +175,7 @@ async function getChangedFilesForPr(
   const localRepositoryIdentity = getLocalRepositoryIdentity(projectRoot);
   const headRepositoryIdentity = `${localRepositoryIdentity}/refs/pull/${pr}/head`;
   return {
-    files: await getDiffFiles(projectRoot, localRefs.baseCommit, localRefs.headCommit),
+    files: await getDiffFiles(projectRoot, localRefs.baseCommit, localRefs.headCommit, signal),
     baseBranch: localRefs.baseCommit,
     source: "git",
     catalogIdentity: createPullRequestCatalogIdentity(
@@ -242,23 +249,25 @@ async function getChangedFilesForBranch(
   branch: string | undefined,
   projectRoot: string,
   baseBranch: string,
+  signal?: AbortSignal,
 ): Promise<ChangedFilesResult> {
-  const targetBranch = branch || (await getCurrentBranch(projectRoot));
+  throwIfOperationAborted(signal);
+  const targetBranch = branch || (await getCurrentBranch(projectRoot, signal));
   assertValidGitRefName(baseBranch, "Base branch");
   assertValidGitRefName(targetBranch, "Branch name");
 
-  const resolvedBase = await resolveGitCommit(projectRoot, baseBranch);
+  const resolvedBase = await resolveGitCommit(projectRoot, baseBranch, signal);
   if (!resolvedBase) {
     throw new Error(`Could not resolve base branch ${JSON.stringify(baseBranch)} to a commit.`);
   }
-  const resolvedHead = await resolveGitCommit(projectRoot, targetBranch);
+  const resolvedHead = await resolveGitCommit(projectRoot, targetBranch, signal);
   if (!resolvedHead) {
     throw new Error(`Could not resolve branch ${JSON.stringify(targetBranch)} to a commit.`);
   }
-  const mergeBase = await getMergeBase(projectRoot, resolvedBase, resolvedHead);
+  const mergeBase = await getMergeBase(projectRoot, resolvedBase, resolvedHead, signal);
 
   return {
-    files: await getDiffFiles(projectRoot, mergeBase, resolvedHead),
+    files: await getDiffFiles(projectRoot, mergeBase, resolvedHead, signal),
     baseBranch,
     source: "git",
     catalogIdentity: targetBranch,
@@ -271,24 +280,29 @@ async function getDiffFiles(
   projectRoot: string,
   baseRef: string,
   headRef: string,
+  signal?: AbortSignal,
 ): Promise<string[]> {
+  throwIfOperationAborted(signal);
   if (!isFullGitCommit(baseRef) || !isFullGitCommit(headRef)) {
     throw new Error("Changed-file diff requires fully resolved commit OIDs.");
   }
   const { stdout } = await execFileAsync(
     "git",
     ["diff", "--name-only", "-z", `${baseRef}...${headRef}`, "--"],
-    { cwd: projectRoot, timeout: 30000, encoding: "utf8" },
+    { cwd: projectRoot, timeout: 30000, encoding: "utf8", signal },
   );
+  throwIfOperationAborted(signal);
   return normalizeFiles(stdout.split("\0"), projectRoot);
 }
 
-async function getCurrentBranch(projectRoot: string): Promise<string> {
+async function getCurrentBranch(projectRoot: string, signal?: AbortSignal): Promise<string> {
+  throwIfOperationAborted(signal);
   const { stdout } = await execFileAsync(
     "git",
     ["branch", "--show-current"],
-    { cwd: projectRoot, timeout: 30000, encoding: "utf8" },
+    { cwd: projectRoot, timeout: 30000, encoding: "utf8", signal },
   );
+  throwIfOperationAborted(signal);
   return stdout.trim() || "HEAD";
 }
 
@@ -296,12 +310,15 @@ async function getMergeBase(
   projectRoot: string,
   baseCommit: string,
   headCommit: string,
+  signal?: AbortSignal,
 ): Promise<string> {
+  throwIfOperationAborted(signal);
   const { stdout } = await execFileAsync(
     "git",
     ["merge-base", "--", baseCommit, headCommit],
-    { cwd: projectRoot, timeout: 30000, encoding: "utf8" },
+    { cwd: projectRoot, timeout: 30000, encoding: "utf8", signal },
   );
+  throwIfOperationAborted(signal);
   const commit = stdout.trim().toLowerCase();
   if (!isFullGitCommit(commit)) {
     throw new Error("git merge-base did not return a full commit OID.");

--- a/src/tools/context.ts
+++ b/src/tools/context.ts
@@ -1,4 +1,5 @@
 import type { HostMode } from "../config/host.js";
+import type { OperationControl } from "../utils/operation-control.js";
 import {
   getCallGraphData,
   getCallGraphPath,
@@ -45,6 +46,7 @@ async function resolveCodebaseContextUnmeasured(
   projectRoot: string | undefined,
   host: HostMode,
   input: CodebaseContextInput,
+  control?: OperationControl,
 ): Promise<CodebaseContextResult> {
   const from = trimOrUndefined(input.from);
   const to = trimOrUndefined(input.to);
@@ -57,7 +59,7 @@ async function resolveCodebaseContextUnmeasured(
   const directory = input.directory ?? undefined;
   const tokenBudget = input.tokenBudget ?? undefined;
   if (from && to) {
-    const path = await getCallGraphPath(
+    const pathArgs = [
       projectRoot,
       host,
       from,
@@ -65,7 +67,10 @@ async function resolveCodebaseContextUnmeasured(
       maxDepth,
       fromFilePath,
       toFilePath,
-    );
+    ] as const;
+    const path = control
+      ? await getCallGraphPath(...pathArgs, control)
+      : await getCallGraphPath(...pathArgs);
     const pathText = formatCallGraphPathResult(path);
     if (path.path.length > 0) {
       const fitted = fitTextToContextBudget(
@@ -87,11 +92,14 @@ async function resolveCodebaseContextUnmeasured(
     }
     const resolvedFrom = path.from;
 
-    const { callers } = await getCallGraphData(projectRoot, host, {
+    const graphParams = {
       name: to,
       direction: "callers",
       filePath: toFilePath,
-    });
+    } as const;
+    const { callers } = control
+      ? await getCallGraphData(projectRoot, host, graphParams, control)
+      : await getCallGraphData(projectRoot, host, graphParams);
     const directEdge = callers.find((edge) => edge.fromSymbolId === resolvedFrom.symbolId);
     if (directEdge) {
       const location = directEdge.fromSymbolFilePath
@@ -127,21 +135,31 @@ async function resolveCodebaseContextUnmeasured(
     directory,
     diagnostic: input.diagnostic,
   }, {
-    lookup: (lookupSymbol, retrievalLimit, scope, exactSymbol, trace) => implementationLookup(projectRoot, host, lookupSymbol, {
-      limit: retrievalLimit,
-      fileType: scope.fileType,
-      directory: scope.directory,
-      exactSymbol,
-      trace,
-    }),
-    search: (queryText, retrievalLimit, scope, trace, searchOptions) => searchCodebase(projectRoot, host, queryText, {
-      limit: retrievalLimit,
-      fileType: scope.fileType,
-      directory: scope.directory,
-      metadataOnly: true,
-      trace,
-      prioritizeSourcePaths: searchOptions?.prioritizeSourcePaths,
-    }),
+    lookup: (lookupSymbol, retrievalLimit, scope, exactSymbol, trace) => {
+      const options = {
+        limit: retrievalLimit,
+        fileType: scope.fileType,
+        directory: scope.directory,
+        exactSymbol,
+        trace,
+      };
+      return control
+        ? implementationLookup(projectRoot, host, lookupSymbol, options, control)
+        : implementationLookup(projectRoot, host, lookupSymbol, options);
+    },
+    search: (queryText, retrievalLimit, scope, trace, searchOptions) => {
+      const options = {
+        limit: retrievalLimit,
+        fileType: scope.fileType,
+        directory: scope.directory,
+        metadataOnly: true,
+        trace,
+        prioritizeSourcePaths: searchOptions?.prioritizeSourcePaths,
+      };
+      return control
+        ? searchCodebase(projectRoot, host, queryText, options, control)
+        : searchCodebase(projectRoot, host, queryText, options);
+    },
   });
 }
 
@@ -180,11 +198,12 @@ export async function resolveCodebaseContext(
   projectRoot: string | undefined,
   host: HostMode,
   input: CodebaseContextInput,
+  control?: OperationControl,
 ): Promise<CodebaseContextResult> {
   const metricsEnabled = isToolEffectivenessEnabled(projectRoot, host);
   const startedAt = metricsEnabled ? performance.now() : 0;
   try {
-    const result = await resolveCodebaseContextUnmeasured(projectRoot, host, input);
+    const result = await resolveCodebaseContextUnmeasured(projectRoot, host, input, control);
     if (trimOrUndefined(input.symbol) && result.details) {
       const candidateCount = result.details.candidateCount ?? result.details.resultCount ?? result.details.selectedCount ?? 0;
       result.details.resolution = candidateCount === 0

--- a/src/tools/edit-context.ts
+++ b/src/tools/edit-context.ts
@@ -1,4 +1,9 @@
 import type { HostMode } from "../config/host.js";
+import type { OperationControl } from "../utils/operation-control.js";
+import {
+  isOperationInterruption,
+  throwIfOperationAborted,
+} from "../utils/operation-control.js";
 import type { SearchResult } from "../indexer/index.js";
 import type { CallEdgeData } from "../native/index.js";
 import {
@@ -35,13 +40,21 @@ export interface CodebaseEditContextResult {
 }
 
 export interface CodebaseEditContextDependencies {
-  searchCodebase: (query: string, options?: { limit?: number }) => Promise<SearchResult[]>;
-  implementationLookup: (query: string, options?: { limit?: number }) => Promise<SearchResult[]>;
+  searchCodebase: (
+    query: string,
+    options?: { limit?: number },
+    control?: OperationControl,
+  ) => Promise<SearchResult[]>;
+  implementationLookup: (
+    query: string,
+    options?: { limit?: number },
+    control?: OperationControl,
+  ) => Promise<SearchResult[]>;
   getCallGraphData: (params: {
     name: string;
     filePath?: string;
     direction: "callers" | "callees";
-  }) => Promise<CallGraphDataResult>;
+  }, control?: OperationControl) => Promise<CallGraphDataResult>;
 }
 
 function edgeLimit(value: number | null | undefined): number {
@@ -69,11 +82,19 @@ function pathsMatch(left: string, right: string): boolean {
 function targetSource(
   results: SearchResult[],
   resolution: Extract<CallGraphSymbolResolution, { status: "resolved" }>,
+  signal?: AbortSignal,
 ): SearchResult | undefined {
-  return results.find((result) => pathsMatch(result.filePath, resolution.filePath)
-    && result.startLine <= resolution.startLine
-    && result.endLine >= resolution.startLine)
-    ?? results.find((result) => pathsMatch(result.filePath, resolution.filePath) && result.name === resolution.name);
+  const containsLine = results.find((result) => {
+    throwIfOperationAborted(signal);
+    return pathsMatch(result.filePath, resolution.filePath)
+      && result.startLine <= resolution.startLine
+      && result.endLine >= resolution.startLine;
+  });
+  if (containsLine) return containsLine;
+  return results.find((result) => {
+    throwIfOperationAborted(signal);
+    return pathsMatch(result.filePath, resolution.filePath) && result.name === resolution.name;
+  });
 }
 
 function formatSource(result: SearchResult): string {
@@ -125,8 +146,11 @@ async function fallbackPack(
   resolution: CodebaseEditContextResult["details"]["resolution"],
   tokenBudget: number | null | undefined,
   candidateSource: SearchResult[] = [],
+  control?: OperationControl,
 ): Promise<CodebaseEditContextResult> {
-  const conceptual = await dependencies.searchCodebase(query, { limit: 5 });
+  throwIfOperationAborted(control?.signal);
+  const conceptual = await dependencies.searchCodebase(query, { limit: 5 }, control);
+  throwIfOperationAborted(control?.signal);
   const pack = buildContextPack([...candidateSource, ...conceptual], {
     tokenBudget: tokenBudget ?? undefined,
     heading: "## Conceptual evidence",
@@ -152,7 +176,9 @@ async function fallbackPack(
 export async function resolveCodebaseEditContextWithDependencies(
   input: SharedCodebaseEditContextArgs,
   dependencies: CodebaseEditContextDependencies,
+  control?: OperationControl,
 ): Promise<CodebaseEditContextResult> {
+  throwIfOperationAborted(control?.signal);
   const symbol = input.symbol?.trim();
   if (!symbol) {
     return fallbackPack(
@@ -161,6 +187,8 @@ export async function resolveCodebaseEditContextWithDependencies(
       "Risk: no authoritative symbol was supplied. Review the conceptual evidence before editing.",
       "not_requested",
       input.tokenBudget,
+      [],
+      control,
     );
   }
 
@@ -170,17 +198,20 @@ export async function resolveCodebaseEditContextWithDependencies(
       name: symbol,
       filePath: input.filePath ?? undefined,
       direction: "callers",
-    });
+    }, control);
   } catch (error) {
-    const candidates = await dependencies.implementationLookup(symbol, { limit: 5 });
-    const message = error instanceof Error ? error.message : String(error);
+    if (isOperationInterruption(error)) throw error;
+    throwIfOperationAborted(control?.signal);
+    const candidates = await dependencies.implementationLookup(symbol, { limit: 5 }, control);
+    throwIfOperationAborted(control?.signal);
     return fallbackPack(
       dependencies,
       input.query,
-      `Risk: graph data is unavailable (${message}). Target and dependencies are not graph-verified.`,
+      "Risk: graph data is unavailable. Target and dependencies are not graph-verified.",
       "graph_unavailable",
       input.tokenBudget,
       candidates,
+      control,
     );
   }
 
@@ -191,32 +222,36 @@ export async function resolveCodebaseEditContextWithDependencies(
       formatResolutionRisk(callersResult.resolution),
       callersResult.resolution.status,
       input.tokenBudget,
+      [],
+      control,
     );
   }
 
   const resolution = callersResult.resolution;
   const [definitionsResult, calleesResult] = await Promise.allSettled([
-    dependencies.implementationLookup(symbol, { limit: 10 }),
+    dependencies.implementationLookup(symbol, { limit: 10 }, control),
     dependencies.getCallGraphData({
       name: symbol,
       filePath: input.filePath ?? resolution.filePath,
       direction: "callees",
-    }),
+    }, control),
   ]);
+  throwIfOperationAborted(control?.signal);
   if (definitionsResult.status === "rejected") throw definitionsResult.reason;
 
   let graphRisk: string | undefined;
   let callees: CallEdgeData[] = [];
   if (calleesResult.status === "rejected") {
-    const message = calleesResult.reason instanceof Error ? calleesResult.reason.message : String(calleesResult.reason);
-    graphRisk = `Risk: callee graph data is unavailable (${message}). Dependency evidence is incomplete.`;
+    if (isOperationInterruption(calleesResult.reason)) throw calleesResult.reason;
+    throwIfOperationAborted(control?.signal);
+    graphRisk = "Risk: callee graph data is unavailable. Dependency evidence is incomplete.";
   } else if (calleesResult.value.resolution.status !== "resolved") {
     graphRisk = "Risk: the target resolved for callers but not callees. Dependency evidence is incomplete.";
   } else {
     callees = calleesResult.value.callees.slice(0, edgeLimit(input.calleeLimit));
   }
 
-  const source = targetSource(definitionsResult.value, resolution);
+  const source = targetSource(definitionsResult.value, resolution, control?.signal);
   const callers = callersResult.callers.slice(0, edgeLimit(input.callerLimit));
   const sourceBudget = Math.max(
     MIN_CONTEXT_PACK_TOKEN_BUDGET,
@@ -251,10 +286,28 @@ export async function resolveCodebaseEditContext(
   projectRoot: string | undefined,
   host: HostMode,
   input: SharedCodebaseEditContextArgs,
+  control?: OperationControl,
 ): Promise<CodebaseEditContextResult> {
   return resolveCodebaseEditContextWithDependencies(input, {
-    searchCodebase: (query, options) => searchCodebase(projectRoot, host, query, options),
-    implementationLookup: (query, options) => implementationLookup(projectRoot, host, query, options),
-    getCallGraphData: (params) => getCallGraphData(projectRoot, host, params),
-  });
+    searchCodebase: (query, options, operationControl) => searchCodebase(
+      projectRoot,
+      host,
+      query,
+      options,
+      operationControl,
+    ),
+    implementationLookup: (query, options, operationControl) => implementationLookup(
+      projectRoot,
+      host,
+      query,
+      options,
+      operationControl,
+    ),
+    getCallGraphData: (params, operationControl) => getCallGraphData(
+      projectRoot,
+      host,
+      params,
+      operationControl,
+    ),
+  }, control);
 }

--- a/src/tools/execute-common.ts
+++ b/src/tools/execute-common.ts
@@ -36,11 +36,14 @@ import {
   formatStatus,
 } from "./utils.js";
 import { formatCodeCommunities } from "./format-communities.js";
+import type { OperationControl } from "../utils/operation-control.js";
+import { runOperationPhase } from "../utils/operation-control.js";
 
 export interface ExecutionResult {
   text: string;
   details?: Record<string, unknown>;
   isError?: boolean;
+  error?: unknown;
 }
 
 export type IndexProgressCallback = (title: string, metadata: Record<string, unknown>) => void | Promise<void>;
@@ -49,8 +52,9 @@ export async function executeCodebaseContext(
   projectRoot: string | undefined,
   host: HostMode,
   args: SharedCodebaseContextArgs,
+  control?: OperationControl,
 ): Promise<ExecutionResult> {
-  const result = await resolveCodebaseContext(projectRoot, host, args);
+  const result = await resolveCodebaseContext(projectRoot, host, args, control);
   return { text: result.text, details: result.details };
 }
 
@@ -58,8 +62,9 @@ export async function executeCodebaseEditContext(
   projectRoot: string | undefined,
   host: HostMode,
   args: SharedCodebaseEditContextArgs,
+  control?: OperationControl,
 ): Promise<ExecutionResult> {
-  return { text: (await resolveCodebaseEditContext(projectRoot, host, args)).text };
+  return { text: (await resolveCodebaseEditContext(projectRoot, host, args, control)).text };
 }
 
 export async function executeIndexCodebase(
@@ -67,27 +72,33 @@ export async function executeIndexCodebase(
   host: HostMode,
   args: SharedIndexCodebaseArgs,
   onProgress?: IndexProgressCallback,
+  control?: OperationControl,
 ): Promise<ExecutionResult> {
-  const result = await runIndexCodebase(projectRoot, host, args, onProgress);
+  const result = await runIndexCodebase(projectRoot, host, args, onProgress, control);
   if (result.kind === "estimate") return { text: formatCostEstimate(result.estimate) };
   if (result.kind === "dryrun") return { text: formatDryRunEstimate(result.dryrun) };
   if (result.kind === "busy") return { text: result.text, isError: true };
   if (result.kind === "message") return { text: result.text };
-  return { text: formatIndexStats(result.stats, args.verbose ?? false) };
+  return {
+    text: formatIndexStats(result.stats, args.verbose ?? false),
+    ...(result.providerError ? { error: result.providerError } : {}),
+  };
 }
 
 export async function executeIndexStatus(
   projectRoot: string | undefined,
   host: HostMode,
+  control?: OperationControl,
 ): Promise<ExecutionResult> {
-  return { text: formatStatus(await getIndexStatus(projectRoot, host)) };
+  return { text: formatStatus(await getIndexStatus(projectRoot, host, control)) };
 }
 
 export async function executeIndexHealthCheck(
   projectRoot: string | undefined,
   host: HostMode,
+  control?: OperationControl,
 ): Promise<ExecutionResult> {
-  const result = await runIndexHealthCheck(projectRoot, host);
+  const result = await runIndexHealthCheck(projectRoot, host, control);
   if (result.kind === "busy") return { text: result.text, isError: true };
   return { text: formatHealthCheck(result.health) };
 }
@@ -96,7 +107,9 @@ export async function executeIndexMetrics(
   projectRoot: string | undefined,
   host: HostMode,
   args: SharedIndexMetricsArgs,
+  control?: OperationControl,
 ): Promise<ExecutionResult> {
+  await runOperationPhase(control, "reading_metrics");
   return { text: (await getIndexMetrics(projectRoot, host, args)).text };
 }
 
@@ -104,7 +117,9 @@ export async function executeIndexLogs(
   projectRoot: string | undefined,
   host: HostMode,
   args: SharedIndexLogsArgs,
+  control?: OperationControl,
 ): Promise<ExecutionResult> {
+  await runOperationPhase(control, "reading_logs");
   return {
     text: (await getIndexLogs(projectRoot, host, {
       limit: args.limit,
@@ -118,13 +133,14 @@ export async function executeImplementationLookup(
   projectRoot: string | undefined,
   host: HostMode,
   args: SharedImplementationLookupArgs,
+  control?: OperationControl,
 ): Promise<ExecutionResult> {
   const results = await implementationLookup(projectRoot, host, args.query, {
     limit: args.limit,
     fileType: args.fileType,
     directory: args.directory,
     exactSymbol: isExactSymbolQuery(args.query),
-  });
+  }, control);
   const exactSymbol = isExactSymbolQuery(args.query);
   return {
     text: formatDefinitionLookup(results, args.query),
@@ -142,8 +158,9 @@ export async function executeCallGraph(
   projectRoot: string | undefined,
   host: HostMode,
   args: SharedCallGraphArgs,
+  control?: OperationControl,
 ): Promise<ExecutionResult> {
-  const result = await getCallGraphData(projectRoot, host, args);
+  const result = await getCallGraphData(projectRoot, host, args, control);
   return { text: formatCallGraphResult(result), details: { resolution: result.resolution, matchKind: "exact_symbol" } };
 }
 
@@ -151,6 +168,7 @@ export async function executeCallGraphPath(
   projectRoot: string | undefined,
   host: HostMode,
   args: SharedCallGraphPathArgs,
+  control?: OperationControl,
 ): Promise<ExecutionResult> {
   const path = await getCallGraphPath(
     projectRoot,
@@ -160,6 +178,7 @@ export async function executeCallGraphPath(
     args.maxDepth,
     args.fromFilePath,
     args.toFilePath,
+    control,
   );
   return { text: formatCallGraphPathResult(path), details: { from: path.from, to: path.to, matchKind: "exact_symbol" } };
 }
@@ -168,8 +187,9 @@ export async function executeCodeCommunities(
   projectRoot: string | undefined,
   host: HostMode,
   args: SharedCodeCommunitiesArgs,
+  control?: OperationControl,
 ): Promise<ExecutionResult> {
-  const result = await getCodeCommunities(projectRoot, host, args);
+  const result = await getCodeCommunities(projectRoot, host, args, control);
   return { text: formatCodeCommunities(result) };
 }
 
@@ -177,7 +197,8 @@ export async function executeArchitectureContext(
   projectRoot: string | undefined,
   host: HostMode,
   args: SharedArchitectureContextArgs,
+  control?: OperationControl,
 ): Promise<ExecutionResult> {
-  const result = await getArchitectureContext(projectRoot, host, args);
+  const result = await getArchitectureContext(projectRoot, host, args, control);
   return { text: result.text, details: result as unknown as Record<string, unknown> };
 }

--- a/src/tools/operation-runtime.ts
+++ b/src/tools/operation-runtime.ts
@@ -1,5 +1,6 @@
 import type { HostMode } from "../config/host.js";
 import type { ParsedCodebaseIndexConfig } from "../config/schema.js";
+import type { OperationControl } from "../utils/operation-control.js";
 import { parseConfig } from "../config/schema.js";
 import { configureAutoIndex, waitForAutoIndexForRetrieval } from "../utils/auto-index.js";
 import { isBackgroundWorkerManaged } from "../utils/background-worker.js";
@@ -11,6 +12,7 @@ import {
 } from "../utils/effectiveness-metrics.js";
 import { countContextTokens } from "./utils.js";
 import { loadRuntimeConfig } from "./config-state.js";
+import { raceWithOperationSignal, throwIfOperationAborted } from "../utils/operation-control.js";
 
 export type IndexerCacheKey = `${HostMode}::${string}`;
 
@@ -121,6 +123,16 @@ export function getOrCreateIndexer(projectRoot: string, host: HostMode): Indexer
   return indexer;
 }
 
+export function getRuntimeConfigForProject(projectRoot: string, host: HostMode): ParsedCodebaseIndexConfig {
+  const key = getIndexerCacheKey(projectRoot, host);
+  let config = configCache.get(key);
+  if (!config) {
+    config = parseConfig(loadRuntimeConfig(projectRoot, host));
+    configCache.set(key, config);
+  }
+  return config;
+}
+
 export function initializeTools(
   projectRoot: string,
   config: ParsedCodebaseIndexConfig,
@@ -183,10 +195,15 @@ export class AutoIndexRetrievalUnavailableError extends Error {
 export async function ensureAutoIndexReadyForRetrieval(
   projectRoot: string | undefined,
   host: HostMode,
+  control?: OperationControl,
 ): Promise<void> {
+  throwIfOperationAborted(control?.signal);
   const root = getProjectRoot(projectRoot, host);
   getIndexerForProject(root, host);
-  const result = await waitForAutoIndexForRetrieval(root, host);
+  const result = await raceWithOperationSignal(
+    waitForAutoIndexForRetrieval(root, host, control),
+    control?.signal,
+  );
   if (!result.ready) {
     throw new AutoIndexRetrievalUnavailableError(
       result.text ?? "Automatic indexing has not produced a readable index yet. Call index_status and retry.",

--- a/src/tools/operations.ts
+++ b/src/tools/operations.ts
@@ -13,7 +13,7 @@ import {
   isArchitecturePathInDirectory,
   selectArchitectureFocusedSymbols,
 } from "./architecture-context.js";
-import { getRecentGitActivity } from "./visualize/activity.js";
+import { getRecentGitActivityAbortable } from "./visualize/activity.js";
 import { transformForVisualization } from "./visualize/transform.js";
 import {
   CODE_COMMUNITIES_DEFAULT_COUPLING_LIMIT,
@@ -60,6 +60,12 @@ import {
   safelyRecordToolEffectiveness,
   type IndexBusyResult,
 } from "./operation-runtime.js";
+import type { OperationControl } from "../utils/operation-control.js";
+import {
+  raceWithOperationSignal,
+  runOperationPhase,
+  throwIfOperationAborted,
+} from "../utils/operation-control.js";
 
 
 type SearchResult = Awaited<ReturnType<Indexer["search"]>>[number];
@@ -186,15 +192,21 @@ function exactSymbolSearchResults(
   projectRoot: string,
   query: string,
   options: { limit?: number; fileType?: string; directory?: string },
+  signal?: AbortSignal,
 ): SearchResult[] {
   const name = query.trim();
   const limit = options.limit ?? 5;
-  return symbols
-    .filter((symbol) => symbolNameMatches(symbol, name))
-    .filter((symbol) => exactSymbolMatchesScope(symbol, projectRoot, options))
+  throwIfOperationAborted(signal);
+  const matching = symbols.filter((symbol) => {
+    throwIfOperationAborted(signal);
+    return symbolNameMatches(symbol, name) && exactSymbolMatchesScope(symbol, projectRoot, options);
+  });
+  throwIfOperationAborted(signal);
+  return matching
     .sort((left, right) => left.filePath.localeCompare(right.filePath) || left.startLine - right.startLine)
     .slice(0, limit)
     .map((symbol) => {
+      throwIfOperationAborted(signal);
       let content = "[File not accessible]";
       try {
         content = readFileSync(symbol.filePath, "utf-8")
@@ -242,13 +254,18 @@ function resolveCallGraphSymbol(
   requestedName: string,
   requestedFilePath?: string,
   requestedSymbolId?: string,
+  signal?: AbortSignal,
 ): CallGraphSymbolResolution {
+  throwIfOperationAborted(signal);
   const name = requestedName.trim();
   const filePath = trimOrUndefined(requestedFilePath);
   const symbolId = trimOrUndefined(requestedSymbolId);
 
   if (symbolId) {
-    const symbol = symbols.find((candidate) => candidate.id === symbolId);
+    const symbol = symbols.find((candidate) => {
+      throwIfOperationAborted(signal);
+      return candidate.id === symbolId;
+    });
     if (symbol) {
       return resolvedSymbol(symbol, projectRoot, "symbolId");
     }
@@ -262,9 +279,15 @@ function resolveCallGraphSymbol(
     };
   }
 
-  const nameCandidates = symbols.filter((symbol) => symbolNameMatches(symbol, name));
+  const nameCandidates = symbols.filter((symbol) => {
+    throwIfOperationAborted(signal);
+    return symbolNameMatches(symbol, name);
+  });
   const matchingCandidates = filePath
-    ? nameCandidates.filter((symbol) => filePathMatches(symbol.filePath, filePath))
+    ? nameCandidates.filter((symbol) => {
+      throwIfOperationAborted(signal);
+      return filePathMatches(symbol.filePath, filePath);
+    })
     : nameCandidates;
 
   if (matchingCandidates.length === 1) {
@@ -303,8 +326,11 @@ export async function searchCodebase(
     blameUntil?: string;
     trace?: (trace: SearchTrace) => void;
   } = {},
+  control?: OperationControl,
 ): Promise<SearchResult[]> {
-  await ensureAutoIndexReadyForRetrieval(projectRoot, host);
+  await runOperationPhase(control, "waiting_for_index");
+  await ensureAutoIndexReadyForRetrieval(projectRoot, host, control);
+  await runOperationPhase(control, "embedding_query");
   const indexer = getIndexerForProject(projectRoot, host);
   return indexer.search(query, options.limit, {
     fileType: options.fileType,
@@ -319,6 +345,9 @@ export async function searchCodebase(
     blameSince: options.blameSince,
     blameUntil: options.blameUntil,
     trace: options.trace,
+    signal: control?.signal,
+    setPhase: control?.setPhase,
+    heartbeat: control?.heartbeat,
   });
 }
 
@@ -329,11 +358,12 @@ export async function searchCodebaseWithEffectiveness<T>(
   query: string,
   options: Parameters<typeof searchCodebase>[3],
   render: (results: SearchResult[]) => { output: T; text: string },
+  control?: OperationControl,
 ): Promise<T> {
   const metricsEnabled = isToolEffectivenessEnabled(projectRoot, host);
   const startedAt = metricsEnabled ? performance.now() : 0;
   try {
-    const results = await searchCodebase(projectRoot, host, query, options);
+    const results = await searchCodebase(projectRoot, host, query, options, control);
     const rendered = render(results);
     if (metricsEnabled) {
       safelyRecordToolEffectiveness({
@@ -378,8 +408,11 @@ export async function findSimilarCode(
     blameSince?: string;
     blameUntil?: string;
   } = {},
+  control?: OperationControl,
 ): Promise<Awaited<ReturnType<Indexer["findSimilar"]>>> {
-  await ensureAutoIndexReadyForRetrieval(projectRoot, host);
+  await runOperationPhase(control, "waiting_for_index");
+  await ensureAutoIndexReadyForRetrieval(projectRoot, host, control);
+  await runOperationPhase(control, "embedding_query");
   const indexer = getIndexerForProject(projectRoot, host);
   return indexer.findSimilar(code, options.limit, {
     fileType: options.fileType,
@@ -388,6 +421,9 @@ export async function findSimilarCode(
     excludeFile: options.excludeFile,
     blameSince: options.blameSince,
     blameUntil: options.blameUntil,
+    signal: control?.signal,
+    setPhase: control?.setPhase,
+    heartbeat: control?.heartbeat,
   });
 }
 
@@ -402,23 +438,36 @@ export async function implementationLookup(
     exactSymbol?: boolean;
     trace?: (trace: SearchTrace) => void;
   } = {},
+  control?: OperationControl,
 ): Promise<SearchResult[]> {
-  await ensureAutoIndexReadyForRetrieval(projectRoot, host);
+  await runOperationPhase(control, "waiting_for_index");
+  await ensureAutoIndexReadyForRetrieval(projectRoot, host, control);
+  await runOperationPhase(control, options.exactSymbol ? "resolving_symbol" : "embedding_query");
   const root = getProjectRoot(projectRoot, host);
   const indexer = getIndexerForProject(root, host);
   if (options.exactSymbol) {
-    return exactSymbolSearchResults(
-      await indexer.getCallGraphSymbols(),
+    const results = exactSymbolSearchResults(
+      await indexer.getCallGraphSymbols({
+        signal: control?.signal,
+        setPhase: control?.setPhase,
+        heartbeat: control?.heartbeat,
+      }),
       root,
       query,
       options,
+      control?.signal,
     );
+    throwIfOperationAborted(control?.signal);
+    return results;
   }
   return indexer.search(query, options.limit, {
     fileType: options.fileType,
     directory: options.directory,
     definitionIntent: true,
     trace: options.trace,
+    signal: control?.signal,
+    setPhase: control?.setPhase,
+    heartbeat: control?.heartbeat,
   });
 }
 
@@ -432,11 +481,16 @@ export async function getCallGraphData(
     filePath?: string;
     relationshipType?: "Call" | "MethodCall" | "Constructor" | "Import" | "Inherits" | "Implements";
   },
+  control?: OperationControl,
 ): Promise<CallGraphDataResult> {
-  await ensureAutoIndexReadyForRetrieval(projectRoot, host);
+  await runOperationPhase(control, "waiting_for_index");
+  await ensureAutoIndexReadyForRetrieval(projectRoot, host, control);
+  await runOperationPhase(control, "resolving_graph");
   const root = getProjectRoot(projectRoot, host);
   const indexer = getIndexerForProject(root, host);
-  return getCallGraphDataForIndexer(indexer, root, params);
+  const result = await getCallGraphDataForIndexer(indexer, root, params, control);
+  throwIfOperationAborted(control?.signal);
+  return result;
 }
 
 export async function getCallGraphDataForIndexer(
@@ -449,25 +503,46 @@ export async function getCallGraphDataForIndexer(
     filePath?: string;
     relationshipType?: "Call" | "MethodCall" | "Constructor" | "Import" | "Inherits" | "Implements";
   },
+  control?: OperationControl,
 ): Promise<CallGraphDataResult> {
-  const symbols = await indexer.getCallGraphSymbols();
-  const resolution = resolveCallGraphSymbol(symbols, projectRoot, params.name, params.filePath, params.symbolId);
+  const operationOptions = {
+    signal: control?.signal,
+    setPhase: control?.setPhase,
+    heartbeat: control?.heartbeat,
+  };
+  const symbols = await indexer.getCallGraphSymbols(operationOptions);
+  const resolution = resolveCallGraphSymbol(
+    symbols,
+    projectRoot,
+    params.name,
+    params.filePath,
+    params.symbolId,
+    control?.signal,
+  );
   const direction = params.direction === "callees" ? "callees" : "callers";
   if (resolution.status !== "resolved") {
     return { direction, resolution, callers: [], callees: [], relationshipType: params.relationshipType };
   }
 
   if (params.direction === "callees") {
-    const callees = await indexer.getCallees(resolution.symbolId, params.relationshipType);
+    const callees = await indexer.getCallees(
+      resolution.symbolId,
+      params.relationshipType,
+      operationOptions,
+    );
     return { direction: "callees", resolution, callees, callers: [], relationshipType: params.relationshipType };
   }
 
-  const includeUnresolved = symbols.filter((symbol) => symbolNameMatches(symbol, resolution.name)).length === 1;
+  const includeUnresolved = symbols.filter((symbol) => {
+    throwIfOperationAborted(control?.signal);
+    return symbolNameMatches(symbol, resolution.name);
+  }).length === 1;
   const callers = await indexer.getCallersForSymbol(
     resolution.symbolId,
     resolution.name,
     includeUnresolved,
     params.relationshipType,
+    operationOptions,
   );
   return { direction: "callers", resolution, callers, callees: [], relationshipType: params.relationshipType };
 }
@@ -480,13 +555,21 @@ export async function getCallGraphPath(
   maxDepth?: number,
   fromFilePath?: string,
   toFilePath?: string,
+  control?: OperationControl,
 ): Promise<CallGraphPathResult> {
-  await ensureAutoIndexReadyForRetrieval(projectRoot, host);
+  await runOperationPhase(control, "waiting_for_index");
+  await ensureAutoIndexReadyForRetrieval(projectRoot, host, control);
+  await runOperationPhase(control, "resolving_graph");
   const root = getProjectRoot(projectRoot, host);
   const indexer = getIndexerForProject(root, host);
-  const symbols = await indexer.getCallGraphSymbols();
-  const fromResolution = resolveCallGraphSymbol(symbols, root, from, fromFilePath);
-  const toResolution = resolveCallGraphSymbol(symbols, root, to, toFilePath);
+  const operationOptions = {
+    signal: control?.signal,
+    setPhase: control?.setPhase,
+    heartbeat: control?.heartbeat,
+  };
+  const symbols = await indexer.getCallGraphSymbols(operationOptions);
+  const fromResolution = resolveCallGraphSymbol(symbols, root, from, fromFilePath, undefined, control?.signal);
+  const toResolution = resolveCallGraphSymbol(symbols, root, to, toFilePath, undefined, control?.signal);
   if (fromResolution.status !== "resolved" || toResolution.status !== "resolved") {
     return { from: fromResolution, to: toResolution, path: [] };
   }
@@ -495,7 +578,9 @@ export async function getCallGraphPath(
     fromResolution.symbolId,
     toResolution.symbolId,
     maxDepth,
+    operationOptions,
   );
+  throwIfOperationAborted(control?.signal);
   return { from: fromResolution, to: toResolution, path };
 }
 
@@ -504,26 +589,50 @@ export async function runIndexCodebase(
   host: HostMode,
   args: { force?: boolean; estimateOnly?: boolean; dryRun?: boolean; verbose?: boolean },
   onProgress?: ProgressCb,
+  control?: OperationControl,
 ): Promise<
   | { kind: "estimate"; estimate: CostEstimate }
   | { kind: "dryrun"; dryrun: DryRunEstimate }
-  | { kind: "stats"; stats: IndexStats }
+  | { kind: "stats"; stats: IndexStats; providerError?: import("../utils/operation-control.js").ProviderRequestError }
   | IndexMessageResult
   | IndexBusyResult
 > {
   const root = getProjectRoot(projectRoot, host);
   const indexer = getIndexerForProject(root, host);
+  await runOperationPhase(control, "preparing_index");
+  let providerError: import("../utils/operation-control.js").ProviderRequestError | undefined;
+  const onProviderError = (error: import("../utils/operation-control.js").ProviderRequestError): void => {
+    providerError ??= error;
+  };
 
   try {
     if (args.estimateOnly) {
-      return { kind: "estimate", estimate: await indexer.estimateCost() };
+      const estimate = await raceWithOperationSignal(
+        indexer.estimateCost({
+          signal: control?.signal,
+          setPhase: control?.setPhase,
+          heartbeat: control?.heartbeat,
+        }),
+        control?.signal,
+      );
+      return { kind: "estimate", estimate };
     }
 
     if (args.dryRun) {
-      return { kind: "dryrun", dryrun: await indexer.dryRunCost() };
+      const dryrun = await raceWithOperationSignal(
+        indexer.dryRunCost({
+          signal: control?.signal,
+          setPhase: control?.setPhase,
+          heartbeat: control?.heartbeat,
+        }),
+        control?.signal,
+      );
+      return { kind: "dryrun", dryrun };
     }
 
     const coordinated = runCoordinatedIndex(root, host, args.force ?? false, (progress) => {
+      const percentage = calculatePercentage(progress);
+      void control?.reportProgress?.(percentage, progress.phase);
       if (onProgress) {
         void onProgress(formatProgressTitle(progress), {
           phase: progress.phase,
@@ -531,17 +640,43 @@ export async function runIndexCodebase(
           totalFiles: progress.totalFiles,
           chunksProcessed: progress.chunksProcessed,
           totalChunks: progress.totalChunks,
-          percentage: calculatePercentage(progress),
+          percentage,
         });
       }
-    });
+    }, control?.signal, control?.heartbeat, onProviderError, control?.setPhase);
     if (!coordinated) {
-      const operation = args.force ? indexer.forceIndex.bind(indexer) : indexer.index.bind(indexer);
-      return { kind: "stats", stats: await operation() };
+      const directProgress = (progress: Parameters<NonNullable<Parameters<Indexer["index"]>[0]>>[0]): void => {
+        const percentage = calculatePercentage(progress);
+        void control?.reportProgress?.(percentage, progress.phase);
+        if (onProgress) {
+          void onProgress(formatProgressTitle(progress), {
+            phase: progress.phase,
+            filesProcessed: progress.filesProcessed,
+            totalFiles: progress.totalFiles,
+            chunksProcessed: progress.chunksProcessed,
+            totalChunks: progress.totalChunks,
+            percentage,
+          });
+        }
+      };
+      const stats = args.force
+        ? await indexer.forceIndex(directProgress, {
+          signal: control?.signal,
+          setPhase: control?.setPhase,
+          heartbeat: control?.heartbeat,
+          onProviderError,
+        })
+        : await indexer.index(directProgress, {
+          signal: control?.signal,
+          setPhase: control?.setPhase,
+          heartbeat: control?.heartbeat,
+          onProviderError,
+        });
+      return { kind: "stats", stats, ...(providerError ? { providerError } : {}) };
     }
-    const result = await coordinated;
+    const result = await raceWithOperationSignal(coordinated, control?.signal);
     if (result.outcome === "ready" && result.stats) {
-      return { kind: "stats", stats: result.stats };
+      return { kind: "stats", stats: result.stats, ...(providerError ? { providerError } : {}) };
     }
     if (result.outcome === "ready" && result.skipped) {
       return { kind: "message", text: "The existing index is healthy and current; no indexing was needed." };
@@ -558,26 +693,45 @@ export async function runIndexCodebase(
   }
 }
 
-export async function getIndexStatus(projectRoot: string | undefined, host: HostMode): Promise<IndexStatusResult> {
+export async function getIndexStatus(
+  projectRoot: string | undefined,
+  host: HostMode,
+  control?: OperationControl,
+): Promise<IndexStatusResult> {
+  await runOperationPhase(control, "reading_status");
   const root = getProjectRoot(projectRoot, host);
   const indexer = getIndexerForProject(root, host);
+  const status = await indexer.getStatus();
+  throwIfOperationAborted(control?.signal);
   return {
-    ...await indexer.getStatus(),
+    ...status,
     autoIndex: getAutoIndexStatus(root, host),
   };
 }
 
-export async function getIndexHealthCheck(projectRoot: string | undefined, host: HostMode): Promise<HealthCheckResult> {
+export async function getIndexHealthCheck(
+  projectRoot: string | undefined,
+  host: HostMode,
+  control?: OperationControl,
+): Promise<HealthCheckResult> {
+  await runOperationPhase(control, "checking_index");
   const indexer = getIndexerForProject(projectRoot, host);
-  return indexer.healthCheck();
+  const result = await indexer.healthCheck({
+    signal: control?.signal,
+    setPhase: control?.setPhase,
+    heartbeat: control?.heartbeat,
+  });
+  throwIfOperationAborted(control?.signal);
+  return result;
 }
 
 export async function runIndexHealthCheck(
   projectRoot: string | undefined,
   host: HostMode,
+  control?: OperationControl,
 ): Promise<{ kind: "health"; health: HealthCheckResult } | IndexBusyResult> {
   try {
-    return { kind: "health", health: await getIndexHealthCheck(projectRoot, host) };
+    return { kind: "health", health: await getIndexHealthCheck(projectRoot, host, control) };
   } catch (error) {
     const busyResult = getIndexBusyResult(error);
     if (!busyResult) throw error;
@@ -596,31 +750,56 @@ export async function getPrImpact(
     checkConflicts?: boolean;
     direction?: "callers" | "callees" | "both";
   },
+  control?: OperationControl,
 ): Promise<PrImpactResult> {
-  await ensureAutoIndexReadyForRetrieval(projectRoot, host);
+  await runOperationPhase(control, "waiting_for_index");
+  await ensureAutoIndexReadyForRetrieval(projectRoot, host, control);
+  await runOperationPhase(control, "analyzing_impact");
   const indexer = getIndexerForProject(projectRoot, host);
-  return indexer.getPrImpact({
-    pr: params.pr,
-    branch: params.branch,
-    maxDepth: params.maxDepth,
-    hubThreshold: params.hubThreshold,
-    checkConflicts: params.checkConflicts,
-    direction: params.direction,
-  });
+  const result = await indexer.getPrImpact(
+    {
+      pr: params.pr,
+      branch: params.branch,
+      maxDepth: params.maxDepth,
+      hubThreshold: params.hubThreshold,
+      checkConflicts: params.checkConflicts,
+      direction: params.direction,
+    },
+    (progress) => {
+      const percentage = calculatePercentage(progress);
+      void control?.reportProgress?.(percentage, progress.phase);
+    },
+    {
+      signal: control?.signal,
+      setPhase: control?.setPhase,
+      heartbeat: control?.heartbeat,
+    },
+  );
+  throwIfOperationAborted(control?.signal);
+  return result;
 }
 
 export async function getCodeCommunities(
   projectRoot: string | undefined,
   host: HostMode,
   params: SharedCodeCommunitiesArgs,
+  control?: OperationControl,
 ): Promise<import("./format-communities.js").CodeCommunitiesResult> {
-  await ensureAutoIndexReadyForRetrieval(projectRoot, host);
+  await runOperationPhase(control, "waiting_for_index");
+  await ensureAutoIndexReadyForRetrieval(projectRoot, host, control);
+  await runOperationPhase(control, "analyzing_communities");
   const indexer = getIndexerForProject(projectRoot, host);
+  const operationOptions = {
+    signal: control?.signal,
+    setPhase: control?.setPhase,
+    heartbeat: control?.heartbeat,
+  };
   const [communities, centrality, couplings] = await Promise.all([
-    indexer.detectCommunities(params.branch),
-    indexer.computeCentrality(params.branch),
-    indexer.detectCommunityCouplings(params.branch),
+    indexer.detectCommunities(params.branch, undefined, operationOptions),
+    indexer.computeCentrality(params.branch, operationOptions),
+    indexer.detectCommunityCouplings(params.branch, operationOptions),
   ]);
+  throwIfOperationAborted(control?.signal);
   return buildCodeCommunitiesResult(communities, centrality, couplings, {
     minSize: Math.max(CODE_COMMUNITIES_MIN_SIZE, Math.floor(params.minSize ?? CODE_COMMUNITIES_MIN_SIZE)),
     limit: Math.min(
@@ -916,59 +1095,96 @@ export async function getArchitectureContext(
   projectRoot: string | undefined,
   host: HostMode,
   params: SharedArchitectureContextArgs,
+  control?: OperationControl,
 ): Promise<import("./architecture-context.js").ArchitectureContextResult> {
-  await ensureAutoIndexReadyForRetrieval(projectRoot, host);
+  await runOperationPhase(control, "waiting_for_index");
+  await ensureAutoIndexReadyForRetrieval(projectRoot, host, control);
+  await runOperationPhase(control, "building_architecture");
   const indexer = getIndexerForProject(projectRoot, host);
-  return getArchitectureContextForIndexer(indexer, getProjectRoot(projectRoot, host), params);
+  const result = await getArchitectureContextForIndexer(
+    indexer,
+    getProjectRoot(projectRoot, host),
+    params,
+    control,
+  );
+  throwIfOperationAborted(control?.signal);
+  return result;
 }
 
 export async function getArchitectureContextForIndexer(
   indexer: Indexer,
   projectRoot: string,
   params: SharedArchitectureContextArgs,
+  control?: OperationControl,
 ): Promise<import("./architecture-context.js").ArchitectureContextResult> {
+  const operationOptions = {
+    signal: control?.signal,
+    setPhase: control?.setPhase,
+    heartbeat: control?.heartbeat,
+  };
   const [communities, centrality, couplings, visualization] = await Promise.all([
-    indexer.detectCommunities(),
-    indexer.computeCentrality(),
-    indexer.detectCommunityCouplings(),
-    indexer.getVisualizationData({ directory: params.directory ?? undefined }),
+    indexer.detectCommunities(undefined, undefined, operationOptions),
+    indexer.computeCentrality(undefined, operationOptions),
+    indexer.detectCommunityCouplings(undefined, operationOptions),
+    indexer.getVisualizationData({
+      directory: params.directory ?? undefined,
+      ...operationOptions,
+    }),
   ]);
+  throwIfOperationAborted(control?.signal);
   let focusedSymbols: SymbolData[] = [];
   if (params.query?.trim()) {
     const results = await indexer.search(params.query.trim(), 24, {
       metadataOnly: true,
       directory: params.directory ?? undefined,
       prioritizeSourcePaths: true,
+      signal: control?.signal,
+      setPhase: control?.setPhase,
+      heartbeat: control?.heartbeat,
     });
+    throwIfOperationAborted(control?.signal);
     focusedSymbols = selectArchitectureFocusedSymbols(
       results,
       visualization.symbols,
       params.depth,
+      control?.signal,
     );
   }
 
+  throwIfOperationAborted(control?.signal);
   const queryRequested = Boolean(params.query?.trim());
-  const focusIds = new Set(focusedSymbols.map((symbol) => symbol.id));
+  const focusIds = new Set(focusedSymbols.map((symbol) => {
+    throwIfOperationAborted(control?.signal);
+    return symbol.id;
+  }));
   const focusedCommunityIds = new Set(
-    communities.filter((member) => focusIds.has(member.symbolId)).map((member) => member.communityId),
+    communities.filter((member) => {
+      throwIfOperationAborted(control?.signal);
+      return focusIds.has(member.symbolId);
+    }).map((member) => member.communityId),
   );
   const communityBySymbolId = new Map(communities.map((member) => [member.symbolId, member.communityId]));
-  const scopedSymbols = visualization.symbols.filter((symbol) =>
-    isArchitecturePathInDirectory(symbol.filePath, params.directory, projectRoot)
-    && (!queryRequested
-      || focusIds.has(symbol.id)
-      || focusedCommunityIds.has(communityBySymbolId.get(symbol.id) ?? -1))
-  );
+  const scopedSymbols = visualization.symbols.filter((symbol) => {
+    throwIfOperationAborted(control?.signal);
+    return isArchitecturePathInDirectory(symbol.filePath, params.directory, projectRoot)
+      && (!queryRequested
+        || focusIds.has(symbol.id)
+        || focusedCommunityIds.has(communityBySymbolId.get(symbol.id) ?? -1));
+  });
   const scopedSymbolIds = new Set(scopedSymbols.map((symbol) => symbol.id));
-  const scopedEdges = visualization.edges.filter((edge) => scopedSymbolIds.has(edge.fromSymbolId));
+  const scopedEdges = visualization.edges.filter((edge) => {
+    throwIfOperationAborted(control?.signal);
+    return scopedSymbolIds.has(edge.fromSymbolId);
+  });
   const recentActivity = params.includeRecentActivity
-    ? getRecentGitActivity(
+    ? (await getRecentGitActivityAbortable(
       transformForVisualization(scopedSymbols, visualization.edges, {
         directory: params.directory ?? undefined,
         includeOrphans: true,
       }),
       projectRoot,
-    ).slice(0, 3).map((change) => ({
+      control?.signal,
+    )).slice(0, 3).map((change) => ({
       title: change.title,
       date: change.when,
       commit: change.source.replace(/^commit\s+/, ""),

--- a/src/tools/operations.ts
+++ b/src/tools/operations.ts
@@ -676,7 +676,12 @@ export async function runIndexCodebase(
     }
     const result = await raceWithOperationSignal(coordinated, control?.signal);
     if (result.outcome === "ready" && result.stats) {
-      return { kind: "stats", stats: result.stats, ...(providerError ? { providerError } : {}) };
+      const coordinatedProviderError = providerError ?? result.providerError;
+      return {
+        kind: "stats",
+        stats: result.stats,
+        ...(coordinatedProviderError ? { providerError: coordinatedProviderError } : {}),
+      };
     }
     if (result.outcome === "ready" && result.skipped) {
       return { kind: "message", text: "The existing index is healthy and current; no indexing was needed." };

--- a/src/tools/visualize/activity.ts
+++ b/src/tools/visualize/activity.ts
@@ -2,6 +2,8 @@ import { execFileSync } from "child_process";
 import * as path from "path";
 
 import type { VisualizationChange, VisualizationData, VisualizationNode } from "./types.js";
+import { runGitRaw } from "../../git/branch-resolution.js";
+import { isOperationInterruption, throwIfOperationAborted } from "../../utils/operation-control.js";
 
 interface FileActivity {
   churn: number;
@@ -36,6 +38,15 @@ export function getRecentGitActivity(data: VisualizationData, projectRoot: strin
   return activity.size > 0 ? buildGitChanges(data, activity, projectRoot) : [];
 }
 
+export async function getRecentGitActivityAbortable(
+  data: VisualizationData,
+  projectRoot: string,
+  signal?: AbortSignal,
+): Promise<VisualizationChange[]> {
+  const activity = await readGitActivityAbortable(projectRoot, signal);
+  return activity.size > 0 ? buildGitChanges(data, activity, projectRoot) : [];
+}
+
 function readGitActivity(projectRoot: string): Map<string, FileActivity> {
   try {
     const output = execFileSync(
@@ -45,6 +56,28 @@ function readGitActivity(projectRoot: string): Map<string, FileActivity> {
     );
     return parseGitActivity(output);
   } catch {
+    return new Map();
+  }
+}
+
+async function readGitActivityAbortable(
+  projectRoot: string,
+  signal?: AbortSignal,
+): Promise<Map<string, FileActivity>> {
+  throwIfOperationAborted(signal);
+  try {
+    const output = await runGitRaw(projectRoot, [
+      "log",
+      "--since=90.days",
+      "--numstat",
+      "--date=short",
+      "--pretty=format:__COMMIT__%x09%h%x09%ad%x09%s",
+    ], { signal });
+    throwIfOperationAborted(signal);
+    return parseGitActivity(output);
+  } catch (error) {
+    if (isOperationInterruption(error)) throw error;
+    throwIfOperationAborted(signal);
     return new Map();
   }
 }

--- a/src/utils/auto-index.ts
+++ b/src/utils/auto-index.ts
@@ -1,7 +1,7 @@
 import type { ParsedCodebaseIndexConfig } from "../config/schema.js";
 import type { HostMode } from "../config/host.js";
 import type { Indexer, IndexProgress, IndexStats } from "../indexer/index.js";
-import type { OperationControl } from "./operation-control.js";
+import type { OperationControl, ProviderRequestError } from "./operation-control.js";
 import type { BackgroundIndexingPolicy } from "./power-source.js";
 import { existsSync, realpathSync } from "fs";
 import * as os from "os";
@@ -65,6 +65,7 @@ export interface CoordinatedIndexResult {
   stats?: IndexStats;
   skipped?: boolean;
   error?: unknown;
+  providerError?: ProviderRequestError;
 }
 
 export interface AutoIndexRetrievalResult {
@@ -302,6 +303,7 @@ class AutoIndexCoordinator {
   private abortController: AbortController | null = null;
   private readonly manualConsumerIds = new Set<symbol>();
   private readonly activeManualConsumerIds = new Set<symbol>();
+  private activeProviderError: ProviderRequestError | undefined;
   private activeHasIndependentOwner = false;
   private readonly manualProgressListeners = new Map<symbol, (progress: IndexProgress) => void>();
   private readonly manualPhaseListeners = new Map<symbol, NonNullable<
@@ -447,9 +449,8 @@ class AutoIndexCoordinator {
         }
       };
       signal?.addEventListener("abort", detach, { once: true });
-      const job = this.enqueueBatteryAwareRequest(request);
-
       try {
+        const job = this.enqueueBatteryAwareRequest(request);
         return await raceWithOperationSignal(job, signal);
       } finally {
         signal?.removeEventListener("abort", detach);
@@ -518,6 +519,9 @@ class AutoIndexCoordinator {
       for (const consumerId of request.manualConsumerIds ?? []) {
         if (this.manualConsumerIds.has(consumerId)) {
           this.activeManualConsumerIds.add(consumerId);
+          if (this.activeProviderError) {
+            this.manualProviderErrorListeners.get(consumerId)?.(this.activeProviderError);
+          }
         }
       }
       return this.inFlight;
@@ -572,6 +576,7 @@ class AutoIndexCoordinator {
       return Promise.resolve({ outcome: "stopped" });
     }
     this.activeRequest = request;
+    this.activeProviderError = undefined;
     this.activeManualConsumerIds.clear();
     for (const consumerId of request.manualConsumerIds ?? []) {
       if (this.manualConsumerIds.has(consumerId)) {
@@ -587,6 +592,7 @@ class AutoIndexCoordinator {
       this.activeRequest = null;
       this.abortController = null;
       this.activeManualConsumerIds.clear();
+      this.activeProviderError = undefined;
       this.activeHasIndependentOwner = false;
       if (this.batteryIndexJob === job) {
         this.batteryIndexJob = null;
@@ -627,6 +633,24 @@ class AutoIndexCoordinator {
     const maxRetries = request.source === "manual"
       ? 0
       : this.registration.config.indexing.autoIndexMaxRetries;
+    const setOperationPhase = async (phase: string): Promise<void> => {
+      this.notifyRetrievalPhase(phase);
+      await Promise.all(Array.from(this.activeManualConsumerIds, async (consumerId) => {
+        await this.manualPhaseListeners.get(consumerId)?.(phase);
+      }));
+    };
+    const heartbeatOperation = async (): Promise<void> => {
+      this.notifyRetrievalHeartbeat();
+      await Promise.all(Array.from(this.activeManualConsumerIds, async (consumerId) => {
+        await this.manualHeartbeatListeners.get(consumerId)?.();
+      }));
+    };
+    const reportProviderError = (error: ProviderRequestError): void => {
+      this.activeProviderError ??= error;
+      for (const consumerId of this.activeManualConsumerIds) {
+        this.manualProviderErrorListeners.get(consumerId)?.(error);
+      }
+    };
     let retryAttempt = 0;
     while (true) {
       try {
@@ -634,7 +658,11 @@ class AutoIndexCoordinator {
         const indexer = this.registration.getIndexer();
         if (request.checkFreshness && !request.force) {
           if (indexer.getIndexFreshness) {
-            const freshness = await indexer.getIndexFreshness();
+            const freshness = await indexer.getIndexFreshness({
+              signal: controller.signal,
+              setPhase: setOperationPhase,
+              heartbeat: heartbeatOperation,
+            });
             this.throwIfCancelled(controller.signal);
             if (freshness.readable && freshness.current) {
               this.setState("ready", {
@@ -670,23 +698,9 @@ class AutoIndexCoordinator {
           this.notifyRetrievalProgress(progress);
         }, {
           signal: controller.signal,
-          setPhase: async (phase) => {
-            this.notifyRetrievalPhase(phase);
-            await Promise.all(Array.from(this.activeManualConsumerIds, async (consumerId) => {
-              await this.manualPhaseListeners.get(consumerId)?.(phase);
-            }));
-          },
-          heartbeat: async () => {
-            this.notifyRetrievalHeartbeat();
-            await Promise.all(Array.from(this.activeManualConsumerIds, async (consumerId) => {
-              await this.manualHeartbeatListeners.get(consumerId)?.();
-            }));
-          },
-          onProviderError: (error) => {
-            for (const consumerId of this.activeManualConsumerIds) {
-              this.manualProviderErrorListeners.get(consumerId)?.(error);
-            }
-          },
+          setPhase: setOperationPhase,
+          heartbeat: heartbeatOperation,
+          onProviderError: reportProviderError,
         });
         this.throwIfCancelled(controller.signal);
         if (request.source === "startup" || request.source === "retrieval") {
@@ -709,7 +723,11 @@ class AutoIndexCoordinator {
             : undefined,
           retryAttempt: undefined,
         });
-        return { outcome: "ready", stats };
+        return {
+          outcome: "ready",
+          stats,
+          ...(this.activeProviderError ? { providerError: this.activeProviderError } : {}),
+        };
       } catch (error) {
         if (error instanceof AutoIndexCancelledError || controller.signal.aborted) {
           if (this.stopped) {
@@ -1093,6 +1111,7 @@ async function waitForAutoIndexForRetrievalFromCoordinator(
   projectRoot: string,
   host: HostMode,
   coordinator: AutoIndexCoordinator | null,
+  control?: Pick<OperationControl, "heartbeat" | "setPhase" | "signal">,
 ): Promise<AutoIndexRetrievalResult> {
   if (!coordinator) return { ready: true };
   const initial = coordinator.snapshot();
@@ -1111,12 +1130,13 @@ async function waitForAutoIndexForRetrievalFromCoordinator(
   }
 
   try {
-    const readiness = await getSearchReadiness(coordinator);
+    const readiness = await getSearchReadiness(coordinator, control);
     if (readiness.searchable) {
       return { ready: true };
     }
     if (readiness.blocked) return unavailableSnapshotResult(readiness.reason);
   } catch {
+    throwIfOperationAborted(control?.signal);
     // The coordinator reports a sanitized actionable failure below.
   }
 
@@ -1124,14 +1144,15 @@ async function waitForAutoIndexForRetrievalFromCoordinator(
   if (job) {
     await withTimeout(job, coordinator.getWaitMs());
   } else if (isBackgroundWorkerManaged(projectRoot, host)) {
-    await waitForPublishedSnapshot(coordinator, coordinator.getWaitMs());
+    await waitForPublishedSnapshot(coordinator, coordinator.getWaitMs(), control);
   }
 
   try {
-    const readiness = await getSearchReadiness(coordinator);
+    const readiness = await getSearchReadiness(coordinator, control);
     if (readiness.searchable) return { ready: true };
     if (readiness.blocked) return unavailableSnapshotResult(readiness.reason);
   } catch {
+    throwIfOperationAborted(control?.signal);
     // The coordinator reports a sanitized actionable failure below.
   }
 
@@ -1162,7 +1183,7 @@ export function waitForAutoIndexForRetrieval(
   const coordinator = getCoordinator(projectRoot, host);
   const detach = coordinator?.subscribeRetrievalActivity(control) ?? (() => undefined);
   return raceWithOperationSignal(
-    waitForAutoIndexForRetrievalFromCoordinator(projectRoot, host, coordinator),
+    waitForAutoIndexForRetrievalFromCoordinator(projectRoot, host, coordinator, control),
     control?.signal,
   ).finally(detach);
 }
@@ -1205,10 +1226,19 @@ interface SearchReadiness {
   searchable: boolean;
 }
 
-async function getSearchReadiness(coordinator: AutoIndexCoordinator): Promise<SearchReadiness> {
+async function getSearchReadiness(
+  coordinator: AutoIndexCoordinator,
+  control?: Pick<OperationControl, "heartbeat" | "setPhase" | "signal">,
+): Promise<SearchReadiness> {
+  throwIfOperationAborted(control?.signal);
   const indexer = coordinator.getIndexer();
   if (indexer.getIndexFreshness) {
-    const freshness = await indexer.getIndexFreshness();
+    const freshness = await indexer.getIndexFreshness({
+      signal: control?.signal,
+      setPhase: control?.setPhase,
+      heartbeat: control?.heartbeat,
+    });
+    throwIfOperationAborted(control?.signal);
     const searchable = freshness.readable && freshness.current && freshness.reason === "current";
     return {
       blocked: freshness.reason === "unreadable"
@@ -1220,6 +1250,8 @@ async function getSearchReadiness(coordinator: AutoIndexCoordinator): Promise<Se
     };
   }
   const indexed = (await indexer.getStatus()).indexed;
+  await control?.heartbeat?.();
+  throwIfOperationAborted(control?.signal);
   return { blocked: false, searchable: indexed };
 }
 
@@ -1254,10 +1286,15 @@ function startRetrievalRefresh(
 async function waitForPublishedSnapshot(
   coordinator: AutoIndexCoordinator,
   waitMs: number,
+  control?: Pick<OperationControl, "heartbeat" | "setPhase" | "signal">,
 ): Promise<void> {
   const deadline = Date.now() + waitMs;
   while (Date.now() < deadline) {
-    if ((await getSearchReadiness(coordinator)).searchable) return;
-    await new Promise<void>((resolve) => setTimeout(resolve, Math.min(250, deadline - Date.now())));
+    throwIfOperationAborted(control?.signal);
+    if ((await getSearchReadiness(coordinator, control)).searchable) return;
+    await raceWithOperationSignal(
+      new Promise<void>((resolve) => setTimeout(resolve, Math.min(250, deadline - Date.now()))),
+      control?.signal,
+    );
   }
 }

--- a/src/utils/auto-index.ts
+++ b/src/utils/auto-index.ts
@@ -1,6 +1,7 @@
 import type { ParsedCodebaseIndexConfig } from "../config/schema.js";
 import type { HostMode } from "../config/host.js";
 import type { Indexer, IndexProgress, IndexStats } from "../indexer/index.js";
+import type { OperationControl } from "./operation-control.js";
 import type { BackgroundIndexingPolicy } from "./power-source.js";
 import { existsSync, realpathSync } from "fs";
 import * as os from "os";
@@ -18,6 +19,10 @@ import {
 } from "./background-worker.js";
 import { hasProjectMarker } from "./files.js";
 import { createBackgroundIndexingPolicy } from "./power-source.js";
+import {
+  raceWithOperationSignal,
+  throwIfOperationAborted,
+} from "./operation-control.js";
 
 export type AutoIndexCoordinatorState =
   | "idle"
@@ -90,8 +95,21 @@ interface IndexRequest {
   allowDisabledAutoIndex?: boolean;
   checkFreshness: boolean;
   force: boolean;
+  hasIndependentOwner?: boolean;
+  manualConsumerIds?: Set<symbol>;
   onProgress?: (progress: IndexProgress) => void;
   source: AutoIndexSource;
+}
+
+type RetrievalActivityControl = Pick<
+  OperationControl,
+  "heartbeat" | "reportProgress" | "setPhase"
+>;
+
+interface RetrievalActivitySubscriber {
+  control: RetrievalActivityControl;
+  queue: Promise<void>;
+  lastPhase?: string;
 }
 
 const MAX_RETRY_DELAY_MS = 10_000;
@@ -246,13 +264,23 @@ function requestPriority(request: IndexRequest): number {
   return 1;
 }
 
+function requestHasIndependentOwner(request: IndexRequest): boolean {
+  return request.hasIndependentOwner ?? request.source !== "manual";
+}
+
 function mergeRequests(current: IndexRequest | null, next: IndexRequest): IndexRequest {
   if (!current) return next;
   const preferred = requestPriority(next) > requestPriority(current) ? next : current;
+  const manualConsumerIds = new Set([
+    ...(current.manualConsumerIds ?? []),
+    ...(next.manualConsumerIds ?? []),
+  ]);
   return {
     allowDisabledAutoIndex: current.allowDisabledAutoIndex || next.allowDisabledAutoIndex,
     checkFreshness: current.checkFreshness && next.checkFreshness,
     force: current.force || next.force,
+    hasIndependentOwner: requestHasIndependentOwner(current) || requestHasIndependentOwner(next),
+    ...(manualConsumerIds.size > 0 ? { manualConsumerIds } : {}),
     onProgress: next.onProgress ?? current.onProgress,
     source: preferred.source,
   };
@@ -261,7 +289,7 @@ function mergeRequests(current: IndexRequest | null, next: IndexRequest): IndexR
 class AutoIndexCoordinator {
   private registration: AutoIndexRegistration;
   private status: AutoIndexStatusSnapshot;
-  private activation: Promise<void> = Promise.resolve();
+  private activation: Promise<void> | null = null;
   private inFlight: Promise<CoordinatedIndexResult> | null = null;
   private activeRequest: IndexRequest | null = null;
   private batteryCheck: Promise<CoordinatedIndexResult> | null = null;
@@ -272,6 +300,16 @@ class AutoIndexCoordinator {
   private pendingRequest: IndexRequest | null = null;
   private pendingFollowUp: Promise<CoordinatedIndexResult> | null = null;
   private abortController: AbortController | null = null;
+  private readonly manualConsumerIds = new Set<symbol>();
+  private readonly activeManualConsumerIds = new Set<symbol>();
+  private activeHasIndependentOwner = false;
+  private readonly manualProgressListeners = new Map<symbol, (progress: IndexProgress) => void>();
+  private readonly manualPhaseListeners = new Map<symbol, NonNullable<
+    NonNullable<Parameters<Indexer["index"]>[1]>["setPhase"]
+  >>();
+  private readonly manualHeartbeatListeners = new Map<symbol, () => void | Promise<void>>();
+  private readonly manualProviderErrorListeners = new Map<symbol, NonNullable<Parameters<Indexer["index"]>[1]>["onProviderError"]>();
+  private readonly retrievalActivitySubscribers = new Map<symbol, RetrievalActivitySubscriber>();
   private stopped = false;
 
   constructor(registration: AutoIndexRegistration) {
@@ -308,7 +346,12 @@ class AutoIndexCoordinator {
   }
 
   activateAfter(activation: Promise<void>): void {
-    this.activation = activation;
+    const pendingActivation = activation.then(() => {
+      if (this.activation === pendingActivation) {
+        this.activation = null;
+      }
+    });
+    this.activation = pendingActivation;
   }
 
   snapshot(): AutoIndexStatusSnapshot {
@@ -316,6 +359,20 @@ class AutoIndexCoordinator {
     return {
       ...this.status,
       progress: this.status.progress ? { ...this.status.progress } : undefined,
+    };
+  }
+
+  subscribeRetrievalActivity(control: RetrievalActivityControl | undefined): () => void {
+    if (!control?.heartbeat && !control?.reportProgress && !control?.setPhase) {
+      return () => undefined;
+    }
+    const id = Symbol("retrieval-activity-subscriber");
+    this.retrievalActivitySubscribers.set(id, {
+      control,
+      queue: Promise.resolve(),
+    });
+    return () => {
+      this.retrievalActivitySubscribers.delete(id);
     };
   }
 
@@ -333,7 +390,77 @@ class AutoIndexCoordinator {
     if (this.stopped) {
       return Promise.resolve({ outcome: "stopped" });
     }
-    return this.activation.then(() => this.enqueueBatteryAwareRequest(request));
+    return this.activation
+      ? this.activation.then(() => this.enqueueBatteryAwareRequest(request))
+      : this.enqueueBatteryAwareRequest(request);
+  }
+
+  requestManual(
+    force: boolean,
+    onProgress?: (progress: IndexProgress) => void,
+    signal?: AbortSignal,
+    heartbeat?: () => void | Promise<void>,
+    onProviderError?: NonNullable<Parameters<Indexer["index"]>[1]>["onProviderError"],
+    setPhase?: NonNullable<Parameters<Indexer["index"]>[1]>["setPhase"],
+  ): Promise<CoordinatedIndexResult> {
+    const attach = async (): Promise<CoordinatedIndexResult> => {
+      throwIfOperationAborted(signal);
+      const consumerId = Symbol("manual-index-consumer");
+      this.manualConsumerIds.add(consumerId);
+      if (onProgress) this.manualProgressListeners.set(consumerId, onProgress);
+      if (setPhase) this.manualPhaseListeners.set(consumerId, setPhase);
+      if (heartbeat) this.manualHeartbeatListeners.set(consumerId, heartbeat);
+      if (onProviderError) this.manualProviderErrorListeners.set(consumerId, onProviderError);
+      const request: IndexRequest = {
+        checkFreshness: !force,
+        force,
+        hasIndependentOwner: false,
+        manualConsumerIds: new Set([consumerId]),
+        source: "manual",
+      };
+      let detached = false;
+      const detach = (): void => {
+        if (detached) return;
+        detached = true;
+        this.manualConsumerIds.delete(consumerId);
+        this.manualProgressListeners.delete(consumerId);
+        this.manualPhaseListeners.delete(consumerId);
+        this.manualHeartbeatListeners.delete(consumerId);
+        this.manualProviderErrorListeners.delete(consumerId);
+        const wasActive = this.activeManualConsumerIds.delete(consumerId);
+        if (wasActive && this.activeManualConsumerIds.size === 0 && !this.activeHasIndependentOwner) {
+          this.abortController?.abort();
+        }
+        if (this.pendingRequest?.manualConsumerIds?.delete(consumerId) === true
+          && this.pendingRequest.manualConsumerIds.size === 0) {
+          if (requestHasIndependentOwner(this.pendingRequest)) {
+            this.pendingRequest = {
+              ...this.pendingRequest,
+              force: false,
+              manualConsumerIds: undefined,
+              onProgress: undefined,
+              source: "watcher",
+            };
+          } else {
+            this.pendingRequest = null;
+          }
+        }
+      };
+      signal?.addEventListener("abort", detach, { once: true });
+      const job = this.enqueueBatteryAwareRequest(request);
+
+      try {
+        return await raceWithOperationSignal(job, signal);
+      } finally {
+        signal?.removeEventListener("abort", detach);
+        detach();
+      }
+    };
+
+    const activation = this.activation;
+    return activation
+      ? raceWithOperationSignal(activation, signal).then(attach)
+      : attach();
   }
 
   private enqueueBatteryAwareRequest(request: IndexRequest): Promise<CoordinatedIndexResult> {
@@ -366,11 +493,15 @@ class AutoIndexCoordinator {
     if (this.inFlight) {
       if (request.force && !this.activeRequest?.force) {
         this.pendingRequest = mergeRequests(this.pendingRequest, request);
-        this.abortController?.abort();
         const active = this.inFlight;
         return active.then(() => {
           if (this.stopped) return { outcome: "stopped" };
-          return this.inFlight ?? this.startRequest(request);
+          const hasLiveManualConsumer = Array.from(request.manualConsumerIds ?? [])
+            .some((consumerId) => this.manualConsumerIds.has(consumerId));
+          if (!requestHasIndependentOwner(request) && !hasLiveManualConsumer) {
+            return { outcome: "stopped" };
+          }
+          return this.pendingFollowUp ?? this.inFlight ?? { outcome: "stopped" };
         });
       }
       if (request.source === "watcher") {
@@ -380,6 +511,14 @@ class AutoIndexCoordinator {
           if (this.stopped) return { outcome: "stopped" };
           return this.pendingFollowUp ?? { outcome: "stopped" };
         });
+      }
+      if (requestHasIndependentOwner(request)) {
+        this.activeHasIndependentOwner = true;
+      }
+      for (const consumerId of request.manualConsumerIds ?? []) {
+        if (this.manualConsumerIds.has(consumerId)) {
+          this.activeManualConsumerIds.add(consumerId);
+        }
       }
       return this.inFlight;
     }
@@ -425,10 +564,21 @@ class AutoIndexCoordinator {
   }
 
   private startRequest(request: IndexRequest): Promise<CoordinatedIndexResult> {
-    if (this.stopped || !this.canRun(request)) {
+    const hasLiveManualConsumer = Array.from(request.manualConsumerIds ?? [])
+      .some((consumerId) => this.manualConsumerIds.has(consumerId));
+    if (this.stopped
+      || !this.canRun(request)
+      || (!requestHasIndependentOwner(request) && !hasLiveManualConsumer)) {
       return Promise.resolve({ outcome: "stopped" });
     }
     this.activeRequest = request;
+    this.activeManualConsumerIds.clear();
+    for (const consumerId of request.manualConsumerIds ?? []) {
+      if (this.manualConsumerIds.has(consumerId)) {
+        this.activeManualConsumerIds.add(consumerId);
+      }
+    }
+    this.activeHasIndependentOwner = requestHasIndependentOwner(request);
     const job = this.run(request);
     this.inFlight = job;
     void job.then(() => {
@@ -436,13 +586,17 @@ class AutoIndexCoordinator {
       this.inFlight = null;
       this.activeRequest = null;
       this.abortController = null;
+      this.activeManualConsumerIds.clear();
+      this.activeHasIndependentOwner = false;
       if (this.batteryIndexJob === job) {
         this.batteryIndexJob = null;
         this.batteryCheck = null;
       }
       const pending = this.pendingRequest;
       this.pendingRequest = null;
-      if (pending && !this.stopped) {
+      const hasLiveManualConsumer = Array.from(pending?.manualConsumerIds ?? [])
+        .some((consumerId) => this.manualConsumerIds.has(consumerId));
+      if (pending && !this.stopped && (requestHasIndependentOwner(pending) || hasLiveManualConsumer)) {
         const followUp = this.request(pending);
         this.pendingFollowUp = followUp;
         void followUp.then(() => {
@@ -501,6 +655,9 @@ class AutoIndexCoordinator {
         const stats = await operation((progress) => {
           this.throwIfCancelled(controller.signal);
           request.onProgress?.(progress);
+          for (const consumerId of this.activeManualConsumerIds) {
+            this.manualProgressListeners.get(consumerId)?.(progress);
+          }
           this.status.progress = {
             phase: progress.phase,
             filesProcessed: progress.filesProcessed,
@@ -510,6 +667,26 @@ class AutoIndexCoordinator {
             percentage: calculatePercentage(progress),
           };
           this.status.updatedAt = now();
+          this.notifyRetrievalProgress(progress);
+        }, {
+          signal: controller.signal,
+          setPhase: async (phase) => {
+            this.notifyRetrievalPhase(phase);
+            await Promise.all(Array.from(this.activeManualConsumerIds, async (consumerId) => {
+              await this.manualPhaseListeners.get(consumerId)?.(phase);
+            }));
+          },
+          heartbeat: async () => {
+            this.notifyRetrievalHeartbeat();
+            await Promise.all(Array.from(this.activeManualConsumerIds, async (consumerId) => {
+              await this.manualHeartbeatListeners.get(consumerId)?.();
+            }));
+          },
+          onProviderError: (error) => {
+            for (const consumerId of this.activeManualConsumerIds) {
+              this.manualProviderErrorListeners.get(consumerId)?.(error);
+            }
+          },
         });
         this.throwIfCancelled(controller.signal);
         if (request.source === "startup" || request.source === "retrieval") {
@@ -546,6 +723,9 @@ class AutoIndexCoordinator {
               source: undefined,
             });
             return { outcome: "stopped" };
+          }
+          if (request.source === "manual") {
+            this.setState("stopped", { completedAt: now(), progress: undefined });
           }
           return { outcome: "stopped" };
         }
@@ -605,6 +785,54 @@ class AutoIndexCoordinator {
       updatedAt: now(),
       blockedReason: this.registration.blockedReason,
     };
+  }
+
+  private enqueueRetrievalActivity(
+    id: symbol,
+    subscriber: RetrievalActivitySubscriber,
+    task: (subscriber: RetrievalActivitySubscriber) => Promise<void>,
+  ): void {
+    subscriber.queue = subscriber.queue.then(async () => {
+      if (this.retrievalActivitySubscribers.get(id) !== subscriber) return;
+      await task(subscriber);
+    }).catch(() => {
+      this.retrievalActivitySubscribers.delete(id);
+    });
+  }
+
+  private notifyRetrievalPhase(phase: string): void {
+    for (const [id, subscriber] of this.retrievalActivitySubscribers) {
+      this.enqueueRetrievalActivity(id, subscriber, async (active) => {
+        if (active.lastPhase === phase) return;
+        active.lastPhase = phase;
+        await active.control.setPhase?.(phase);
+      });
+    }
+  }
+
+  private notifyRetrievalHeartbeat(): void {
+    for (const [id, subscriber] of this.retrievalActivitySubscribers) {
+      this.enqueueRetrievalActivity(id, subscriber, async (active) => {
+        await active.control.heartbeat?.();
+      });
+    }
+  }
+
+  private notifyRetrievalProgress(progress: IndexProgress): void {
+    for (const [id, subscriber] of this.retrievalActivitySubscribers) {
+      this.enqueueRetrievalActivity(id, subscriber, async (active) => {
+        if (active.control.reportProgress) {
+          active.lastPhase = progress.phase;
+          await active.control.reportProgress(calculatePercentage(progress), progress.phase);
+          return;
+        }
+        if (active.lastPhase !== progress.phase) {
+          active.lastPhase = progress.phase;
+          await active.control.setPhase?.(progress.phase);
+        }
+        await active.control.heartbeat?.();
+      });
+    }
   }
 
   private throwIfCancelled(signal: AbortSignal): void {
@@ -835,13 +1063,19 @@ export function runCoordinatedIndex(
   host: HostMode,
   force: boolean,
   onProgress?: (progress: IndexProgress) => void,
+  signal?: AbortSignal,
+  heartbeat?: () => void | Promise<void>,
+  onProviderError?: NonNullable<Parameters<Indexer["index"]>[1]>["onProviderError"],
+  setPhase?: NonNullable<Parameters<Indexer["index"]>[1]>["setPhase"],
 ): Promise<CoordinatedIndexResult> | null {
-  return getCoordinator(projectRoot, host)?.request({
-    checkFreshness: !force,
+  return getCoordinator(projectRoot, host)?.requestManual(
     force,
     onProgress,
-    source: "manual",
-  }) ?? null;
+    signal,
+    heartbeat,
+    onProviderError,
+    setPhase,
+  ) ?? null;
 }
 
 export function getAutoIndexStatus(
@@ -855,11 +1089,11 @@ export function getAutoIndexStatus(
   };
 }
 
-export async function waitForAutoIndexForRetrieval(
+async function waitForAutoIndexForRetrievalFromCoordinator(
   projectRoot: string,
   host: HostMode,
+  coordinator: AutoIndexCoordinator | null,
 ): Promise<AutoIndexRetrievalResult> {
-  const coordinator = getCoordinator(projectRoot, host);
   if (!coordinator) return { ready: true };
   const initial = coordinator.snapshot();
   if (!initial.enabled) return { ready: true };
@@ -918,6 +1152,19 @@ export async function waitForAutoIndexForRetrieval(
     ready: false,
     text: `Automatic indexing is ${status.state}. Retry shortly or call index_status for progress. You can also run index_codebase explicitly.`,
   };
+}
+
+export function waitForAutoIndexForRetrieval(
+  projectRoot: string,
+  host: HostMode,
+  control?: Pick<OperationControl, "heartbeat" | "reportProgress" | "setPhase" | "signal">,
+): Promise<AutoIndexRetrievalResult> {
+  const coordinator = getCoordinator(projectRoot, host);
+  const detach = coordinator?.subscribeRetrievalActivity(control) ?? (() => undefined);
+  return raceWithOperationSignal(
+    waitForAutoIndexForRetrievalFromCoordinator(projectRoot, host, coordinator),
+    control?.signal,
+  ).finally(detach);
 }
 
 export async function stopAutoIndex(

--- a/src/utils/background-worker.ts
+++ b/src/utils/background-worker.ts
@@ -588,6 +588,7 @@ class BackgroundWorkerController {
   private teardownRetryTimer: ReturnType<typeof setTimeout> | null = null;
   private transition: Promise<void> = Promise.resolve();
   private stopPromise: Promise<void> | null = null;
+  private stopDrainPromise: Promise<void> | null = null;
   private stopped = false;
   private stopping = false;
   private losingLeadership = false;
@@ -779,6 +780,11 @@ class BackgroundWorkerController {
     return completion;
   }
 
+  async waitForStopCompletion(): Promise<void> {
+    await (this.stopPromise ?? Promise.resolve());
+    await (this.stopDrainPromise ?? Promise.resolve());
+  }
+
   private canRun(): boolean {
     return this.config.indexing.autoIndex || this.hooks.watcherFactory != null;
   }
@@ -848,22 +854,24 @@ class BackgroundWorkerController {
     lease: BackgroundWorkerLease,
     completion: Promise<void>,
   ): void {
-    void completion.then(
-      () => {
-        void this.enqueue(async () => {
-          if (this.lease !== lease || !this.stopping) return;
-          this.leaderWorkStopped = true;
-          this.releaseStoppedLease(lease);
-        }).catch((error: unknown) => {
-          console.error("[codebase-index] Failed to release background worker lease after automatic indexing stopped:", error);
-          this.scheduleTeardownRetry();
-        });
-      },
+    const drain = completion.then(
+      () => this.enqueue(async () => {
+        if (this.lease !== lease || !this.stopping) return;
+        this.leaderWorkStopped = true;
+        this.releaseStoppedLease(lease);
+      }).catch((error: unknown) => {
+        console.error("[codebase-index] Failed to release background worker lease after automatic indexing stopped:", error);
+        this.scheduleTeardownRetry();
+        throw error;
+      }),
       (error: unknown) => {
         console.error("[codebase-index] Failed while waiting for automatic indexing to stop:", error);
         this.scheduleTeardownRetry();
+        throw error;
       },
     );
+    this.stopDrainPromise = drain;
+    void drain.catch(() => undefined);
   }
 
   private releaseStoppedLease(lease: BackgroundWorkerLease): void {
@@ -877,6 +885,7 @@ class BackgroundWorkerController {
   }
 
   private finishStoppedLease(): void {
+    this.stopDrainPromise = null;
     this.leaderWorkStopped = false;
     this.stopAutoIndexOnTeardown = true;
     this.stopping = false;
@@ -1125,12 +1134,17 @@ export function isBackgroundWorkerStopping(projectRoot: string, host: HostMode):
   return key !== undefined && workers.get(key)?.isStopping() === true;
 }
 
-export async function stopBackgroundWorker(projectRoot: string, host: HostMode): Promise<void> {
+export async function stopBackgroundWorker(
+  projectRoot: string,
+  host: HostMode,
+  waitForCompletion = false,
+): Promise<void> {
   const projectKey = projectLookupKey(projectRoot, host);
   const key = workerKeysByProject.get(projectKey);
   const worker = key ? workers.get(key) : undefined;
   if (!worker) return;
   await worker.stop();
+  if (waitForCompletion) await worker.waitForStopCompletion();
 }
 
 export async function resetBackgroundWorkersForTests(): Promise<void> {

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -3,6 +3,10 @@ import { existsSync, readFileSync, promises as fsPromises } from "fs";
 import * as path from "path";
 
 import { hasFilteredPathSegment, isBuildPathSegment, isHiddenPathSegment } from "./paths.js";
+import {
+  isOperationInterruption,
+  throwIfOperationAborted,
+} from "./operation-control.js";
 
 const PROJECT_MARKERS = [
   ".git",
@@ -158,6 +162,8 @@ function matchGlob(filePath: string, pattern: string): boolean {
 export interface WalkOptions {
   maxDepth: number;
   maxFilesPerDirectory: number;
+  signal?: AbortSignal;
+  heartbeat?: () => void | Promise<void>;
 }
 
 export async function* walkDirectory(
@@ -171,12 +177,16 @@ export async function* walkDirectory(
   options: WalkOptions,
   currentDepth: number = 0
 ): AsyncGenerator<{ path: string; size: number }> {
+  throwIfOperationAborted(options.signal);
   const entries = await fsPromises.readdir(dir, { withFileTypes: true });
+  throwIfOperationAborted(options.signal);
 
   const filesInDir: Array<{ path: string; size: number }> = [];
   const subdirs: Array<{ fullPath: string; relativePath: string }> = [];
 
   for (const entry of entries) {
+    throwIfOperationAborted(options.signal);
+    await options.heartbeat?.();
     const fullPath = path.join(dir, entry.name);
     const relativePath = toPosixRelativePath(path.relative(projectRoot, fullPath));
 
@@ -227,6 +237,8 @@ export async function* walkDirectory(
   filesInDir.sort((a, b) => a.size - b.size);
   const limitedFiles = filesInDir.slice(0, options.maxFilesPerDirectory);
   for (const f of limitedFiles) {
+    throwIfOperationAborted(options.signal);
+    await options.heartbeat?.();
     yield f;
   }
   for (let i = options.maxFilesPerDirectory; i < filesInDir.length; i++) {
@@ -236,6 +248,7 @@ export async function* walkDirectory(
   const canRecurse = options.maxDepth === -1 || currentDepth < options.maxDepth;
   if (canRecurse) {
     for (const sub of subdirs) {
+      throwIfOperationAborted(options.signal);
       yield* walkDirectory(
         sub.fullPath,
         projectRoot,
@@ -275,12 +288,15 @@ export async function collectFiles(
     opts,
     0
   )) {
+    throwIfOperationAborted(opts.signal);
+    await opts.heartbeat?.();
     files.push(file);
   }
 
   if (additionalRoots && additionalRoots.length > 0) {
     const normalizedRoots = new Set<string>();
     for (const kbRoot of additionalRoots) {
+      throwIfOperationAborted(opts.signal);
       const resolved = path.normalize(
         path.isAbsolute(kbRoot) ? kbRoot : path.resolve(projectRoot, kbRoot)
       );
@@ -288,6 +304,7 @@ export async function collectFiles(
     }
 
     for (const resolvedKbRoot of normalizedRoots) {
+      throwIfOperationAborted(opts.signal);
       try {
         const stat = await fsPromises.stat(resolvedKbRoot);
         if (!stat.isDirectory()) {
@@ -306,9 +323,13 @@ export async function collectFiles(
           opts,
           0
         )) {
+          throwIfOperationAborted(opts.signal);
+          await opts.heartbeat?.();
           files.push(file);
         }
-      } catch {
+      } catch (error) {
+        if (isOperationInterruption(error)) throw error;
+        throwIfOperationAborted(opts.signal);
         skipped.push({ path: resolvedKbRoot, reason: "excluded" });
       }
     }

--- a/src/utils/operation-control.ts
+++ b/src/utils/operation-control.ts
@@ -1,0 +1,191 @@
+export interface OperationControl {
+  signal?: AbortSignal;
+  setPhase?: (phase: string) => void | Promise<void>;
+  heartbeat?: () => void | Promise<void>;
+  reportProgress?: (progress: number, phase?: string) => void | Promise<void>;
+}
+
+export class OperationCancelledError extends Error {
+  constructor() {
+    super("The operation was cancelled.");
+    this.name = "OperationCancelledError";
+  }
+}
+
+export class OperationStallTimeoutError extends Error {
+  constructor() {
+    super("The operation stopped reporting activity before the configured deadline.");
+    this.name = "OperationStallTimeoutError";
+  }
+}
+
+export class ProviderRequestError extends Error {
+  readonly statusCode?: number;
+  readonly timedOut: boolean;
+  readonly retryable?: boolean;
+  readonly kind?: ProviderRequestKind;
+
+  constructor(options: {
+    statusCode?: number;
+    timedOut?: boolean;
+    retryable?: boolean;
+    kind?: ProviderRequestKind;
+    message?: string;
+  } = {}) {
+    super(options.message ?? (options.timedOut === true
+      ? "The embedding or reranking provider timed out."
+      : "The embedding or reranking provider request failed."));
+    this.name = "ProviderRequestError";
+    this.statusCode = options.statusCode;
+    this.timedOut = options.timedOut === true;
+    this.kind = options.kind;
+    this.retryable = options.retryable ?? (
+      this.timedOut
+      || options.statusCode === undefined
+      || options.statusCode === 429
+      || options.statusCode >= 500
+    );
+  }
+}
+
+export type ProviderRequestKind =
+  | "context_length"
+  | "endpoint_unavailable"
+  | "malformed_response";
+
+export type OperationInterruptionError = OperationCancelledError | OperationStallTimeoutError;
+
+export function getOperationInterruption(error: unknown): OperationInterruptionError | undefined {
+  const pending = [error];
+  const visited = new Set<object>();
+
+  while (pending.length > 0) {
+    const current = pending.shift();
+    if (current instanceof OperationCancelledError || current instanceof OperationStallTimeoutError) {
+      return current;
+    }
+    if (typeof current !== "object" || current === null || visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+    if (current instanceof AggregateError) {
+      pending.unshift(...current.errors);
+    }
+  }
+
+  return undefined;
+}
+
+export function isOperationInterruption(error: unknown): boolean {
+  return getOperationInterruption(error) !== undefined;
+}
+
+function normalizeAbortReason(signal: AbortSignal): Error {
+  if (signal.reason instanceof OperationCancelledError
+    || signal.reason instanceof OperationStallTimeoutError
+    || signal.reason instanceof ProviderRequestError) {
+    return signal.reason;
+  }
+  return new OperationCancelledError();
+}
+
+export interface ProviderRequestSignal {
+  signal: AbortSignal;
+  dispose: () => void;
+}
+
+export function createProviderRequestSignal(
+  source: AbortSignal | undefined,
+  timeoutMs: number | undefined,
+): ProviderRequestSignal {
+  const linked = createLinkedAbortController(source);
+  const timeout = timeoutMs === undefined
+    ? undefined
+    : setTimeout(
+        () => linked.controller.abort(new ProviderRequestError({ timedOut: true, retryable: true })),
+        timeoutMs,
+      );
+  return {
+    signal: linked.controller.signal,
+    dispose: () => {
+      if (timeout) clearTimeout(timeout);
+      linked.dispose();
+    },
+  };
+}
+
+export function throwIfOperationAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted === true) {
+    throw normalizeAbortReason(signal);
+  }
+}
+
+export interface LinkedAbortController {
+  controller: AbortController;
+  dispose: () => void;
+}
+
+export function createLinkedAbortController(
+  source: AbortSignal | undefined,
+  fallbackReason: Error = new OperationCancelledError(),
+): LinkedAbortController {
+  const controller = new AbortController();
+  if (!source) {
+    return { controller, dispose: () => undefined };
+  }
+
+  const abort = (): void => {
+    const reason = source.reason instanceof OperationCancelledError
+      || source.reason instanceof OperationStallTimeoutError
+      ? source.reason
+      : fallbackReason;
+    controller.abort(reason);
+  };
+  if (source.aborted) {
+    abort();
+    return { controller, dispose: () => undefined };
+  }
+
+  source.addEventListener("abort", abort, { once: true });
+  return {
+    controller,
+    dispose: () => source.removeEventListener("abort", abort),
+  };
+}
+
+export async function raceWithOperationSignal<T>(
+  promise: Promise<T>,
+  signal: AbortSignal | undefined,
+): Promise<T> {
+  throwIfOperationAborted(signal);
+  if (!signal) return promise;
+
+  return new Promise<T>((resolve, reject) => {
+    const abort = (): void => reject(normalizeAbortReason(signal));
+    signal.addEventListener("abort", abort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", abort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", abort);
+        reject(error);
+      },
+    );
+  });
+}
+
+export async function runOperationPhase(
+  control: OperationControl | undefined,
+  phase: string,
+): Promise<void> {
+  throwIfOperationAborted(control?.signal);
+  await control?.setPhase?.(phase);
+  throwIfOperationAborted(control?.signal);
+}
+
+export async function operationHeartbeat(control: OperationControl | undefined): Promise<void> {
+  throwIfOperationAborted(control?.signal);
+  await control?.heartbeat?.();
+}

--- a/tests/architecture-context-adapters.test.ts
+++ b/tests/architecture-context-adapters.test.ts
@@ -1,3 +1,6 @@
+import * as os from "node:os";
+import * as path from "node:path";
+
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -14,6 +17,7 @@ vi.mock("../src/tools/execute-common.js", async (importOriginal) => ({
 
 import codebaseIndexPiExtension from "../src/pi-extension.js";
 import { registerMcpTools } from "../src/adapters/mcp/register-tools.js";
+import { McpRuntimeDiagnostics } from "../src/adapters/mcp/runtime-diagnostics.js";
 import { architecture_context } from "../src/adapters/opencode/tools.js";
 import { TOOL_NAME } from "../src/tools/tool-names.js";
 
@@ -84,7 +88,11 @@ describe("architecture_context host execution contracts", () => {
     expect(executeArchitectureContext).toHaveBeenNthCalledWith(1, "/repo/opencode", "opencode", args);
 
     const mcpServer = new McpServer({ name: "architecture-contract", version: "1.0.0" });
-    registerMcpTools(mcpServer, { projectRoot: "/repo/mcp", host: "codex" });
+    registerMcpTools(mcpServer, {
+      projectRoot: "/repo/mcp",
+      host: "codex",
+      diagnostics: new McpRuntimeDiagnostics(path.join(os.tmpdir(), "architecture-context-adapters-index")),
+    });
     const client = new Client({ name: "architecture-contract-client", version: "1.0.0" });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     await mcpServer.connect(serverTransport);
@@ -96,7 +104,13 @@ describe("architecture_context host execution contracts", () => {
       await client.close();
       await mcpServer.close();
     }
-    expect(executeArchitectureContext).toHaveBeenNthCalledWith(2, "/repo/mcp", "codex", args);
+    expect(executeArchitectureContext).toHaveBeenNthCalledWith(
+      2,
+      "/repo/mcp",
+      "codex",
+      args,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
 
     const piTools = new Map<string, RegisteredPiTool>();
     codebaseIndexPiExtension({

--- a/tests/architecture-context.test.ts
+++ b/tests/architecture-context.test.ts
@@ -11,9 +11,13 @@ import {
   buildArchitectureContext,
   selectArchitectureFocusedSymbols,
 } from "../src/tools/architecture-context.js";
-import { getRecentGitActivity } from "../src/tools/visualize/activity.js";
+import {
+  getRecentGitActivity,
+  getRecentGitActivityAbortable,
+} from "../src/tools/visualize/activity.js";
 import { transformForVisualization } from "../src/tools/visualize/transform.js";
 import { estimateTokens } from "../src/utils/cost.js";
+import { OperationCancelledError } from "../src/utils/operation-control.js";
 
 function symbol(id: string, name: string, filePath: string, startLine = 2): SymbolData {
   return {
@@ -268,5 +272,14 @@ describe("architecture_context", () => {
     expect(activity[0]?.source).toMatch(/^commit [0-9a-f]+$/);
     expect(activity[0]?.summary).toContain("Latest: feat: update API validation");
     expect(getRecentGitActivity(data, path.join(tempDir, "missing"))).toEqual([]);
+  });
+
+  it("does not start Git activity collection for a cancelled operation", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const data = transformForVisualization([symbols[0]], [], { includeOrphans: true });
+
+    await expect(getRecentGitActivityAbortable(data, tempDir, controller.signal))
+      .rejects.toBeInstanceOf(OperationCancelledError);
   });
 });

--- a/tests/auto-index.test.ts
+++ b/tests/auto-index.test.ts
@@ -5,8 +5,15 @@ import * as path from "path";
 
 import { parseConfig } from "../src/config/schema.js";
 import { IndexLockContentionError } from "../src/indexer/index-lock.js";
-import type { IndexFreshnessResult, IndexProgress, IndexStats, StatusResult } from "../src/indexer/index.js";
+import type {
+  Indexer,
+  IndexFreshnessResult,
+  IndexProgress,
+  IndexStats,
+  StatusResult,
+} from "../src/indexer/index.js";
 import type { BackgroundIndexingPolicy } from "../src/utils/power-source.js";
+import { OperationCancelledError, ProviderRequestError } from "../src/utils/operation-control.js";
 import {
   configureBackgroundWorker,
   isBackgroundWorkerLeader,
@@ -107,7 +114,10 @@ class MockIndexer {
   freshness: IndexFreshnessResult = { readable: false, current: false, reason: "missing" };
   getStatus = vi.fn(async () => status(this.readable));
   getIndexFreshness = vi.fn(async () => this.freshness);
-  index = vi.fn(async (onProgress?: (progress: IndexProgress) => void) => {
+  index = vi.fn(async (
+    onProgress?: (progress: IndexProgress) => void,
+    _options?: Parameters<Indexer["index"]>[1],
+  ) => {
     onProgress?.({
       phase: "complete",
       filesProcessed: 1,
@@ -119,7 +129,10 @@ class MockIndexer {
     this.freshness = { readable: true, current: true, reason: "current" };
     return stats();
   });
-  forceIndex = vi.fn(async (onProgress?: (progress: IndexProgress) => void) => this.index(onProgress));
+  forceIndex = vi.fn(async (
+    onProgress?: (progress: IndexProgress) => void,
+    options?: Parameters<Indexer["index"]>[1],
+  ) => this.index(onProgress, options));
 }
 
 describe("auto-index coordinator", () => {
@@ -264,6 +277,221 @@ describe("auto-index coordinator", () => {
     expect(indexer.index).toHaveBeenCalledOnce();
   });
 
+  it("detaches a cancelled manual caller without stopping shared indexing", async () => {
+    const indexer = new MockIndexer();
+    const indexing = deferred<IndexStats>();
+    let emitProgress: ((progress: IndexProgress) => void) | undefined;
+    let underlyingSignal: AbortSignal | undefined;
+    indexer.index.mockImplementation(async (onProgress, options) => {
+      emitProgress = onProgress;
+      underlyingSignal = options?.signal;
+      return indexing.promise;
+    });
+    configureAutoIndex(projectRoot, "jcode", config(), () => indexer);
+
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    const firstProgress = vi.fn();
+    const secondProgress = vi.fn();
+    const first = runCoordinatedIndex(projectRoot, "jcode", false, firstProgress, firstController.signal);
+    await vi.waitFor(() => expect(indexer.index).toHaveBeenCalledOnce());
+    const second = runCoordinatedIndex(projectRoot, "jcode", false, secondProgress, secondController.signal);
+
+    emitProgress?.({
+      phase: "embedding",
+      filesProcessed: 1,
+      totalFiles: 1,
+      chunksProcessed: 0,
+      totalChunks: 2,
+    });
+    expect(firstProgress).toHaveBeenCalledOnce();
+    expect(secondProgress).toHaveBeenCalledOnce();
+
+    firstController.abort();
+    await expect(first).rejects.toBeInstanceOf(OperationCancelledError);
+    expect(underlyingSignal?.aborted).toBe(false);
+
+    emitProgress?.({
+      phase: "embedding",
+      filesProcessed: 1,
+      totalFiles: 1,
+      chunksProcessed: 1,
+      totalChunks: 2,
+    });
+    expect(firstProgress).toHaveBeenCalledOnce();
+    expect(secondProgress).toHaveBeenCalledTimes(2);
+
+    indexer.readable = true;
+    indexing.resolve(stats());
+    await expect(second).resolves.toMatchObject({ outcome: "ready" });
+    expect(indexer.index).toHaveBeenCalledOnce();
+  });
+
+  it("forwards phase updates to an attached coordinated caller", async () => {
+    const indexer = new MockIndexer();
+    indexer.index.mockImplementation(async (_onProgress, options) => {
+      await options?.setPhase?.("embedding");
+      indexer.readable = true;
+      indexer.freshness = { readable: true, current: true, reason: "current" };
+      return stats();
+    });
+    configureAutoIndex(projectRoot, "jcode", config(), () => indexer);
+    const setPhase = vi.fn(async () => undefined);
+
+    await expect(runCoordinatedIndex(
+      projectRoot,
+      "jcode",
+      false,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      setPhase,
+    )).resolves.toMatchObject({ outcome: "ready" });
+
+    expect(setPhase).toHaveBeenCalledWith("embedding");
+  });
+
+  it("delivers provider failures only to consumers still attached to shared indexing", async () => {
+    const indexer = new MockIndexer();
+    const indexing = deferred<IndexStats>();
+    let reportProviderError: ((error: ProviderRequestError) => void) | undefined;
+    indexer.index.mockImplementation(async (_onProgress, options) => {
+      reportProviderError = options?.onProviderError;
+      return indexing.promise;
+    });
+    configureAutoIndex(projectRoot, "jcode", config(), () => indexer);
+
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    const firstError = vi.fn();
+    const secondError = vi.fn();
+    const first = runCoordinatedIndex(
+      projectRoot,
+      "jcode",
+      false,
+      undefined,
+      firstController.signal,
+      undefined,
+      firstError,
+    );
+    await vi.waitFor(() => expect(indexer.index).toHaveBeenCalledOnce());
+    const second = runCoordinatedIndex(
+      projectRoot,
+      "jcode",
+      false,
+      undefined,
+      secondController.signal,
+      undefined,
+      secondError,
+    );
+
+    firstController.abort();
+    await expect(first).rejects.toBeInstanceOf(OperationCancelledError);
+    reportProviderError?.(new ProviderRequestError({ statusCode: 500 }));
+    expect(firstError).not.toHaveBeenCalled();
+    expect(secondError).toHaveBeenCalledOnce();
+
+    indexer.readable = true;
+    indexing.resolve(stats());
+    await expect(second).resolves.toMatchObject({ outcome: "ready" });
+  });
+
+  it("cancels an exclusively owned manual index after its caller detaches", async () => {
+    const indexer = new MockIndexer();
+    let underlyingSignal: AbortSignal | undefined;
+    indexer.index.mockImplementation(async (_onProgress, options) => {
+      underlyingSignal = options?.signal;
+      return new Promise<IndexStats>((_resolve, reject) => {
+        options?.signal?.addEventListener("abort", () => reject(new OperationCancelledError()), { once: true });
+      });
+    });
+    configureAutoIndex(projectRoot, "jcode", config(), () => indexer);
+
+    const controller = new AbortController();
+    const operation = runCoordinatedIndex(projectRoot, "jcode", false, undefined, controller.signal);
+    await vi.waitFor(() => expect(indexer.index).toHaveBeenCalledOnce());
+    controller.abort();
+
+    await expect(operation).rejects.toBeInstanceOf(OperationCancelledError);
+    await vi.waitFor(() => expect(underlyingSignal?.aborted).toBe(true));
+    await vi.waitFor(() => expect(getAutoIndexStatus(projectRoot, "jcode").state).toBe("stopped"));
+  });
+
+  it("keeps manual indexing alive after an independent retrieval joins", async () => {
+    const indexer = new MockIndexer();
+    const indexing = deferred<IndexStats>();
+    let underlyingSignal: AbortSignal | undefined;
+    indexer.index.mockImplementation(async (_onProgress, options) => {
+      underlyingSignal = options?.signal;
+      return indexing.promise;
+    });
+    configureAutoIndex(projectRoot, "jcode", config(), () => indexer);
+
+    const controller = new AbortController();
+    const manual = runCoordinatedIndex(projectRoot, "jcode", false, undefined, controller.signal);
+    await vi.waitFor(() => expect(indexer.index).toHaveBeenCalledOnce());
+    const retrieval = startAutoIndex(projectRoot, "jcode", "retrieval");
+    expect(retrieval).not.toBeNull();
+
+    controller.abort();
+    await expect(manual).rejects.toBeInstanceOf(OperationCancelledError);
+    expect(underlyingSignal?.aborted).toBe(false);
+
+    indexer.readable = true;
+    indexer.freshness = { readable: true, current: true, reason: "current" };
+    indexing.resolve(stats());
+    await expect(retrieval).resolves.toMatchObject({ outcome: "ready" });
+  });
+
+  it("removes a queued force index when its only caller cancels", async () => {
+    const indexer = new MockIndexer();
+    const background = deferred<IndexStats>();
+    let underlyingSignal: AbortSignal | undefined;
+    indexer.index.mockImplementation((_onProgress, options) => {
+      underlyingSignal = options?.signal;
+      return background.promise;
+    });
+    configureAutoIndex(projectRoot, "jcode", config(), () => indexer);
+
+    const backgroundJob = requestBackgroundIndex(projectRoot, "jcode");
+    await vi.waitFor(() => expect(indexer.index).toHaveBeenCalledOnce());
+    const controller = new AbortController();
+    const force = runCoordinatedIndex(projectRoot, "jcode", true, undefined, controller.signal);
+    controller.abort();
+
+    await expect(force).rejects.toBeInstanceOf(OperationCancelledError);
+    expect(underlyingSignal?.aborted).toBe(false);
+    background.resolve(stats());
+    await expect(backgroundJob).resolves.toMatchObject({ outcome: "ready" });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(indexer.forceIndex).not.toHaveBeenCalled();
+  });
+
+  it("preserves a pending watcher when a merged force caller cancels", async () => {
+    const indexer = new MockIndexer();
+    const active = deferred<IndexStats>();
+    indexer.index
+      .mockImplementationOnce(() => active.promise)
+      .mockResolvedValueOnce(stats());
+    configureAutoIndex(projectRoot, "jcode", config(), () => indexer);
+
+    const activeJob = startAutoIndex(projectRoot, "jcode");
+    await vi.waitFor(() => expect(indexer.index).toHaveBeenCalledOnce());
+    const watcher = requestBackgroundIndex(projectRoot, "jcode");
+    const controller = new AbortController();
+    const force = runCoordinatedIndex(projectRoot, "jcode", true, undefined, controller.signal);
+    controller.abort();
+
+    await expect(force).rejects.toBeInstanceOf(OperationCancelledError);
+    indexer.readable = true;
+    active.resolve(stats());
+    await expect(activeJob).resolves.toMatchObject({ outcome: "ready" });
+    await expect(watcher).resolves.toMatchObject({ outcome: "ready" });
+    expect(indexer.index).toHaveBeenCalledTimes(2);
+    expect(indexer.forceIndex).not.toHaveBeenCalled();
+  });
+
   it("returns an actionable in-progress response after the configured wait", async () => {
     const indexer = new MockIndexer();
     const indexing = deferred<IndexStats>();
@@ -276,6 +504,67 @@ describe("auto-index coordinator", () => {
     expect(result.text).toContain("Automatic indexing is indexing");
     expect(result.text).toContain("index_status");
     indexing.resolve(stats());
+  });
+
+  it("forwards only real shared-index activity while a retrieval waits without taking ownership", async () => {
+    vi.useFakeTimers();
+    const indexer = new MockIndexer();
+    const indexing = deferred<IndexStats>();
+    let emitProgress: ((progress: IndexProgress) => void) | undefined;
+    let emitPhase: ((phase: string) => void | Promise<void>) | undefined;
+    let underlyingSignal: AbortSignal | undefined;
+    indexer.index.mockImplementation((onProgress, options) => {
+      emitProgress = onProgress;
+      emitPhase = options?.setPhase;
+      underlyingSignal = options?.signal;
+      return indexing.promise;
+    });
+    configureAutoIndex(projectRoot, "jcode", config({ autoIndexWaitMs: 1200 }), () => indexer);
+    const heartbeat = vi.fn(async () => undefined);
+    const setPhase = vi.fn(async () => undefined);
+    const controller = new AbortController();
+
+    const waiting = waitForAutoIndexForRetrieval(projectRoot, "jcode", {
+      heartbeat,
+      setPhase,
+      signal: controller.signal,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(indexer.index).toHaveBeenCalledOnce();
+
+    await emitPhase?.("embedding");
+    emitProgress?.({
+      phase: "embedding",
+      filesProcessed: 1,
+      totalFiles: 1,
+      chunksProcessed: 1,
+      totalChunks: 2,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(setPhase).toHaveBeenCalledWith("embedding");
+    expect(heartbeat).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(500);
+    expect(heartbeat).toHaveBeenCalledOnce();
+
+    controller.abort();
+
+    await expect(waiting).rejects.toBeInstanceOf(OperationCancelledError);
+    expect(underlyingSignal?.aborted).toBe(false);
+    emitProgress?.({
+      phase: "embedding",
+      filesProcessed: 1,
+      totalFiles: 1,
+      chunksProcessed: 2,
+      totalChunks: 2,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(heartbeat).toHaveBeenCalledOnce();
+    indexer.readable = true;
+    indexer.freshness = { readable: true, current: true, reason: "current" };
+    indexing.resolve(stats());
+    await vi.runAllTimersAsync();
+    expect(getAutoIndexStatus(projectRoot, "jcode")).toMatchObject({ state: "ready" });
   });
 
   it("retries transient locks with bounded exponential backoff", async () => {

--- a/tests/auto-index.test.ts
+++ b/tests/auto-index.test.ts
@@ -113,7 +113,9 @@ class MockIndexer {
   readable = false;
   freshness: IndexFreshnessResult = { readable: false, current: false, reason: "missing" };
   getStatus = vi.fn(async () => status(this.readable));
-  getIndexFreshness = vi.fn(async () => this.freshness);
+  getIndexFreshness = vi.fn(async (
+    _options?: Parameters<Indexer["getIndexFreshness"]>[0],
+  ) => this.freshness);
   index = vi.fn(async (
     onProgress?: (progress: IndexProgress) => void,
     _options?: Parameters<Indexer["index"]>[1],
@@ -202,6 +204,48 @@ describe("auto-index coordinator", () => {
 
     await expect(waitForAutoIndexForRetrieval(projectRoot, "pi")).resolves.toEqual({ ready: true });
     await vi.waitFor(() => expect(indexer.index).toHaveBeenCalledOnce());
+  });
+
+  it("cancels a retrieval freshness check through the caller control", async () => {
+    const indexer = new MockIndexer();
+    let preflightSignal: AbortSignal | undefined;
+    let markPreflightStarted: (() => void) | undefined;
+    const preflightStarted = new Promise<void>((resolve) => {
+      markPreflightStarted = resolve;
+    });
+    indexer.getIndexFreshness.mockImplementation(async (options) => {
+      preflightSignal = options?.signal;
+      await options?.setPhase?.("scanning");
+      await options?.heartbeat?.();
+      markPreflightStarted?.();
+      return new Promise<IndexFreshnessResult>((_resolve, reject) => {
+        options?.signal?.addEventListener(
+          "abort",
+          () => reject(new OperationCancelledError()),
+          { once: true },
+        );
+      });
+    });
+    configureAutoIndex(projectRoot, "pi", config(), () => indexer);
+    const controller = new AbortController();
+    const heartbeat = vi.fn(async () => undefined);
+    const setPhase = vi.fn(async () => undefined);
+
+    const result = waitForAutoIndexForRetrieval(projectRoot, "pi", {
+      signal: controller.signal,
+      heartbeat,
+      setPhase,
+    });
+    await preflightStarted;
+
+    expect(preflightSignal).toBe(controller.signal);
+    expect(setPhase).toHaveBeenCalledWith("scanning");
+    expect(heartbeat).toHaveBeenCalledOnce();
+    controller.abort();
+
+    await expect(result).rejects.toBeInstanceOf(OperationCancelledError);
+    expect(preflightSignal?.aborted).toBe(true);
+    expect(indexer.index).not.toHaveBeenCalled();
   });
 
   it("does not serve a stale snapshot while its refresh is in flight", async () => {
@@ -352,6 +396,54 @@ describe("auto-index coordinator", () => {
     expect(setPhase).toHaveBeenCalledWith("embedding");
   });
 
+  it("propagates cancellation and activity through the coordinated freshness preflight", async () => {
+    const indexer = new MockIndexer();
+    let preflightSignal: AbortSignal | undefined;
+    let markPreflightStarted: (() => void) | undefined;
+    const preflightStarted = new Promise<void>((resolve) => {
+      markPreflightStarted = resolve;
+    });
+    indexer.getIndexFreshness.mockImplementation(async (options) => {
+      preflightSignal = options?.signal;
+      await options?.setPhase?.("scanning");
+      await options?.heartbeat?.();
+      markPreflightStarted?.();
+      return new Promise<IndexFreshnessResult>((_resolve, reject) => {
+        options?.signal?.addEventListener(
+          "abort",
+          () => reject(new OperationCancelledError()),
+          { once: true },
+        );
+      });
+    });
+    configureAutoIndex(projectRoot, "jcode", config(), () => indexer);
+    const controller = new AbortController();
+    const heartbeat = vi.fn(async () => undefined);
+    const setPhase = vi.fn(async () => undefined);
+
+    const result = runCoordinatedIndex(
+      projectRoot,
+      "jcode",
+      false,
+      undefined,
+      controller.signal,
+      heartbeat,
+      undefined,
+      setPhase,
+    );
+    await preflightStarted;
+
+    expect(preflightSignal).toBeDefined();
+    expect(preflightSignal).not.toBe(controller.signal);
+    expect(setPhase).toHaveBeenCalledWith("scanning");
+    expect(heartbeat).toHaveBeenCalledOnce();
+    controller.abort();
+
+    await expect(result).rejects.toBeInstanceOf(OperationCancelledError);
+    await vi.waitFor(() => expect(preflightSignal?.aborted).toBe(true));
+    expect(indexer.index).not.toHaveBeenCalled();
+  });
+
   it("delivers provider failures only to consumers still attached to shared indexing", async () => {
     const indexer = new MockIndexer();
     const indexing = deferred<IndexStats>();
@@ -395,6 +487,68 @@ describe("auto-index coordinator", () => {
     indexer.readable = true;
     indexing.resolve(stats());
     await expect(second).resolves.toMatchObject({ outcome: "ready" });
+  });
+
+  it("replays a provider failure to late consumers without leaking it into the next job", async () => {
+    const indexer = new MockIndexer();
+    const firstIndexing = deferred<IndexStats>();
+    const secondIndexing = deferred<IndexStats>();
+    let reportProviderError: ((error: ProviderRequestError) => void) | undefined;
+    indexer.index
+      .mockImplementationOnce(async (_onProgress, options) => {
+        reportProviderError = options?.onProviderError;
+        return firstIndexing.promise;
+      })
+      .mockImplementationOnce(async () => secondIndexing.promise);
+    configureAutoIndex(projectRoot, "jcode", config(), () => indexer);
+
+    const firstError = vi.fn();
+    const first = runCoordinatedIndex(
+      projectRoot,
+      "jcode",
+      false,
+      undefined,
+      undefined,
+      undefined,
+      firstError,
+    );
+    await vi.waitFor(() => expect(indexer.index).toHaveBeenCalledOnce());
+    const providerError = new ProviderRequestError({ statusCode: 500 });
+    reportProviderError?.(providerError);
+
+    const lateError = vi.fn();
+    const late = runCoordinatedIndex(
+      projectRoot,
+      "jcode",
+      false,
+      undefined,
+      undefined,
+      undefined,
+      lateError,
+    );
+
+    expect(firstError).toHaveBeenCalledWith(providerError);
+    expect(lateError).toHaveBeenCalledWith(providerError);
+    firstIndexing.resolve(stats());
+    const [firstResult, lateResult] = await Promise.all([first, late]);
+    expect(firstResult.providerError).toBe(providerError);
+    expect(lateResult.providerError).toBe(providerError);
+
+    const nextError = vi.fn();
+    const next = runCoordinatedIndex(
+      projectRoot,
+      "jcode",
+      true,
+      undefined,
+      undefined,
+      undefined,
+      nextError,
+    );
+    await vi.waitFor(() => expect(indexer.index).toHaveBeenCalledTimes(2));
+    secondIndexing.resolve(stats());
+
+    await expect(next).resolves.not.toHaveProperty("providerError");
+    expect(nextError).not.toHaveBeenCalled();
   });
 
   it("cancels an exclusively owned manual index after its caller detaches", async () => {

--- a/tests/background-worker.test.ts
+++ b/tests/background-worker.test.ts
@@ -623,6 +623,35 @@ describe("background worker lease", () => {
     await vi.waitFor(() => expect(existsSync(leasePath)).toBe(false));
   });
 
+  it("waits for an unfinished automatic index and lease release during ordered shutdown", async () => {
+    const autoIndexCompletion = createDeferred();
+    const parsed = config();
+    const stopAutoIndex = vi.fn(async () => ({
+      completed: false as const,
+      completion: autoIndexCompletion.promise,
+    }));
+    configureBackgroundWorker(projectRoot, "codex", parsed, {
+      startAutoIndex: vi.fn(),
+      stopAutoIndex,
+    });
+
+    await vi.waitFor(() => expect(isBackgroundWorkerLeader(projectRoot, "codex")).toBe(true));
+    const leasePath = getBackgroundWorkerLeasePath(projectRoot, parsed, "codex");
+    let shutdownSettled = false;
+    const shutdown = stopBackgroundWorker(projectRoot, "codex", true).then(() => {
+      shutdownSettled = true;
+    });
+
+    await vi.waitFor(() => expect(stopAutoIndex).toHaveBeenCalledOnce());
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(existsSync(leasePath)).toBe(true);
+    expect(shutdownSettled).toBe(false);
+
+    autoIndexCompletion.resolve();
+    await shutdown;
+    expect(existsSync(leasePath)).toBe(false);
+  });
+
   it("retains a watcher-only lease until watcher-triggered indexing has drained", async () => {
     const autoIndexCompletion = createDeferred();
     const parsed = config({ autoIndex: false, watchFiles: true });

--- a/tests/branch-materialization.test.ts
+++ b/tests/branch-materialization.test.ts
@@ -9,6 +9,7 @@ import {
   isValidGitRemoteName,
   withMaterializedBranch,
 } from "../src/git/branch-materialization.js";
+import { OperationCancelledError } from "../src/utils/operation-control.js";
 
 function git(cwd: string, args: string[]): string {
   return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
@@ -236,6 +237,25 @@ describe("branch materialization", () => {
         throw new Error("injected indexing failure");
       },
     )).rejects.toThrow("injected indexing failure");
+
+    expect(fs.existsSync(path.dirname(materializedPath))).toBe(false);
+    expect(git(repo, ["worktree", "list", "--porcelain"])).toBe(beforeWorktrees);
+    expect(git(repo, ["rev-parse", "HEAD"])).toBe(mainCommit);
+  });
+
+  it("cleans up the temporary worktree when the caller cancels", async () => {
+    const beforeWorktrees = git(repo, ["worktree", "list", "--porcelain"]);
+    const controller = new AbortController();
+    let materializedPath = "";
+
+    await expect(withMaterializedBranch(
+      { projectRoot: repo, branch: "feature", signal: controller.signal },
+      async (worktreePath) => {
+        materializedPath = worktreePath;
+        controller.abort();
+        return "ignored";
+      },
+    )).rejects.toBeInstanceOf(OperationCancelledError);
 
     expect(fs.existsSync(path.dirname(materializedPath))).toBe(false);
     expect(git(repo, ["worktree", "list", "--porcelain"])).toBe(beforeWorktrees);

--- a/tests/changed-files.test.ts
+++ b/tests/changed-files.test.ts
@@ -7,6 +7,7 @@ import {
   createPullRequestCatalogIdentity,
   getChangedFiles,
 } from "../src/tools/changed-files.js";
+import { OperationCancelledError } from "../src/utils/operation-control.js";
 
 vi.mock("child_process", () => ({
   execFile: vi.fn(),
@@ -213,6 +214,28 @@ describe("getChangedFiles", () => {
         "github.com/fork-owner/fork-project",
       ),
       files: ["src/pr.ts", "tests/pr.test.ts"],
+    });
+  });
+
+  it("cancels gh PR metadata lookup without falling back to local refs", async () => {
+    const controller = new AbortController();
+    (execFile as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (_cmd: string, _args: string[], options: { signal?: AbortSignal }, callback: (error: Error) => void) => {
+        options.signal?.addEventListener("abort", () => {
+          const error = new Error("aborted");
+          error.name = "AbortError";
+          callback(error);
+        }, { once: true });
+      },
+    );
+
+    const operation = getChangedFiles({ pr: 42, projectRoot, signal: controller.signal });
+    controller.abort();
+
+    await expect(operation).rejects.toBeInstanceOf(OperationCancelledError);
+    expect(execFile).toHaveBeenCalledOnce();
+    expect((execFile as unknown as ReturnType<typeof vi.fn>).mock.calls[0]?.[2]).toMatchObject({
+      signal: controller.signal,
     });
   });
 

--- a/tests/communities.test.ts
+++ b/tests/communities.test.ts
@@ -7,6 +7,7 @@ import { Indexer } from "../src/indexer/index.js";
 import { code_communities, initializeTools } from "../src/tools/index.js";
 import type { Database } from "../src/native/index.js";
 import { buildCodeCommunitiesResult, formatCodeCommunities } from "../src/tools/format-communities.js";
+import { OperationCancelledError } from "../src/utils/operation-control.js";
 
 vi.mock("child_process", () => ({
   execFile: vi.fn(),
@@ -472,5 +473,19 @@ describe("code_communities tool", () => {
     expect(centrality.length).toBe(3);
     expect(centrality[0]).toHaveProperty("callerCount");
     expect(centrality[0]).toHaveProperty("calleeCount");
+  });
+
+  it("checks cancellation after native community calculations and emits activity", async () => {
+    const indexer = await createIndexer();
+    const controller = new AbortController();
+    const heartbeat = vi.fn(async () => {
+      controller.abort();
+    });
+
+    await expect(indexer.detectCommunities("main", undefined, {
+      signal: controller.signal,
+      heartbeat,
+    })).rejects.toBeInstanceOf(OperationCancelledError);
+    expect(heartbeat).toHaveBeenCalled();
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -89,6 +89,18 @@ describe("config schema", () => {
       expect(config.exclude).toHaveLength(DEFAULT_EXCLUDE.length);
       expect(config.indexing.pauseBackgroundIndexingOnBattery).toBe(false);
       expect(config.search.communityBoost).toBe(0);
+      expect(config.mcp.stallTimeoutMs).toBe(300_000);
+    });
+
+    it("normalizes the MCP stall timeout", () => {
+      expect(parseConfig({ mcp: { stallTimeoutMs: 0 } }).mcp.stallTimeoutMs).toBe(0);
+      expect(parseConfig({ mcp: { stallTimeoutMs: 1 } }).mcp.stallTimeoutMs).toBe(1000);
+      expect(parseConfig({ mcp: { stallTimeoutMs: 1000.9 } }).mcp.stallTimeoutMs).toBe(1000);
+      expect(parseConfig({ mcp: { stallTimeoutMs: 12_345 } }).mcp.stallTimeoutMs).toBe(12_345);
+      expect(parseConfig({ mcp: { stallTimeoutMs: Number.MAX_SAFE_INTEGER } }).mcp.stallTimeoutMs)
+        .toBe(2_147_483_647);
+      expect(parseConfig({ mcp: { stallTimeoutMs: -1 } }).mcp.stallTimeoutMs).toBe(300_000);
+      expect(parseConfig({ mcp: { stallTimeoutMs: Number.NaN } }).mcp.stallTimeoutMs).toBe(300_000);
     });
 
     it("parses and clamps the opt-in community ranking boost", () => {

--- a/tests/custom-provider.test.ts
+++ b/tests/custom-provider.test.ts
@@ -8,6 +8,19 @@ import pRetry from "p-retry";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import {
+  OperationCancelledError,
+  ProviderRequestError,
+} from "../src/utils/operation-control.js";
+
+function getRejectedError<T>(promise: Promise<T>): Promise<Error> {
+  return promise.then<Error>(
+    () => {
+      throw new Error("Expected promise to reject");
+    },
+    (error: unknown) => error instanceof Error ? error : new Error(String(error)),
+  );
+}
 
 describe("CustomEmbeddingProvider", () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;
@@ -20,20 +33,6 @@ describe("CustomEmbeddingProvider", () => {
       throw new Error("Expected custom provider info");
     }
     return info;
-  }
-
-  function getRejectedError<T>(promise: Promise<T>): Promise<Error> {
-    return promise.then<Error>(
-      () => {
-        throw new Error("Expected promise to reject");
-      },
-      (error: unknown) => {
-        if (error instanceof Error) {
-          return error;
-        }
-        return new Error(String(error));
-      }
-    );
   }
 
   beforeEach(() => {
@@ -176,7 +175,7 @@ describe("CustomEmbeddingProvider", () => {
     fetchSpy.mockResolvedValueOnce(new Response("Rate limited", { status: 429 }));
 
     const provider = createProvider();
-    await expect(provider.embedQuery("test")).rejects.toThrow("Custom embedding API error: 429");
+    await expect(provider.embedQuery("test")).rejects.toThrow("Custom embedding provider returned HTTP 429.");
   });
 
   it("should throw on unexpected response format", async () => {
@@ -230,9 +229,10 @@ describe("CustomEmbeddingProvider", () => {
     }), { status: 200 }));
 
     const provider = createProvider();
-    await expect(provider.embedQuery("test")).rejects.toThrow(
-      "Dimension mismatch: customProvider.dimensions is 768, but the API returned vectors with 1024 dimensions"
-    );
+    await expect(provider.embedQuery("test")).rejects.toMatchObject({
+      kind: "malformed_response",
+      retryable: false,
+    });
   });
 
   it("should always throw on dimension mismatch, even after a successful call", async () => {
@@ -251,10 +251,11 @@ describe("CustomEmbeddingProvider", () => {
     const result1 = await provider.embedQuery("first");
     expect(result1.embedding).toHaveLength(768);
 
-    // Second call throws on dimension mismatch
-    await expect(provider.embedQuery("second")).rejects.toThrow(
-      "Dimension mismatch: customProvider.dimensions is 768, but the API returned vectors with 512 dimensions"
-    );
+    // Second call still rejects the incompatible provider contract.
+    await expect(provider.embedQuery("second")).rejects.toMatchObject({
+      kind: "malformed_response",
+      retryable: false,
+    });
   });
 
   it("should use configurable timeout", async () => {
@@ -302,8 +303,8 @@ describe("CustomEmbeddingProvider", () => {
     const provider = createProvider();
     const error = await getRejectedError(provider.embedQuery("test"));
     expect(error).toBeInstanceOf(CustomProviderNonRetryableError);
-    expect(error.message).toContain("non-retryable");
     expect(error.message).toContain("401");
+    expect(error.message).not.toContain("Unauthorized");
   });
 
   it("should throw non-retryable error on 400 Bad Request", async () => {
@@ -347,9 +348,10 @@ describe("CustomEmbeddingProvider", () => {
     }), { status: 200 }));
 
     const provider = createProvider();
-    await expect(provider.embedBatch(["text1", "text2", "text3"])).rejects.toThrow(
-      "Embedding count mismatch: sent 3 texts but received 2 embeddings"
-    );
+    await expect(provider.embedBatch(["text1", "text2", "text3"])).rejects.toMatchObject({
+      kind: "malformed_response",
+      retryable: false,
+    });
   });
 
   it("should throw on embedding count mismatch (more than expected)", async () => {
@@ -363,9 +365,10 @@ describe("CustomEmbeddingProvider", () => {
     }), { status: 200 }));
 
     const provider = createProvider();
-    await expect(provider.embedBatch(["text1"])).rejects.toThrow(
-      "Embedding count mismatch: sent 1 texts but received 2 embeddings"
-    );
+    await expect(provider.embedBatch(["text1"])).rejects.toMatchObject({
+      kind: "malformed_response",
+      retryable: false,
+    });
   });
 
   it("should throw AbortError with timeout message when fetch is aborted", async () => {
@@ -382,15 +385,47 @@ describe("CustomEmbeddingProvider", () => {
     const provider = createEmbeddingProvider(info);
 
     await expect(provider.embedQuery("test")).rejects.toThrow(
-      "Custom embedding API request timed out after 5000ms for http://localhost:11434/v1/embeddings"
+      "Custom embedding provider request timed out after 5000ms."
     );
   });
 
-  it("should re-throw non-AbortError fetch failures as-is", async () => {
+  it("keeps the provider timeout active while reading the response body", async () => {
+    vi.useFakeTimers();
+    try {
+      fetchSpy.mockImplementation(async (_url, init) => ({
+        ok: true,
+        status: 200,
+        json: async () => new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          }, { once: true });
+        }),
+      }) as Response);
+      const provider = createEmbeddingProvider(createCustomProviderInfo({
+        baseUrl: "http://localhost:11434/v1",
+        model: "nomic-embed-text",
+        dimensions: 768,
+        timeoutMs: 1000,
+      }));
+      const assertion = expect(provider.embedQuery("test"))
+        .rejects.toThrow("Custom embedding provider request timed out after 1000ms.");
+
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(1000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("redacts non-AbortError fetch failures", async () => {
     fetchSpy.mockRejectedValueOnce(new TypeError("fetch failed"));
 
     const provider = createProvider();
-    await expect(provider.embedQuery("test")).rejects.toThrow("fetch failed");
+    const error = await getRejectedError(provider.embedQuery("test"));
+    expect(error).toBeInstanceOf(ProviderRequestError);
+    expect(error.message).toBe("Custom embedding provider request failed.");
+    expect(error.message).not.toContain("fetch failed");
   });
 
   it("should not retry on CustomProviderNonRetryableError via pRetry shouldRetry", async () => {
@@ -562,11 +597,14 @@ describe("OllamaEmbeddingProvider", () => {
     expect(calls).toBe(1);
   });
 
-  it("rethrows non-context ollama errors", async () => {
+  it("redacts non-context ollama errors", async () => {
     fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify({ error: "boom" }), { status: 500 }));
 
     const provider = createOllamaProvider();
-    await expect(provider.embedBatch(["hello"])).rejects.toThrow("Ollama embedding API error: 500");
+    const error = await getRejectedError(provider.embedBatch(["hello"]));
+    expect(error).toBeInstanceOf(ProviderRequestError);
+    expect(error.message).toBe("Ollama embedding provider returned HTTP 500.");
+    expect(error.message).not.toContain("boom");
   });
 
   it("aborts ollama embedding requests after the bounded timeout", async () => {
@@ -587,6 +625,29 @@ describe("OllamaEmbeddingProvider", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("does not fall back to per-text requests after caller cancellation", async () => {
+    let calls = 0;
+    let markRequestStarted: (() => void) | undefined;
+    const requestStarted = new Promise<void>((resolve) => {
+      markRequestStarted = resolve;
+    });
+    fetchSpy.mockImplementation(async (_url, init) => {
+      calls += 1;
+      markRequestStarted?.();
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")), { once: true });
+      });
+    });
+    const controller = new AbortController();
+    const provider = createOllamaProvider();
+    const operation = provider.embedBatch(["first", "second"], { signal: controller.signal });
+    await requestStarted;
+    controller.abort();
+
+    await expect(operation).rejects.toBeInstanceOf(OperationCancelledError);
+    expect(calls).toBe(1);
   });
 
   it("rejects ollama embeddings with the wrong vector dimensions", async () => {

--- a/tests/edit-context.test.ts
+++ b/tests/edit-context.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { countContextTokens } from "../src/tools/utils.js";
+import { OperationCancelledError } from "../src/utils/operation-control.js";
 
 const operationMocks = vi.hoisted(() => ({
   getCallGraphData: vi.fn(),
@@ -191,5 +192,26 @@ describe("codebase edit context", () => {
     expect(result.text).toContain("Risk: symbol \"missingSymbol\" could not be resolved");
     expect(result.text).toContain("src/auth-policy.ts");
     expect(result.details.resolution).toBe("not_found");
+  });
+
+  it("does not format resolved evidence after the operation is cancelled", async () => {
+    const controller = new AbortController();
+    operationMocks.getCallGraphData.mockImplementation(async (_root, _host, args) => ({
+      direction: args.direction,
+      resolution: resolved,
+      callers: [],
+      callees: [],
+    }));
+    operationMocks.implementationLookup.mockImplementation(async () => {
+      controller.abort();
+      return [source];
+    });
+
+    await expect(resolveCodebaseEditContext(
+      "/repo",
+      "jcode",
+      { query: "tighten token validation", symbol: "validateToken" },
+      { signal: controller.signal },
+    )).rejects.toBeInstanceOf(OperationCancelledError);
   });
 });

--- a/tests/embeddings.test.ts
+++ b/tests/embeddings.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import pRetry from "p-retry";
 import {
   createCustomProviderInfo,
   detectEmbeddingProvider,
@@ -7,6 +8,9 @@ import {
 } from "../src/embeddings/detector.js";
 import { EMBEDDING_MODELS } from "../src/config/constants.js";
 import { GoogleEmbeddingProvider } from "../src/embeddings/providers/google.js";
+import { OpenAIEmbeddingProvider } from "../src/embeddings/providers/openai.js";
+import { shouldRetryEmbeddingRequest } from "../src/indexer/index.js";
+import { ProviderRequestError } from "../src/utils/operation-control.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -235,10 +239,11 @@ describe("GoogleEmbeddingProvider", () => {
     })));
     const provider = new GoogleEmbeddingProvider(
       { provider: "google", baseUrl: "https://example.test", apiKey: "test" },
-      EMBEDDING_MODELS.google["gemini-embedding-2"],
+      { ...EMBEDDING_MODELS.google["gemini-embedding-2"], dimensions: 2 },
     );
+    const setPhase = vi.fn(async () => undefined);
 
-    await provider.embedQuery("find the indexer");
+    await provider.embedQuery("find the indexer", { setPhase });
     await provider.embedDocument("export class Indexer {}");
 
     expect(JSON.parse(String(fetchSpy.mock.calls[0][1]?.body)).requests[0]).toMatchObject({
@@ -247,5 +252,122 @@ describe("GoogleEmbeddingProvider", () => {
     expect(JSON.parse(String(fetchSpy.mock.calls[1][1]?.body)).requests[0]).toMatchObject({
       content: { parts: [{ text: "title: none | text: export class Indexer {}" }] },
     });
+    expect(setPhase).toHaveBeenCalledWith("embedding");
+  });
+
+  it("bounds the request while reading a response body", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => ({
+        ok: true,
+        status: 200,
+        json: async () => new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")), { once: true });
+        }),
+      }) as Response);
+      const provider = new GoogleEmbeddingProvider(
+        { provider: "google", baseUrl: "https://example.test", apiKey: "test" },
+        EMBEDDING_MODELS.google["gemini-embedding-2"],
+      );
+      const assertion = expect(provider.embedQuery("query"))
+        .rejects.toMatchObject({ timedOut: true, retryable: true });
+
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(120_000);
+      await assertion;
+      expect(fetchSpy).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    { embeddings: [] },
+    { embeddings: [{ values: [0.1] }] },
+    { embeddings: [{ values: [0.1, Number.NaN] }] },
+  ])("rejects malformed vectors without exposing response data", async (body) => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify(body)));
+    const provider = new GoogleEmbeddingProvider(
+      { provider: "google", baseUrl: "https://secret.example", apiKey: "private" },
+      { ...EMBEDDING_MODELS.google["gemini-embedding-2"], dimensions: 2 },
+    );
+
+    const error = await provider.embedQuery("private query").catch((reason: unknown) => reason);
+    expect(error).toMatchObject({ kind: "malformed_response", retryable: false });
+    expect(String(error)).not.toContain("secret.example");
+    expect(String(error)).not.toContain("private query");
+  });
+});
+
+describe("OpenAIEmbeddingProvider", () => {
+  it("bounds the request while reading a response body", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => ({
+        ok: true,
+        status: 200,
+        json: async () => new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")), { once: true });
+        }),
+      }) as Response);
+      const provider = new OpenAIEmbeddingProvider(
+        { provider: "openai", baseUrl: "https://example.test", apiKey: "test" },
+        EMBEDDING_MODELS.openai["text-embedding-3-small"],
+      );
+      const assertion = expect(provider.embedQuery("query"))
+        .rejects.toMatchObject({ timedOut: true, retryable: true });
+
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(120_000);
+      await assertion;
+      expect(fetchSpy).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    { data: [], usage: { total_tokens: 1 } },
+    { data: [{ embedding: [0.1] }], usage: { total_tokens: 1 } },
+    { data: [{ embedding: [0.1, Number.POSITIVE_INFINITY] }], usage: { total_tokens: 1 } },
+  ])("rejects malformed vectors without exposing response data", async (body) => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify(body)));
+    const provider = new OpenAIEmbeddingProvider(
+      { provider: "openai", baseUrl: "https://secret.example", apiKey: "private" },
+      { ...EMBEDDING_MODELS.openai["text-embedding-3-small"], dimensions: 2 },
+    );
+
+    const error = await provider.embedQuery("private query").catch((reason: unknown) => reason);
+    expect(error).toMatchObject({ kind: "malformed_response", retryable: false });
+    expect(String(error)).not.toContain("secret.example");
+    expect(String(error)).not.toContain("private query");
+  });
+});
+
+describe("embedding request retries", () => {
+  it("does not retry non-retryable provider 4xx failures", async () => {
+    const request = vi.fn(async () => {
+      throw new ProviderRequestError({ statusCode: 400 });
+    });
+
+    await expect(pRetry(request, {
+      retries: 3,
+      minTimeout: 0,
+      shouldRetry: ({ error }) => shouldRetryEmbeddingRequest(error),
+    })).rejects.toBeInstanceOf(ProviderRequestError);
+    expect(request).toHaveBeenCalledOnce();
+  });
+
+  it.each([429, 500])("retries retryable provider status %i", async (statusCode) => {
+    const request = vi.fn(async () => {
+      throw new ProviderRequestError({ statusCode });
+    });
+
+    await expect(pRetry(request, {
+      retries: 2,
+      minTimeout: 0,
+      shouldRetry: ({ error }) => shouldRetryEmbeddingRequest(error),
+    })).rejects.toBeInstanceOf(ProviderRequestError);
+    expect(request).toHaveBeenCalledTimes(3);
   });
 });

--- a/tests/indexer-clear-index.test.ts
+++ b/tests/indexer-clear-index.test.ts
@@ -10,6 +10,7 @@ import { readFailedBatchRecords } from "../src/indexer/failed-state-persistence.
 import { Indexer } from "../src/indexer/index.js";
 import { Database, InvertedIndex, VectorStore } from "../src/native/index.js";
 import { hashContent } from "../src/native/index.js";
+import { OperationCancelledError } from "../src/utils/operation-control.js";
 
 function canonicalPath(filePath: string): string {
   return fs.realpathSync.native(filePath);
@@ -154,6 +155,48 @@ describe("indexer clearIndex force rebuild", () => {
     expect(embeddingBuffer).not.toBeNull();
     const floatCount = embeddingBuffer!.byteLength / Float32Array.BYTES_PER_ELEMENT;
     expect(floatCount).toBe(4);
+  });
+
+  it("releases the mutation lease when force indexing is cancelled at the clear barrier", async () => {
+    const indexer = createIndexer(tempDir, 8);
+    await indexer.index();
+    const barrier = Promise.withResolvers<void>();
+    const enteredBarrier = Promise.withResolvers<void>();
+    const internals = indexer as unknown as {
+      removeProjectRuntimeStateArtifacts: () => Promise<void>;
+    };
+    const originalRemove = internals.removeProjectRuntimeStateArtifacts.bind(indexer);
+    internals.removeProjectRuntimeStateArtifacts = async (): Promise<void> => {
+      enteredBarrier.resolve();
+      await barrier.promise;
+      await originalRemove();
+    };
+    const controller = new AbortController();
+
+    const operation = indexer.forceIndex(undefined, { signal: controller.signal });
+    await enteredBarrier.promise;
+    controller.abort();
+    barrier.resolve();
+
+    await expect(operation).rejects.toBeInstanceOf(OperationCancelledError);
+    expect(fs.existsSync(path.join(tempDir, ".opencode", "index", "indexing.lock"))).toBe(false);
+  });
+
+  it("releases the mutation lease when a health-check heartbeat cancels the operation", async () => {
+    const indexer = createIndexer(tempDir, 8);
+    await indexer.index();
+    const controller = new AbortController();
+    const heartbeat = vi.fn(async () => {
+      controller.abort();
+    });
+
+    await expect(indexer.healthCheck({
+      signal: controller.signal,
+      heartbeat,
+    })).rejects.toBeInstanceOf(OperationCancelledError);
+
+    expect(heartbeat).toHaveBeenCalled();
+    expect(fs.existsSync(path.join(tempDir, ".opencode", "index", "indexing.lock"))).toBe(false);
   });
 
   it("removes a deleted file indexed through a symlinked global project root", async () => {

--- a/tests/indexer-failed-batches.test.ts
+++ b/tests/indexer-failed-batches.test.ts
@@ -9,6 +9,7 @@ import { readFailedBatchRecords } from "../src/indexer/failed-state-persistence.
 import { Indexer } from "../src/indexer/index.js";
 import { Database, VectorStore, hashContent } from "../src/native/index.js";
 import { formatStatus } from "../src/tools/utils.js";
+import { ProviderRequestError } from "../src/utils/operation-control.js";
 
 function projectIdentityHash(projectRoot: string): string {
   return hashContent(fs.realpathSync.native(projectRoot)).slice(0, 16);
@@ -256,6 +257,23 @@ describe("indexer failed batch recovery", () => {
     expect(recoveredStatus.indexed).toBe(true);
     expect(recoveredStatus.failedBatchesCount).toBe(0);
     expect(recoveredStatus.failedBatchesPath).toBeUndefined();
+  });
+
+  it("forwards provider failures while preparing a missing branch index", async () => {
+    const indexer = createIndexer();
+    const onProviderError = vi.fn();
+    failEmbeddings = true;
+
+    const result = await indexer.indexBranchIfMissing(
+      "default",
+      "a".repeat(40),
+      undefined,
+      { onProviderError },
+    );
+
+    expect(result.prepared).toBe(true);
+    expect(result.stats?.failedChunks).toBeGreaterThan(0);
+    expect(onProviderError).toHaveBeenCalledWith(expect.any(ProviderRequestError));
   });
 
   it("drops excluded files from incremental retries of stale failed batches", async () => {
@@ -996,7 +1014,7 @@ describe("indexer failed batch recovery", () => {
     expect(persistedBatches).toHaveLength(1);
     expect(persistedBatches[0]?.chunks[0]?.id).toBeDefined();
     expect(persistedBatches[0]?.attemptCount).toBeGreaterThan(1);
-    expect(persistedBatches[0]?.error).toContain("persistent split failure");
+    expect(persistedBatches[0]?.error).toBe("Ollama embedding provider returned HTTP 500.");
   });
 
   it("isolates a permanently-failing chunk from healthy chunks on the recovery run (batched ollama)", async () => {
@@ -1148,7 +1166,7 @@ describe("indexer failed batch recovery", () => {
 
       expect(persistedBatches).toHaveLength(1);
       expect(persistedBatches[0]?.attemptCount).toBe(2);
-      expect(persistedBatches[0]?.error).toContain("transient batch failure");
+      expect(persistedBatches[0]?.error).toBe("Custom embedding provider returned HTTP 500.");
     } finally {
       addBatchSpy.mockRestore();
     }
@@ -1278,7 +1296,7 @@ describe("indexer failed batch recovery", () => {
 
     expect(persistedBatches).toHaveLength(1);
     expect(persistedBatches[0]?.chunks).toHaveLength(2);
-    expect(persistedBatches[0]?.error).toContain("shared batch failure");
+    expect(persistedBatches[0]?.error).toBe("Custom embedding provider returned HTTP 500.");
     expect(persistedBatches[0]?.attemptCount).toBe(1);
 
     const status = await indexer.getStatus();
@@ -1370,7 +1388,7 @@ describe("indexer failed batch recovery", () => {
     expect(status.failedBatchesCount).toBe(1);
     expect(persistedBatches).toHaveLength(1);
     expect(persistedBatches[0]?.chunks).toHaveLength(2);
-    expect(persistedBatches[0]?.error).toContain("shared retry failure");
+    expect(persistedBatches[0]?.error).toBe("Custom embedding provider returned HTTP 500.");
   });
 
   it("preserves foreign legacy failed batches without rewriting them during global scoped saves", async () => {
@@ -1613,7 +1631,7 @@ describe("indexer failed batch recovery", () => {
       error: string;
     }>;
     expect(persistedBatches[0]?.attemptCount).toBe(2);
-    expect(persistedBatches[0]?.error).toContain("invalid api key");
+    expect(persistedBatches[0]?.error).toBe("Custom embedding provider returned HTTP 401.");
   });
 
   it("clears pending global force re-embed metadata after retryFailedBatches() recovers all remaining chunks", async () => {

--- a/tests/indexing-transaction.test.ts
+++ b/tests/indexing-transaction.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { parseConfig } from "../src/config/schema.js";
 import { Indexer } from "../src/indexer/index.js";
 import { Database } from "../src/native/index.js";
+import { OperationCancelledError } from "../src/utils/operation-control.js";
 
 describe("indexing database transaction", () => {
   let projectDir: string;
@@ -155,6 +156,77 @@ describe("indexing database transaction", () => {
       expect(fs.readdirSync(indexDir).some((entry) => (
         entry.startsWith(".failed-batches.json.") && entry.endsWith(".tmp")
       ))).toBe(false);
+    } finally {
+      after.close();
+    }
+  });
+
+  it("rolls back and releases the lease when indexing is cancelled during embedding", async () => {
+    fs.writeFileSync(
+      path.join(projectDir, "src", "stable.ts"),
+      "export function stable() { return 'stable'; }\n",
+      "utf8",
+    );
+    await indexer.index();
+
+    const databasePath = path.join(indexDir, "codebase.db");
+    const fileHashesPath = path.join(indexDir, "file-hashes.json");
+    const before = Database.openReadOnly(databasePath);
+    const beforeStats = before.getStats();
+    const beforeBranches = before.getAllBranches().map((branch) => ({
+      branch,
+      chunks: before.getBranchChunkIds(branch),
+      symbols: before.getBranchSymbolIds(branch),
+    }));
+    before.close();
+    const previousFileHashes = fs.readFileSync(fileHashesPath, "utf8");
+
+    fs.writeFileSync(
+      path.join(projectDir, "src", "cancelled.ts"),
+      "export function cancelled() { return 'cancelled'; }\n",
+      "utf8",
+    );
+    let providerSignal: AbortSignal | undefined;
+    let markEmbeddingStarted: (() => void) | undefined;
+    const embeddingStarted = new Promise<void>((resolve) => {
+      markEmbeddingStarted = resolve;
+    });
+    fetchSpy.mockImplementationOnce(async (_url, init) => {
+      providerSignal = init?.signal ?? undefined;
+      markEmbeddingStarted?.();
+      return new Promise<Response>((_resolve, reject) => {
+        if (!providerSignal) {
+          reject(new Error("Expected an embedding request signal."));
+          return;
+        }
+        const rejectCancellation = (): void => reject(providerSignal?.reason ?? new Error("cancelled"));
+        if (providerSignal.aborted) rejectCancellation();
+        else providerSignal.addEventListener("abort", rejectCancellation, { once: true });
+      });
+    });
+
+    const controller = new AbortController();
+    const operation = indexer.index(undefined, { signal: controller.signal });
+    await embeddingStarted;
+    controller.abort();
+
+    await expect(operation).rejects.toBeInstanceOf(OperationCancelledError);
+    expect(providerSignal?.aborted).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    const after = Database.openReadOnly(databasePath);
+    try {
+      expect(after.getStats()).toEqual(beforeStats);
+      expect(after.getChunksByFile(path.join(projectDir, "src", "cancelled.ts"))).toEqual([]);
+      expect(after.getSymbolsByFile(path.join(projectDir, "src", "cancelled.ts"))).toEqual([]);
+      expect(after.getAllBranches().map((branch) => ({
+        branch,
+        chunks: after.getBranchChunkIds(branch),
+        symbols: after.getBranchSymbolIds(branch),
+      }))).toEqual(beforeBranches);
+      expect(fs.readFileSync(fileHashesPath, "utf8")).toBe(previousFileHashes);
+      expect(fs.existsSync(path.join(indexDir, "indexing.lock"))).toBe(false);
+      expect(fs.readdirSync(indexDir).filter((entry) => entry.includes(".tmp."))).toEqual([]);
     } finally {
       after.close();
     }

--- a/tests/mcp-cli-lifecycle.test.ts
+++ b/tests/mcp-cli-lifecycle.test.ts
@@ -14,6 +14,7 @@ const lifecycleMocks = vi.hoisted(() => ({
     }
   },
   createMcpServer: vi.fn(),
+  markMcpServerOrderedShutdown: vi.fn(),
   attachMcpBackgroundWatcher: vi.fn(),
   createWatcherWithIndexer: vi.fn(),
   isHomeDirectory: vi.fn(() => false),
@@ -24,6 +25,7 @@ const lifecycleMocks = vi.hoisted(() => ({
 vi.mock("../src/mcp-server.js", () => ({
   createMcpServer: lifecycleMocks.createMcpServer,
   attachMcpBackgroundWatcher: lifecycleMocks.attachMcpBackgroundWatcher,
+  markMcpServerOrderedShutdown: lifecycleMocks.markMcpServerOrderedShutdown,
 }));
 
 vi.mock("../src/utils/auto-index.js", () => ({
@@ -84,6 +86,10 @@ describe("MCP CLI shutdown lifecycle", () => {
     );
 
     lifecycleMocks.createMcpServer.mockReset();
+    lifecycleMocks.markMcpServerOrderedShutdown.mockReset();
+    lifecycleMocks.markMcpServerOrderedShutdown.mockImplementation(async () => {
+      events.push("diagnostics.mark");
+    });
     lifecycleMocks.attachMcpBackgroundWatcher.mockReset();
     lifecycleMocks.createWatcherWithIndexer.mockReset();
     lifecycleMocks.stopBackgroundWorker.mockReset();
@@ -179,7 +185,7 @@ describe("MCP CLI shutdown lifecycle", () => {
 
     stopGate.resolve();
     await expectSuccessfulShutdown();
-    expect(events).toEqual(["watcher.stop", "backgroundWorker.stop", "server.close", "exit:0"]);
+    expect(events).toEqual(["diagnostics.mark", "watcher.stop", "backgroundWorker.stop", "server.close", "exit:0"]);
   });
 
   it("runs teardown when stdin closes without an end event", async () => {
@@ -188,7 +194,7 @@ describe("MCP CLI shutdown lifecycle", () => {
     process.stdin.emit("close");
 
     await expectSuccessfulShutdown();
-    expect(events).toEqual(["watcher.stop", "backgroundWorker.stop", "server.close", "exit:0"]);
+    expect(events).toEqual(["diagnostics.mark", "watcher.stop", "backgroundWorker.stop", "server.close", "exit:0"]);
   });
 
   it("connects the transport before waiting for background watcher startup", async () => {
@@ -212,6 +218,54 @@ describe("MCP CLI shutdown lifecycle", () => {
     await expectSuccessfulShutdown();
   });
 
+  it("cleans up before rethrowing a transport startup failure", async () => {
+    const connectError = new Error("transport startup failed");
+    const baselineListeners = {
+      close: process.stdin.listenerCount("close"),
+      end: process.stdin.listenerCount("end"),
+      sigint: process.listenerCount("SIGINT"),
+    };
+    server.connect = vi.fn(async () => {
+      throw connectError;
+    });
+    lifecycleMocks.createMcpServer.mockReturnValue(server);
+
+    await expect(startCli()).rejects.toBe(connectError);
+
+    expect(lifecycleMocks.markMcpServerOrderedShutdown).toHaveBeenCalledOnce();
+    expect(lifecycleMocks.stopBackgroundWorker).toHaveBeenCalledOnce();
+    expect(server.close).toHaveBeenCalledOnce();
+    expect(lifecycleMocks.exit).not.toHaveBeenCalled();
+    expect(process.stdin.listenerCount("close")).toBe(baselineListeners.close);
+    expect(process.stdin.listenerCount("end")).toBe(baselineListeners.end);
+    expect(process.listenerCount("SIGINT")).toBe(baselineListeners.sigint);
+  });
+
+  it("cleans up an attached worker before rethrowing a watcher startup failure", async () => {
+    const watcherError = new Error("watcher startup failed");
+    const baselineListeners = {
+      close: process.stdin.listenerCount("close"),
+      end: process.stdin.listenerCount("end"),
+      sigint: process.listenerCount("SIGINT"),
+    };
+    lifecycleMocks.attachMcpBackgroundWatcher.mockImplementation(async (_project, _config, _host, factory) => {
+      watcherAttached = true;
+      factory?.();
+      throw watcherError;
+    });
+
+    await expect(startCli()).rejects.toBe(watcherError);
+
+    expect(lifecycleMocks.markMcpServerOrderedShutdown).toHaveBeenCalledOnce();
+    expect(watcher.stop).toHaveBeenCalledOnce();
+    expect(lifecycleMocks.stopBackgroundWorker).toHaveBeenCalledOnce();
+    expect(server.close).toHaveBeenCalledOnce();
+    expect(lifecycleMocks.exit).not.toHaveBeenCalled();
+    expect(process.stdin.listenerCount("close")).toBe(baselineListeners.close);
+    expect(process.stdin.listenerCount("end")).toBe(baselineListeners.end);
+    expect(process.listenerCount("SIGINT")).toBe(baselineListeners.sigint);
+  });
+
   it("still closes the server when watcher teardown fails", async () => {
     const stopError = new Error("watcher stop failed");
     watcher.stop = vi.fn(async () => {
@@ -229,7 +283,7 @@ describe("MCP CLI shutdown lifecycle", () => {
     });
     expect(server.close).toHaveBeenCalledOnce();
     expect(error).toHaveBeenCalledWith("Failed to stop MCP file watcher cleanly:", stopError);
-    expect(events).toEqual(["watcher.stop", "server.close", "exit:1"]);
+    expect(events).toEqual(["diagnostics.mark", "watcher.stop", "server.close", "exit:1"]);
   });
 
   it("still closes the server when background worker shutdown fails", async () => {
@@ -249,7 +303,7 @@ describe("MCP CLI shutdown lifecycle", () => {
     expect(lifecycleMocks.stopBackgroundWorker).toHaveBeenCalledOnce();
     expect(server.close).toHaveBeenCalledOnce();
     expect(error).toHaveBeenCalledWith("Failed to stop automatic indexing cleanly:", stopError);
-    expect(events).toEqual(["backgroundWorker.stop", "server.close", "exit:1"]);
+    expect(events).toEqual(["diagnostics.mark", "backgroundWorker.stop", "server.close", "exit:1"]);
   });
 
   it("handles SIGINT while MCP transport startup is still pending", async () => {
@@ -281,13 +335,31 @@ describe("MCP CLI shutdown lifecycle", () => {
     expect(server.close).toHaveBeenCalledOnce();
   });
 
+  it("does not exit on SIGINT until background indexing has released its worker lease", async () => {
+    const workerStopGate = createDeferred<void>();
+    lifecycleMocks.stopBackgroundWorker.mockImplementation(async () => {
+      events.push("backgroundWorker.stop");
+      await workerStopGate.promise;
+    });
+    await startCli();
+
+    process.emit("SIGINT");
+    await vi.waitFor(() => expect(lifecycleMocks.stopBackgroundWorker).toHaveBeenCalledOnce());
+    expect(server.close).not.toHaveBeenCalled();
+    expect(lifecycleMocks.exit).not.toHaveBeenCalled();
+
+    workerStopGate.resolve();
+    await vi.waitFor(() => expect(lifecycleMocks.exit).toHaveBeenCalledWith(0));
+    expect(server.close).toHaveBeenCalledOnce();
+  });
+
   it("runs teardown when the MCP server closes", async () => {
     await startCli();
 
     server.server.onclose?.();
 
     await expectSuccessfulShutdown();
-    expect(events).toEqual(["server.onclose", "watcher.stop", "backgroundWorker.stop", "server.close", "exit:0"]);
+    expect(events).toEqual(["server.onclose", "diagnostics.mark", "watcher.stop", "backgroundWorker.stop", "server.close", "exit:0"]);
   });
 
   if (process.platform !== "win32") {
@@ -297,7 +369,7 @@ describe("MCP CLI shutdown lifecycle", () => {
       process.emit(signal);
 
       await expectSuccessfulShutdown();
-      expect(events).toEqual(["watcher.stop", "backgroundWorker.stop", "server.close", "exit:0"]);
+      expect(events).toEqual(["diagnostics.mark", "watcher.stop", "backgroundWorker.stop", "server.close", "exit:0"]);
     });
   }
 

--- a/tests/mcp-knowledge-bases.test.ts
+++ b/tests/mcp-knowledge-bases.test.ts
@@ -184,7 +184,7 @@ describe("MCP knowledge-base tools", () => {
     }
   });
 
-  it("surfaces a missing path as isError with no config write and no indexer refresh", async () => {
+  it("returns a redacted structured error for a missing path without writing config or refreshing", async () => {
     const { client, configPath, close } = await bootstrap("claude");
     try {
       const baselineInstances = indexerInstances.length;
@@ -195,9 +195,17 @@ describe("MCP knowledge-base tools", () => {
         arguments: { path: missingPath },
       });
 
-      const content = result.content as Array<{ type: string; text?: string }>;
       expect(result.isError).toBe(true);
-      expect(content[0].text).toContain("Error: Directory does not exist");
+      expect(result.structuredContent).toMatchObject({
+        error: {
+          schemaVersion: 1,
+          code: "INTERNAL_ERROR",
+          operation: "add_knowledge_base",
+          retryable: false,
+        },
+      });
+      expect(JSON.stringify(result)).not.toContain(missingPath);
+      expect(JSON.stringify(result)).not.toContain("Directory does not exist");
       expect(fs.existsSync(configPath)).toBe(false);
       expect(indexerInstances.length).toBe(baselineInstances);
     } finally {

--- a/tests/mcp-operation-execution.test.ts
+++ b/tests/mcp-operation-execution.test.ts
@@ -616,6 +616,74 @@ describe("MCP operation execution", () => {
     expect(index).toHaveBeenCalledOnce();
   });
 
+  it("keeps a retrieval alive while its freshness preflight reports heartbeats", async () => {
+    const config = parseConfig({
+      mcp: { stallTimeoutMs: 1000 },
+      indexing: {
+        autoIndex: true,
+        autoIndexWaitMs: 2500,
+        requireProjectMarker: false,
+      },
+    });
+    configCache.set(getIndexerCacheKey(projectRoot, "jcode"), config);
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    let markPreflightStarted: (() => void) | undefined;
+    let markFirstHeartbeat: (() => void) | undefined;
+    let markSecondHeartbeat: (() => void) | undefined;
+    const preflightStarted = new Promise<void>((resolve) => {
+      markPreflightStarted = resolve;
+    });
+    const firstHeartbeat = new Promise<void>((resolve) => {
+      markFirstHeartbeat = resolve;
+    });
+    const secondHeartbeat = new Promise<void>((resolve) => {
+      markSecondHeartbeat = resolve;
+    });
+    const index = vi.fn(async () => {
+      throw new Error("Freshness should have avoided indexing.");
+    });
+    const getIndexFreshness = vi.fn(async (
+      options?: Parameters<Indexer["getIndexFreshness"]>[0],
+    ) => {
+      await options?.setPhase?.("scanning");
+      markPreflightStarted?.();
+      return new Promise<Awaited<ReturnType<Indexer["getIndexFreshness"]>>>((resolve) => {
+        setTimeout(() => {
+          void Promise.resolve(options?.heartbeat?.()).then(() => markFirstHeartbeat?.());
+        }, 700);
+        setTimeout(() => {
+          void Promise.resolve(options?.heartbeat?.()).then(() => markSecondHeartbeat?.());
+        }, 1400);
+        setTimeout(() => resolve({ readable: true, current: true, reason: "current" }), 1800);
+      });
+    });
+    configureAutoIndex(projectRoot, "jcode", config, () => ({
+      forceIndex: index,
+      getIndexFreshness,
+      getStatus: vi.fn(),
+      index,
+    }));
+
+    const operation = executeMcpOperation(runtime, "codebase_context", createExtra(), async (control) => {
+      await control.setPhase?.("waiting_for_index");
+      const result = await waitForAutoIndexForRetrieval(projectRoot, "jcode", control);
+      return success(result.ready ? "ready" : "not ready");
+    });
+    await preflightStarted;
+
+    await vi.advanceTimersByTimeAsync(700);
+    await firstHeartbeat;
+    await vi.advanceTimersByTimeAsync(700);
+    await secondHeartbeat;
+    await vi.advanceTimersByTimeAsync(400);
+
+    await expect(operation).resolves.toMatchObject({
+      content: [{ type: "text", text: "ready" }],
+    });
+    expect(getIndexFreshness).toHaveBeenCalledOnce();
+    expect(index).not.toHaveBeenCalled();
+  });
+
   it("preserves client cancellation when diagnostic completion does not settle", async () => {
     configCache.set(
       getIndexerCacheKey(projectRoot, "jcode"),

--- a/tests/mcp-operation-execution.test.ts
+++ b/tests/mcp-operation-execution.test.ts
@@ -1,0 +1,1008 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import type { ServerNotification } from "@modelcontextprotocol/sdk/types.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { parseConfig } from "../src/config/schema.js";
+import { createCustomProviderInfo } from "../src/embeddings/detector.js";
+import { createEmbeddingProvider } from "../src/embeddings/provider.js";
+import type { Indexer, IndexProgress, IndexStats } from "../src/indexer/index.js";
+import {
+  executeMcpOperation,
+  type McpOperationExtra,
+} from "../src/adapters/mcp/operation-execution.js";
+import { McpRuntimeDiagnostics } from "../src/adapters/mcp/runtime-diagnostics.js";
+import type { McpServerRuntime } from "../src/adapters/mcp/shared.js";
+import {
+  configureAutoIndex,
+  resetAutoIndexCoordinatorsForTests,
+  waitForAutoIndexForRetrieval,
+} from "../src/utils/auto-index.js";
+import {
+  configCache,
+  getIndexerCacheKey,
+} from "../src/tools/operation-runtime.js";
+import {
+  OperationCancelledError,
+  ProviderRequestError,
+} from "../src/utils/operation-control.js";
+
+function success(text = "ok") {
+  return { content: [{ type: "text" as const, text }] };
+}
+
+function createExtra(options: {
+  controller?: AbortController;
+  progressToken?: string | number;
+  sendNotification?: (notification: ServerNotification) => Promise<void>;
+} = {}): McpOperationExtra {
+  const controller = options.controller ?? new AbortController();
+  return {
+    signal: controller.signal,
+    requestId: 1,
+    ...(options.progressToken !== undefined
+      ? { _meta: { progressToken: options.progressToken } }
+      : {}),
+    sendNotification: options.sendNotification ?? (async () => undefined),
+    sendRequest: async () => {
+      throw new Error("Unexpected MCP request from test handler.");
+    },
+  } as unknown as McpOperationExtra;
+}
+
+describe("MCP operation execution", () => {
+  let projectRoot: string;
+  let runtime: McpServerRuntime;
+
+  beforeEach(() => {
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-operation-"));
+    configCache.set(getIndexerCacheKey(projectRoot, "jcode"), parseConfig({}));
+    runtime = {
+      projectRoot,
+      host: "jcode",
+      diagnostics: new McpRuntimeDiagnostics(path.join(projectRoot, ".codebase-index", "index")),
+    };
+  });
+
+  afterEach(async () => {
+    await resetAutoIndexCoordinatorsForTests();
+    vi.useRealTimers();
+    configCache.delete(getIndexerCacheKey(projectRoot, "jcode"));
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it("returns a redacted structured internal error", async () => {
+    const result = await executeMcpOperation(runtime, "codebase_search", createExtra(), async () => {
+      throw new Error("secret=abc query=user-input path=/private/work URL=https://provider.invalid/body");
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent).toMatchObject({
+      error: {
+        schemaVersion: 1,
+        code: "INTERNAL_ERROR",
+        operation: "codebase_search",
+        retryable: false,
+      },
+    });
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("secret=abc");
+    expect(serialized).not.toContain("user-input");
+    expect(serialized).not.toContain("/private/work");
+    expect(serialized).not.toContain("provider.invalid");
+  });
+
+  it("keeps diagnostics initialization failures inside the structured error boundary", async () => {
+    const failingRuntime = {
+      ...runtime,
+      diagnostics: {
+        begin: async () => {
+          throw new Error(`private runtime path: ${projectRoot}`);
+        },
+      },
+    } as unknown as McpServerRuntime;
+
+    const result = await executeMcpOperation(
+      failingRuntime,
+      "codebase_search",
+      createExtra(),
+      async () => success(),
+    );
+
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: { error: { code: "INTERNAL_ERROR", phase: "starting" } },
+    });
+    expect(JSON.stringify(result)).not.toContain(projectRoot);
+  });
+
+  it("classifies aggregate interruption from diagnostics initialization", async () => {
+    const failingRuntime = {
+      ...runtime,
+      diagnostics: {
+        begin: async () => {
+          throw new AggregateError([
+            new Error("private diagnostics path=/private/runtime"),
+            new OperationCancelledError(),
+          ]);
+        },
+      },
+    } as unknown as McpServerRuntime;
+
+    const result = await executeMcpOperation(
+      failingRuntime,
+      "codebase_search",
+      createExtra(),
+      async () => success(),
+    );
+
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: { error: { code: "OPERATION_CANCELLED", phase: "starting" } },
+    });
+    expect(JSON.stringify(result)).not.toContain("/private/runtime");
+  });
+
+  it("honors client cancellation while diagnostics initialization is pending", async () => {
+    const controller = new AbortController();
+    const pendingRuntime = {
+      ...runtime,
+      diagnostics: {
+        begin: async () => new Promise(() => undefined),
+      },
+    } as unknown as McpServerRuntime;
+    const operation = executeMcpOperation(
+      pendingRuntime,
+      "codebase_search",
+      createExtra({ controller }),
+      async () => success(),
+    );
+
+    controller.abort();
+    await expect(operation).resolves.toMatchObject({
+      isError: true,
+      structuredContent: { error: { code: "OPERATION_CANCELLED", phase: "starting" } },
+    });
+  });
+
+  it("times out while diagnostics initialization is pending", async () => {
+    configCache.set(
+      getIndexerCacheKey(projectRoot, "jcode"),
+      parseConfig({ mcp: { stallTimeoutMs: 1000 } }),
+    );
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    const pendingRuntime = {
+      ...runtime,
+      diagnostics: {
+        begin: async () => new Promise(() => undefined),
+      },
+    } as unknown as McpServerRuntime;
+    const operation = executeMcpOperation(
+      pendingRuntime,
+      "codebase_search",
+      createExtra(),
+      async () => success(),
+    );
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await expect(operation).resolves.toMatchObject({
+      isError: true,
+      structuredContent: { error: { code: "OPERATION_TIMEOUT", phase: "starting" } },
+    });
+  });
+
+  it("handles a synchronous late diagnostic cleanup failure after cancellation", async () => {
+    const controller = new AbortController();
+    let resolveBegin: ((value: { complete: () => Promise<void> }) => void) | undefined;
+    const pendingRuntime = {
+      ...runtime,
+      diagnostics: {
+        begin: async () => new Promise<{ complete: () => Promise<void> }>((resolve) => {
+          resolveBegin = resolve;
+        }),
+      },
+    } as unknown as McpServerRuntime;
+    const operation = executeMcpOperation(
+      pendingRuntime,
+      "codebase_search",
+      createExtra({ controller }),
+      async () => success(),
+    );
+
+    controller.abort();
+    await expect(operation).resolves.toMatchObject({
+      isError: true,
+      structuredContent: { error: { code: "OPERATION_CANCELLED", phase: "starting" } },
+    });
+    resolveBegin?.({
+      complete: (() => {
+        throw new Error("late private cleanup failure");
+      }) as unknown as () => Promise<void>,
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+  });
+
+  it.each([
+    [{ statusCode: 429 }, true],
+    [{ statusCode: 500 }, true],
+    [{ timedOut: true }, true],
+    [{ statusCode: 400 }, false],
+  ] as const)("classifies provider failures with retryability %s", async (options, retryable) => {
+    const result = await executeMcpOperation(runtime, "codebase_search", createExtra(), async () => {
+      throw new ProviderRequestError(options);
+    });
+    expect(result.structuredContent).toMatchObject({
+      error: { code: "PROVIDER_ERROR", retryable },
+    });
+  });
+
+  it("classifies client cancellation without exposing the abort reason", async () => {
+    const controller = new AbortController();
+    const operation = executeMcpOperation(
+      runtime,
+      "index_codebase",
+      createExtra({ controller }),
+      async () => new Promise(() => undefined),
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    controller.abort(new Error("private cancellation reason"));
+
+    const result = await operation;
+    expect(result.structuredContent).toMatchObject({
+      error: { code: "OPERATION_CANCELLED", retryable: true },
+    });
+    expect(JSON.stringify(result)).not.toContain("private cancellation reason");
+  });
+
+  it("classifies nested aggregate cancellation without exposing cleanup failures", async () => {
+    const result = await executeMcpOperation(runtime, "pr_impact", createExtra(), async () => {
+      throw new AggregateError([
+        new Error("cleanup path=/private/work secret=abc"),
+        new AggregateError([
+          new Error("provider URL=https://provider.invalid/body"),
+          new OperationCancelledError(),
+        ]),
+      ]);
+    });
+
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: {
+        error: { code: "OPERATION_CANCELLED", operation: "pr_impact", retryable: true },
+      },
+    });
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("/private/work");
+    expect(serialized).not.toContain("secret=abc");
+    expect(serialized).not.toContain("provider.invalid");
+  });
+
+  it("defers diagnostic completion until cooperative cleanup settles after cancellation", async () => {
+    const controller = new AbortController();
+    let releaseCleanup: (() => void) | undefined;
+    let diagnosticsCompleted = false;
+    const cleanupRuntime = {
+      ...runtime,
+      diagnostics: {
+        begin: async () => ({
+          id: "cleanup-operation",
+          setPhase: async () => undefined,
+          heartbeat: async () => undefined,
+          complete: async () => {
+            diagnosticsCompleted = true;
+          },
+        }),
+      },
+    } as unknown as McpServerRuntime;
+    const operation = executeMcpOperation(
+      cleanupRuntime,
+      "pr_impact",
+      createExtra({ controller }),
+      async (control) => {
+        await new Promise<void>((resolve) => {
+          control.signal?.addEventListener("abort", () => {
+            releaseCleanup = resolve;
+          }, { once: true });
+        });
+        return success();
+      },
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+    controller.abort();
+    await vi.waitFor(() => expect(releaseCleanup).toBeTypeOf("function"));
+    expect(diagnosticsCompleted).toBe(false);
+
+    await expect(operation).resolves.toMatchObject({
+      isError: true,
+      structuredContent: { error: { code: "OPERATION_CANCELLED" } },
+    });
+    expect(diagnosticsCompleted).toBe(false);
+    releaseCleanup?.();
+    await vi.waitFor(() => expect(diagnosticsCompleted).toBe(true));
+    expect(diagnosticsCompleted).toBe(true);
+  });
+
+  it("keeps diagnostics active beyond the old settlement timeout until the handler settles", async () => {
+    configCache.set(
+      getIndexerCacheKey(projectRoot, "jcode"),
+      parseConfig({ mcp: { stallTimeoutMs: 1000 } }),
+    );
+    const originalBegin = runtime.diagnostics.begin.bind(runtime.diagnostics);
+    const completeDiagnostic = vi.fn();
+    vi.spyOn(runtime.diagnostics, "begin").mockImplementation(async (operationName) => {
+      const tracked = await originalBegin(operationName);
+      return {
+        ...tracked,
+        complete: async () => {
+          completeDiagnostic();
+          await tracked.complete();
+        },
+      };
+    });
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    let rejectHandler: ((error: Error) => void) | undefined;
+    let markHandlerStarted: (() => void) | undefined;
+    const handlerStarted = new Promise<void>((resolve) => {
+      markHandlerStarted = resolve;
+    });
+    const operation = executeMcpOperation(runtime, "index_codebase", createExtra(), async (control) => {
+      await control.setPhase?.("embedding");
+      return new Promise((_resolve, reject) => {
+        rejectHandler = reject;
+        markHandlerStarted?.();
+      });
+    });
+
+    await handlerStarted;
+    await vi.advanceTimersByTimeAsync(6000);
+    await expect(operation).resolves.toMatchObject({
+      isError: true,
+      structuredContent: { error: { code: "OPERATION_TIMEOUT" } },
+    });
+    await expect(runtime.diagnostics.snapshot(undefined, 1000)).resolves.toMatchObject({
+      activeOperations: [{ operation: "index_codebase", phase: "embedding", status: "suspected_stall" }],
+    });
+
+    rejectHandler?.(new Error("late private failure"));
+    await vi.runAllTimersAsync();
+    await expect(runtime.diagnostics.snapshot(undefined, 1000)).resolves.toMatchObject({ activeOperations: [] });
+    expect(completeDiagnostic).toHaveBeenCalledOnce();
+  });
+
+  it("does not invoke the handler or emit progress for a pre-cancelled request", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("private pre-cancel reason"));
+    const sendNotification = vi.fn(async () => undefined);
+    const handler = vi.fn(async () => success());
+
+    const result = await executeMcpOperation(
+      runtime,
+      "index_codebase",
+      createExtra({ controller, progressToken: "unused", sendNotification }),
+      handler,
+    );
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(sendNotification).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: { error: { code: "OPERATION_CANCELLED" } },
+    });
+  });
+
+  it("uses the real five-minute default and rearms it on heartbeat", async () => {
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    let markHandlerStarted: (() => void) | undefined;
+    const handlerStarted = new Promise<void>((resolve) => {
+      markHandlerStarted = resolve;
+    });
+    const operation = executeMcpOperation(runtime, "index_codebase", createExtra(), async (control) => {
+      markHandlerStarted?.();
+      setTimeout(() => {
+        void control.heartbeat?.();
+      }, 250_000);
+      return new Promise((resolve) => {
+        setTimeout(() => resolve(success()), 500_000);
+      });
+    });
+    await handlerStarted;
+
+    await vi.advanceTimersByTimeAsync(500_000);
+    expect((await operation).isError).not.toBe(true);
+  });
+
+  it("returns OPERATION_TIMEOUT after the configured inactivity period", async () => {
+    configCache.set(
+      getIndexerCacheKey(projectRoot, "jcode"),
+      parseConfig({ mcp: { stallTimeoutMs: 1000 } }),
+    );
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    let markHandlerStarted: (() => void) | undefined;
+    const handlerStarted = new Promise<void>((resolve) => {
+      markHandlerStarted = resolve;
+    });
+    const operation = executeMcpOperation(
+      runtime,
+      "index_codebase",
+      createExtra(),
+      async () => {
+        markHandlerStarted?.();
+        return new Promise(() => undefined);
+      },
+    );
+    await handlerStarted;
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await expect(operation).resolves.toMatchObject({
+      isError: true,
+      structuredContent: {
+        error: { code: "OPERATION_TIMEOUT", phase: "starting", retryable: true },
+      },
+    });
+  });
+
+  it("times out an opaque provider wait before the provider deadline and aborts the provider request", async () => {
+    configCache.set(
+      getIndexerCacheKey(projectRoot, "jcode"),
+      parseConfig({ mcp: { stallTimeoutMs: 1000 } }),
+    );
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    const provider = createEmbeddingProvider(createCustomProviderInfo({
+      baseUrl: "http://localhost:11434/v1",
+      model: "opaque-provider",
+      dimensions: 8,
+      timeoutMs: 5000,
+    }));
+    let requestSignal: AbortSignal | undefined;
+    let markProviderStarted: (() => void) | undefined;
+    const providerStarted = new Promise<void>((resolve) => {
+      markProviderStarted = resolve;
+    });
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+      requestSignal = init?.signal ?? undefined;
+      markProviderStarted?.();
+      return new Promise((_resolve, reject) => {
+        const signal = init?.signal;
+        if (signal?.aborted) {
+          reject(signal.reason);
+          return;
+        }
+        signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+      });
+    });
+
+    try {
+      const operation = executeMcpOperation(runtime, "index_codebase", createExtra(), async (control) => {
+        await provider.embedQuery("opaque request", control);
+        return success();
+      });
+      await providerStarted;
+
+      await vi.advanceTimersByTimeAsync(1000);
+      await expect(operation).resolves.toMatchObject({
+        isError: true,
+        structuredContent: {
+          error: { code: "OPERATION_TIMEOUT", phase: "embedding", retryable: true },
+        },
+      });
+      expect(requestSignal?.aborted).toBe(true);
+      await expect(runtime.diagnostics.snapshot(undefined, 1000)).resolves.toMatchObject({
+        activeOperations: [],
+      });
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("keeps a retrieval alive while its shared index reports real progress", async () => {
+    const config = parseConfig({
+      mcp: { stallTimeoutMs: 1000 },
+      indexing: {
+        autoIndex: true,
+        autoIndexWaitMs: 2500,
+        requireProjectMarker: false,
+      },
+    });
+    configCache.set(getIndexerCacheKey(projectRoot, "jcode"), config);
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    const originalBegin = runtime.diagnostics.begin.bind(runtime.diagnostics);
+    let markEmbeddingForwarded: (() => void) | undefined;
+    let markEmbeddingProgressForwarded: (() => void) | undefined;
+    let markStoringForwarded: (() => void) | undefined;
+    const embeddingForwarded = new Promise<void>((resolve) => {
+      markEmbeddingForwarded = resolve;
+    });
+    const embeddingProgressForwarded = new Promise<void>((resolve) => {
+      markEmbeddingProgressForwarded = resolve;
+    });
+    const storingForwarded = new Promise<void>((resolve) => {
+      markStoringForwarded = resolve;
+    });
+    vi.spyOn(runtime.diagnostics, "begin").mockImplementation(async (operationName) => {
+      const tracked = await originalBegin(operationName);
+      return {
+        ...tracked,
+        setPhase: async (phase) => {
+          await tracked.setPhase(phase);
+          if (phase === "embedding") markEmbeddingForwarded?.();
+          if (phase === "storing") markStoringForwarded?.();
+        },
+        heartbeat: async () => {
+          await tracked.heartbeat();
+          markEmbeddingProgressForwarded?.();
+        },
+      };
+    });
+    let indexed = false;
+    let markIndexStarted: (() => void) | undefined;
+    const indexStarted = new Promise<void>((resolve) => {
+      markIndexStarted = resolve;
+    });
+    const stats: IndexStats = {
+      totalFiles: 1,
+      totalChunks: 2,
+      indexedChunks: 2,
+      failedChunks: 0,
+      tokensUsed: 2,
+      durationMs: 1800,
+      existingChunks: 0,
+      removedChunks: 0,
+      skippedFiles: [],
+      parseFailures: [],
+    };
+    const index = vi.fn(async (
+      onProgress?: (progress: IndexProgress) => void,
+      options?: Parameters<Indexer["index"]>[1],
+    ) => {
+      await options?.setPhase?.("embedding");
+      markIndexStarted?.();
+      return new Promise<IndexStats>((resolve) => {
+        setTimeout(() => onProgress?.({
+          phase: "embedding",
+          filesProcessed: 1,
+          totalFiles: 1,
+          chunksProcessed: 1,
+          totalChunks: 2,
+        }), 700);
+        setTimeout(() => onProgress?.({
+          phase: "storing",
+          filesProcessed: 1,
+          totalFiles: 1,
+          chunksProcessed: 2,
+          totalChunks: 2,
+        }), 1400);
+        setTimeout(() => {
+          indexed = true;
+          resolve(stats);
+        }, 1800);
+      });
+    });
+    const indexer = {
+      forceIndex: index,
+      getStatus: vi.fn(async () => ({
+        indexed,
+        vectorCount: indexed ? 2 : 0,
+        provider: "custom",
+        model: "test",
+        indexPath: "/private/index/path",
+        currentBranch: "main",
+        baseBranch: "main",
+        compatibility: { compatible: true },
+        failedBatchesCount: 0,
+      })),
+      index,
+    };
+    configureAutoIndex(projectRoot, "jcode", config, () => indexer);
+
+    const operation = executeMcpOperation(runtime, "codebase_context", createExtra(), async (control) => {
+      await control.setPhase?.("waiting_for_index");
+      const result = await waitForAutoIndexForRetrieval(projectRoot, "jcode", control);
+      return success(result.ready ? "ready" : "not ready");
+    });
+    await indexStarted;
+    await embeddingForwarded;
+
+    await vi.advanceTimersByTimeAsync(700);
+    await embeddingProgressForwarded;
+    await vi.advanceTimersByTimeAsync(700);
+    await storingForwarded;
+    await vi.advanceTimersByTimeAsync(400);
+
+    await expect(operation).resolves.toMatchObject({
+      content: [{ type: "text", text: "ready" }],
+    });
+    expect(index).toHaveBeenCalledOnce();
+  });
+
+  it("preserves client cancellation when diagnostic completion does not settle", async () => {
+    configCache.set(
+      getIndexerCacheKey(projectRoot, "jcode"),
+      parseConfig({ mcp: { stallTimeoutMs: 1000 } }),
+    );
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    const controller = new AbortController();
+    const pendingRuntime = {
+      ...runtime,
+      diagnostics: {
+        begin: async () => ({
+          id: "pending-completion",
+          setPhase: async () => undefined,
+          heartbeat: async () => undefined,
+          complete: async () => new Promise<void>(() => undefined),
+        }),
+      },
+    } as unknown as McpServerRuntime;
+    const operation = executeMcpOperation(
+      pendingRuntime,
+      "index_codebase",
+      createExtra({ controller }),
+      async () => new Promise(() => undefined),
+    );
+    await Promise.resolve();
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    await expect(operation).resolves.toMatchObject({
+      isError: true,
+      structuredContent: { error: { code: "OPERATION_CANCELLED" } },
+    });
+  });
+
+  it("preserves an inactivity timeout when diagnostic completion does not settle", async () => {
+    configCache.set(
+      getIndexerCacheKey(projectRoot, "jcode"),
+      parseConfig({ mcp: { stallTimeoutMs: 1000 } }),
+    );
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    const pendingRuntime = {
+      ...runtime,
+      diagnostics: {
+        begin: async () => ({
+          id: "pending-completion",
+          setPhase: async () => undefined,
+          heartbeat: async () => undefined,
+          complete: async () => new Promise<void>(() => undefined),
+        }),
+      },
+    } as unknown as McpServerRuntime;
+    const operation = executeMcpOperation(
+      pendingRuntime,
+      "index_codebase",
+      createExtra(),
+      async () => new Promise(() => undefined),
+    );
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    await expect(operation).resolves.toMatchObject({
+      isError: true,
+      structuredContent: { error: { code: "OPERATION_TIMEOUT" } },
+    });
+  });
+
+  it("returns INTERNAL_ERROR when successful diagnostic completion throws synchronously", async () => {
+    const failingRuntime = {
+      ...runtime,
+      diagnostics: {
+        begin: async () => ({
+          id: "failing-completion",
+          setPhase: async () => undefined,
+          heartbeat: async () => undefined,
+          complete: (() => {
+            throw new Error("private completion failure");
+          }) as unknown as () => Promise<void>,
+        }),
+      },
+    } as unknown as McpServerRuntime;
+
+    const result = await executeMcpOperation(
+      failingRuntime,
+      "codebase_search",
+      createExtra(),
+      async () => success(),
+    );
+
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: { error: { code: "INTERNAL_ERROR" } },
+    });
+    expect(JSON.stringify(result)).not.toContain("private completion failure");
+  });
+
+  it("does not emit progress without a progress token", async () => {
+    const sendNotification = vi.fn(async () => undefined);
+    await executeMcpOperation(
+      runtime,
+      "index_codebase",
+      createExtra({ sendNotification }),
+      async (control) => {
+        await control.reportProgress?.(20, "embedding");
+        return success();
+      },
+    );
+    expect(sendNotification).not.toHaveBeenCalled();
+  });
+
+  it("reuses the exact token and serializes strictly increasing progress", async () => {
+    const notifications: ServerNotification[] = [];
+    let inFlight = false;
+    const sendNotification = vi.fn(async (notification: ServerNotification) => {
+      expect(inFlight).toBe(false);
+      inFlight = true;
+      await Promise.resolve();
+      notifications.push(notification);
+      inFlight = false;
+    });
+
+    const result = await executeMcpOperation(
+      runtime,
+      "index_codebase",
+      createExtra({ progressToken: "opaque-token", sendNotification }),
+      async (control) => {
+        await control.reportProgress?.(10, "scanning");
+        await control.reportProgress?.(10, "scanning");
+        await control.reportProgress?.(5, "scanning");
+        await control.reportProgress?.(50.8, "embedding");
+        await control.reportProgress?.(100, "complete");
+        return success();
+      },
+    );
+
+    expect(result.isError).not.toBe(true);
+    expect(notifications.map((notification) => notification.params)).toEqual([
+      { progressToken: "opaque-token", progress: 0, total: 100 },
+      { progressToken: "opaque-token", progress: 10, total: 100 },
+      { progressToken: "opaque-token", progress: 50, total: 100 },
+      { progressToken: "opaque-token", progress: 100, total: 100 },
+    ]);
+  });
+
+  it("rearms the inactivity deadline on duplicate raw progress without emitting a duplicate", async () => {
+    configCache.set(
+      getIndexerCacheKey(projectRoot, "jcode"),
+      parseConfig({ mcp: { stallTimeoutMs: 1000 } }),
+    );
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    const notifications: ServerNotification[] = [];
+    let markHandlerStarted: (() => void) | undefined;
+    const handlerStarted = new Promise<void>((resolve) => {
+      markHandlerStarted = resolve;
+    });
+
+    const operation = executeMcpOperation(
+      runtime,
+      "index_codebase",
+      createExtra({
+        progressToken: "duplicate-heartbeat",
+        sendNotification: async (notification) => {
+          notifications.push(notification);
+        },
+      }),
+      async (control) => {
+        markHandlerStarted?.();
+        setTimeout(() => {
+          void control.reportProgress?.(10, "embedding");
+        }, 600);
+        setTimeout(() => {
+          void control.reportProgress?.(10, "embedding");
+        }, 1200);
+        return new Promise((resolve) => {
+          setTimeout(() => resolve(success()), 1800);
+        });
+      },
+    );
+    await handlerStarted;
+
+    await vi.advanceTimersByTimeAsync(1800);
+    const result = await operation;
+    expect(result.isError).not.toBe(true);
+    expect(notifications.map((notification) => notification.params)).toEqual([
+      { progressToken: "duplicate-heartbeat", progress: 0, total: 100 },
+      { progressToken: "duplicate-heartbeat", progress: 10, total: 100 },
+      { progressToken: "duplicate-heartbeat", progress: 100, total: 100 },
+    ]);
+  });
+
+  it("turns progress delivery failure into a handled internal error", async () => {
+    const result = await executeMcpOperation(
+      runtime,
+      "index_codebase",
+      createExtra({
+        progressToken: 42,
+        sendNotification: async () => {
+          throw new Error("closed transport with private detail");
+        },
+      }),
+      async () => success(),
+    );
+
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: { error: { code: "INTERNAL_ERROR", retryable: false } },
+    });
+    expect(JSON.stringify(result)).not.toContain("private detail");
+  });
+
+  it("times out when initial progress delivery never settles", async () => {
+    configCache.set(
+      getIndexerCacheKey(projectRoot, "jcode"),
+      parseConfig({ mcp: { stallTimeoutMs: 1000 } }),
+    );
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    const handler = vi.fn(async () => success());
+    let markNotificationStarted: (() => void) | undefined;
+    const notificationStarted = new Promise<void>((resolve) => {
+      markNotificationStarted = resolve;
+    });
+    const operation = executeMcpOperation(
+      runtime,
+      "index_codebase",
+      createExtra({
+        progressToken: "blocked-initial",
+        sendNotification: async () => {
+          markNotificationStarted?.();
+          return new Promise(() => undefined);
+        },
+      }),
+      handler,
+    );
+
+    await notificationStarted;
+    await vi.advanceTimersByTimeAsync(1000);
+    await expect(operation).resolves.toMatchObject({
+      isError: true,
+      structuredContent: { error: { code: "OPERATION_TIMEOUT" } },
+    });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("does not start the handler after the initial progress notification fails", async () => {
+    const handler = vi.fn(async () => {
+      throw new Error("late private handler failure");
+    });
+    const result = await executeMcpOperation(
+      runtime,
+      "index_codebase",
+      createExtra({
+        progressToken: "token",
+        sendNotification: async () => {
+          throw new Error("initial progress failure");
+        },
+      }),
+      handler,
+    );
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: { error: { code: "INTERNAL_ERROR" } },
+    });
+  });
+
+  it("handles synchronous notification failures", async () => {
+    const result = await executeMcpOperation(
+      runtime,
+      "index_codebase",
+      createExtra({
+        progressToken: "token",
+        sendNotification: (() => {
+          throw new Error("synchronous private failure");
+        }) as unknown as (notification: ServerNotification) => Promise<void>,
+      }),
+      async () => success(),
+    );
+
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: { error: { code: "INTERNAL_ERROR" } },
+    });
+    expect(JSON.stringify(result)).not.toContain("synchronous private failure");
+  });
+
+  it("reports a final progress delivery failure instead of returning success", async () => {
+    let notificationCount = 0;
+    const result = await executeMcpOperation(
+      runtime,
+      "index_codebase",
+      createExtra({
+        progressToken: "token",
+        sendNotification: async () => {
+          notificationCount += 1;
+          if (notificationCount === 2) throw new Error("private final progress failure");
+        },
+      }),
+      async () => success(),
+    );
+
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: { error: { code: "INTERNAL_ERROR" } },
+    });
+    expect(JSON.stringify(result)).not.toContain("private final progress failure");
+  });
+
+  it("times out when final progress delivery never settles", async () => {
+    configCache.set(
+      getIndexerCacheKey(projectRoot, "jcode"),
+      parseConfig({ mcp: { stallTimeoutMs: 1000 } }),
+    );
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    let notificationCount = 0;
+    let markFinalNotificationStarted: (() => void) | undefined;
+    const finalNotificationStarted = new Promise<void>((resolve) => {
+      markFinalNotificationStarted = resolve;
+    });
+    const operation = executeMcpOperation(
+      runtime,
+      "index_codebase",
+      createExtra({
+        progressToken: "blocked-final",
+        sendNotification: async () => {
+          notificationCount += 1;
+          if (notificationCount > 1) {
+            markFinalNotificationStarted?.();
+            return new Promise(() => undefined);
+          }
+        },
+      }),
+      async () => success(),
+    );
+
+    await finalNotificationStarted;
+    await vi.advanceTimersByTimeAsync(1000);
+    await expect(operation).resolves.toMatchObject({
+      isError: true,
+      structuredContent: { error: { code: "OPERATION_TIMEOUT" } },
+    });
+  });
+
+  it("handles an ignored progress promise when notification delivery fails", async () => {
+    let notificationCount = 0;
+    const result = await executeMcpOperation(
+      runtime,
+      "index_codebase",
+      createExtra({
+        progressToken: "token",
+        sendNotification: async () => {
+          notificationCount += 1;
+          if (notificationCount > 1) throw new Error("private transport failure");
+        },
+      }),
+      async (control) => {
+        void control.reportProgress?.(20, "embedding");
+        return new Promise(() => undefined);
+      },
+    );
+
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: { error: { code: "INTERNAL_ERROR" } },
+    });
+    expect(JSON.stringify(result)).not.toContain("private transport failure");
+  });
+
+  it("adds diagnostics to index_status and excludes the current call", async () => {
+    let releaseOperation: (() => void) | undefined;
+    const active = executeMcpOperation(runtime, "index_codebase", createExtra(), async (control) => {
+      await control.setPhase?.("embedding");
+      return new Promise((resolve) => {
+        releaseOperation = () => resolve(success());
+      });
+    });
+    while (!releaseOperation) await new Promise((resolve) => setImmediate(resolve));
+
+    const status = await executeMcpOperation(runtime, "index_status", createExtra(), async () => success("ready"));
+    expect(status.structuredContent).toMatchObject({
+      mcpDiagnostics: {
+        schemaVersion: 1,
+        activeOperations: [{ operation: "index_codebase", phase: "embedding", status: "active" }],
+      },
+    });
+    expect(JSON.stringify(status.structuredContent)).not.toContain('"operation":"index_status"');
+
+    releaseOperation();
+    await active;
+  });
+});

--- a/tests/mcp-runtime-diagnostics.test.ts
+++ b/tests/mcp-runtime-diagnostics.test.ts
@@ -88,6 +88,65 @@ describe("MCP runtime diagnostics", () => {
     });
   });
 
+  it("rebinds later operations to the current root and marks every used root on shutdown", async () => {
+    const firstRoot = path.join(tempDir, "first-index");
+    const secondRoot = path.join(tempDir, "second-index");
+    let currentRoot = firstRoot;
+    const diagnostics = new McpRuntimeDiagnostics(() => currentRoot);
+    const first = await diagnostics.begin("index_codebase");
+    await first.setPhase("embedding");
+
+    currentRoot = secondRoot;
+    const second = await diagnostics.begin("codebase_context");
+    await second.setPhase("embedding_query");
+
+    await expect(new McpRuntimeDiagnostics(firstRoot).snapshot(undefined, 1000)).resolves.toMatchObject({
+      activeOperations: [{ operation: "index_codebase", phase: "embedding" }],
+    });
+    await expect(diagnostics.snapshot(first.id, 1000)).resolves.toMatchObject({
+      activeOperations: [{ operation: "codebase_context", phase: "embedding_query" }],
+    });
+
+    await diagnostics.markOrderedShutdown();
+
+    await expect(new McpRuntimeDiagnostics(firstRoot).snapshot(undefined, 1000)).resolves.toMatchObject({
+      activeOperations: [],
+      latestInterruptedOperation: {
+        operation: "index_codebase",
+        phase: "embedding",
+        cause: "ordered_shutdown",
+      },
+    });
+    await expect(new McpRuntimeDiagnostics(secondRoot).snapshot(undefined, 1000)).resolves.toMatchObject({
+      activeOperations: [],
+      latestInterruptedOperation: {
+        operation: "codebase_context",
+        phase: "embedding_query",
+        cause: "ordered_shutdown",
+      },
+    });
+  });
+
+  it("completes an in-flight operation in the root captured when it began", async () => {
+    const firstRoot = path.join(tempDir, "captured-index");
+    const secondRoot = path.join(tempDir, "current-index");
+    let currentRoot = firstRoot;
+    const diagnostics = new McpRuntimeDiagnostics(() => currentRoot);
+    const first = await diagnostics.begin("index_codebase");
+
+    currentRoot = secondRoot;
+    const second = await diagnostics.begin("codebase_context");
+    await first.complete();
+
+    await expect(new McpRuntimeDiagnostics(firstRoot).snapshot(undefined, 1000)).resolves.toMatchObject({
+      activeOperations: [],
+    });
+    await expect(diagnostics.snapshot(undefined, 1000)).resolves.toMatchObject({
+      activeOperations: [{ operation: "codebase_context" }],
+    });
+    await second.complete();
+  });
+
   it("infers interruption only when a local PID is confirmed absent", async () => {
     const runtimeDir = path.join(indexRoot, "mcp-runtime");
     fs.mkdirSync(runtimeDir, { recursive: true, mode: 0o700 });

--- a/tests/mcp-runtime-diagnostics.test.ts
+++ b/tests/mcp-runtime-diagnostics.test.ts
@@ -50,6 +50,31 @@ describe("MCP runtime diagnostics", () => {
     await operation.complete();
   });
 
+  it("keeps tracking calls non-fatal if diagnostics storage becomes unavailable", async () => {
+    const diagnostics = new McpRuntimeDiagnostics(indexRoot);
+    const operation = await diagnostics.begin("index_codebase");
+    const runtimeDir = path.join(indexRoot, "mcp-runtime");
+    const [recordName] = fs.readdirSync(runtimeDir);
+    expect(recordName).toBeDefined();
+    const recordPath = path.join(runtimeDir, recordName!);
+    const persistedActiveOperation = fs.readFileSync(recordPath, "utf8");
+    fs.rmSync(recordPath, { force: true });
+    fs.mkdirSync(recordPath);
+
+    await expect(operation.setPhase("embedding")).resolves.toBeUndefined();
+    await expect(operation.heartbeat()).resolves.toBeUndefined();
+    await expect(operation.complete()).resolves.toBeUndefined();
+
+    fs.rmSync(recordPath, { recursive: true, force: true });
+    fs.writeFileSync(recordPath, persistedActiveOperation);
+    await expect(diagnostics.snapshot(undefined, 1000)).resolves.toEqual({
+      schemaVersion: 1,
+      activeOperations: [],
+    });
+    expect(fs.readdirSync(runtimeDir)).toEqual([]);
+    await expect(diagnostics.markOrderedShutdown()).resolves.toBeUndefined();
+  });
+
   it("tracks concurrent operations and marks stale activity only as suspected", async () => {
     const diagnostics = new McpRuntimeDiagnostics(indexRoot);
     const first = await diagnostics.begin("codebase_context");

--- a/tests/mcp-runtime-diagnostics.test.ts
+++ b/tests/mcp-runtime-diagnostics.test.ts
@@ -1,0 +1,236 @@
+import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { McpRuntimeDiagnostics } from "../src/adapters/mcp/runtime-diagnostics.js";
+
+describe("MCP runtime diagnostics", () => {
+  let tempDir: string;
+  let indexRoot: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-diagnostics-"));
+    indexRoot = path.join(tempDir, "index");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("writes private atomic process state and removes normally completed operations", async () => {
+    const diagnostics = new McpRuntimeDiagnostics(indexRoot);
+    const operation = await diagnostics.begin("index_codebase");
+    const runtimeDir = path.join(indexRoot, "mcp-runtime");
+    const files = fs.readdirSync(runtimeDir);
+
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/^[a-f0-9]{16}-\d+-[a-f0-9]{32}\.json$/);
+    expect(fs.statSync(runtimeDir).mode & 0o777).toBe(0o700);
+    expect(fs.statSync(path.join(runtimeDir, files[0])).mode & 0o777).toBe(0o600);
+    expect(files.some((file) => file.endsWith(".tmp"))).toBe(false);
+
+    await operation.complete();
+    expect(fs.readdirSync(runtimeDir)).toEqual([]);
+    await expect(diagnostics.snapshot(undefined, 1000)).resolves.toEqual({
+      schemaVersion: 1,
+      activeOperations: [],
+    });
+  });
+
+  it("corrects permissions on an existing runtime directory", async () => {
+    const runtimeDir = path.join(indexRoot, "mcp-runtime");
+    fs.mkdirSync(runtimeDir, { recursive: true, mode: 0o755 });
+    fs.chmodSync(runtimeDir, 0o755);
+
+    const operation = await new McpRuntimeDiagnostics(indexRoot).begin("index_status");
+    expect(fs.statSync(runtimeDir).mode & 0o777).toBe(0o700);
+    await operation.complete();
+  });
+
+  it("tracks concurrent operations and marks stale activity only as suspected", async () => {
+    const diagnostics = new McpRuntimeDiagnostics(indexRoot);
+    const first = await diagnostics.begin("codebase_context");
+    const second = await diagnostics.begin("index_codebase");
+    await first.setPhase("embedding_query");
+    await second.setPhase("embedding");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    const snapshot = await diagnostics.snapshot(first.id, 1);
+    expect(snapshot.activeOperations).toEqual([
+      expect.objectContaining({
+        operation: "index_codebase",
+        phase: "embedding",
+        status: "suspected_stall",
+      }),
+    ]);
+    expect(snapshot.latestInterruptedOperation).toBeUndefined();
+
+    await first.complete();
+    await second.complete();
+  });
+
+  it("marks active calls interrupted during ordered shutdown", async () => {
+    const diagnostics = new McpRuntimeDiagnostics(indexRoot);
+    const operation = await diagnostics.begin("index_codebase");
+    await operation.setPhase("embedding");
+    await diagnostics.markOrderedShutdown();
+
+    const observer = new McpRuntimeDiagnostics(indexRoot);
+    const snapshot = await observer.snapshot(undefined, 1000);
+    expect(snapshot.activeOperations).toEqual([]);
+    expect(snapshot.latestInterruptedOperation).toMatchObject({
+      operation: "index_codebase",
+      phase: "embedding",
+      cause: "ordered_shutdown",
+    });
+  });
+
+  it("infers interruption only when a local PID is confirmed absent", async () => {
+    const runtimeDir = path.join(indexRoot, "mcp-runtime");
+    fs.mkdirSync(runtimeDir, { recursive: true, mode: 0o700 });
+    const hostnameHash = createHash("sha256").update(os.hostname()).digest("hex").slice(0, 16);
+    const startupToken = "a".repeat(32);
+    const startedAt = new Date(Date.now() - 2000).toISOString();
+    fs.writeFileSync(
+      path.join(runtimeDir, `${hostnameHash}-2147483647-${startupToken}.json`),
+      JSON.stringify({
+        schemaVersion: 1,
+        hostnameHash,
+        pid: 2147483647,
+        startupToken,
+        updatedAt: new Date().toISOString(),
+        activeOperations: [{
+          id: "operation-id",
+          sessionId: "session-id",
+          operation: "index_codebase",
+          phase: "embedding",
+          startedAt,
+          lastActivityAt: startedAt,
+        }],
+      }),
+      { mode: 0o600 },
+    );
+
+    const snapshot = await new McpRuntimeDiagnostics(indexRoot).snapshot(undefined, 1000);
+    expect(snapshot.activeOperations).toEqual([]);
+    expect(snapshot.latestInterruptedOperation).toMatchObject({
+      operation: "index_codebase",
+      phase: "embedding",
+      cause: "process_exit",
+    });
+  });
+
+  it("does not infer remote process death and purges records older than seven days", async () => {
+    const runtimeDir = path.join(indexRoot, "mcp-runtime");
+    fs.mkdirSync(runtimeDir, { recursive: true, mode: 0o700 });
+    const activeToken = "b".repeat(32);
+    const oldToken = "c".repeat(32);
+    const operation = {
+      id: "operation-id",
+      sessionId: "session-id",
+      operation: "codebase_context",
+      phase: "embedding_query",
+      startedAt: new Date().toISOString(),
+      lastActivityAt: new Date().toISOString(),
+    };
+    const remotePath = path.join(runtimeDir, `${"d".repeat(16)}-12345-${activeToken}.json`);
+    fs.writeFileSync(remotePath, JSON.stringify({
+      schemaVersion: 1,
+      hostnameHash: "d".repeat(16),
+      pid: 12345,
+      startupToken: activeToken,
+      updatedAt: new Date().toISOString(),
+      activeOperations: [operation],
+    }));
+    const oldPath = path.join(runtimeDir, `${"e".repeat(16)}-12346-${oldToken}.json`);
+    fs.writeFileSync(oldPath, JSON.stringify({
+      schemaVersion: 1,
+      hostnameHash: "e".repeat(16),
+      pid: 12346,
+      startupToken: oldToken,
+      updatedAt: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString(),
+      activeOperations: [operation],
+    }));
+
+    const snapshot = await new McpRuntimeDiagnostics(indexRoot).snapshot(undefined, 1000);
+    expect(snapshot.activeOperations).toEqual([
+      expect.objectContaining({ operation: "codebase_context" }),
+    ]);
+    expect(snapshot.latestInterruptedOperation).toBeUndefined();
+    expect(fs.existsSync(remotePath)).toBe(true);
+    expect(fs.existsSync(oldPath)).toBe(false);
+  });
+
+  it("allows for disk heartbeat granularity when inspecting another process", async () => {
+    const runtimeDir = path.join(indexRoot, "mcp-runtime");
+    fs.mkdirSync(runtimeDir, { recursive: true, mode: 0o700 });
+    const hostnameHash = "d".repeat(16);
+    const startupToken = "f".repeat(32);
+    const recordPath = path.join(runtimeDir, `${hostnameHash}-12345-${startupToken}.json`);
+    const writeRecord = (lastActivityAt: string): void => {
+      fs.writeFileSync(recordPath, JSON.stringify({
+        schemaVersion: 1,
+        hostnameHash,
+        pid: 12345,
+        startupToken,
+        updatedAt: new Date().toISOString(),
+        activeOperations: [{
+          id: "operation-id",
+          sessionId: "session-id",
+          operation: "index_codebase",
+          phase: "embedding",
+          startedAt: lastActivityAt,
+          lastActivityAt,
+        }],
+      }));
+    };
+
+    writeRecord(new Date(Date.now() - 2000).toISOString());
+    const diagnostics = new McpRuntimeDiagnostics(indexRoot);
+    await expect(diagnostics.snapshot(undefined, 1000)).resolves.toMatchObject({
+      activeOperations: [{ status: "active" }],
+    });
+
+    writeRecord(new Date(Date.now() - 7000).toISOString());
+    await expect(diagnostics.snapshot(undefined, 1000)).resolves.toMatchObject({
+      activeOperations: [{ status: "suspected_stall" }],
+    });
+  });
+
+  it("reconstructs persisted next actions instead of trusting file content", async () => {
+    const runtimeDir = path.join(indexRoot, "mcp-runtime");
+    fs.mkdirSync(runtimeDir, { recursive: true, mode: 0o700 });
+    const hostnameHash = "e".repeat(16);
+    const startupToken = "a".repeat(32);
+    const timestamp = new Date().toISOString();
+    fs.writeFileSync(
+      path.join(runtimeDir, `${hostnameHash}-12346-${startupToken}.json`),
+      JSON.stringify({
+        schemaVersion: 1,
+        hostnameHash,
+        pid: 12346,
+        startupToken,
+        updatedAt: timestamp,
+        activeOperations: [],
+        latestInterruptedOperation: {
+          operation: "index_codebase",
+          phase: "embedding",
+          startedAt: timestamp,
+          lastActivityAt: timestamp,
+          cause: "ordered_shutdown",
+          nextAction: "Expose /private/path and secret=abc",
+        },
+      }),
+    );
+
+    const snapshot = await new McpRuntimeDiagnostics(indexRoot).snapshot(undefined, 1000);
+    expect(snapshot.latestInterruptedOperation?.nextAction).toBe(
+      "Retry the operation from a connected MCP client.",
+    );
+    expect(JSON.stringify(snapshot)).not.toContain("/private/path");
+    expect(JSON.stringify(snapshot)).not.toContain("secret=abc");
+  });
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -27,6 +27,7 @@ import {
 const { testMainRepo } = vi.hoisted(() => ({
   testMainRepo: `/tmp/codebase-index-mcp-vitest-main-repo-${process.pid}`,
 }));
+const supportsReadOnlyDirectoryTest = process.platform !== "win32" && process.getuid?.() !== 0;
 
 function returnedTokenBucket(tokens: number): keyof EffectivenessMetricsSnapshot["returnedTokenEstimate"] {
   if (tokens === 0) return "0";
@@ -1049,6 +1050,31 @@ describe("MCP server tools and prompts", () => {
       },
     });
   });
+
+  it.runIf(supportsReadOnlyDirectoryTest)(
+    "should execute index_status when diagnostics storage is not writable",
+    async () => {
+      const indexRoot = `${testMainRepo}/.opencode/index`;
+      fs.chmodSync(indexRoot, 0o555);
+
+      try {
+        const result = await client.callTool({ name: "index_status", arguments: {} });
+        const content = result.content as Array<{ type: string; text?: string }>;
+
+        expect(result.isError).not.toBe(true);
+        expect(content[0]?.text).toContain("Indexed chunks");
+        expect(result.structuredContent).toMatchObject({
+          mcpDiagnostics: {
+            schemaVersion: 1,
+            activeOperations: [],
+          },
+        });
+        expect(fs.existsSync(`${indexRoot}/mcp-runtime`)).toBe(false);
+      } finally {
+        fs.chmodSync(indexRoot, 0o755);
+      }
+    },
+  );
 
   it("emits monotone in-memory progress with the exact caller token", async () => {
     const send = vi.spyOn(serverTransport, "send");

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -19,6 +19,10 @@ import {
 } from "../src/tools/operations.js";
 import { MCP_SERVER_CURRENT_NAME } from "../src/identity-catalog.js";
 import { MCP_TOOL_NAMES } from "../src/tools/tool-names.js";
+import {
+  OperationCancelledError,
+  ProviderRequestError,
+} from "../src/utils/operation-control.js";
 
 const { testMainRepo } = vi.hoisted(() => ({
   testMainRepo: `/tmp/codebase-index-mcp-vitest-main-repo-${process.pid}`,
@@ -401,6 +405,7 @@ describe("createMcpServer", () => {
 describe("MCP server tools and prompts", () => {
   let client: Client;
   let server: ReturnType<typeof createMcpServer>;
+  let serverTransport: ReturnType<typeof InMemoryTransport.createLinkedPair>[1];
 
   beforeEach(async () => {
     resetProcessEffectivenessMetrics();
@@ -449,7 +454,9 @@ describe("MCP server tools and prompts", () => {
     server = createMcpServer("/tmp/test-project", config, "opencode");
     client = new Client({ name: "test-client", version: "1.0.0" });
 
-    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const transports = InMemoryTransport.createLinkedPair();
+    const clientTransport = transports[0];
+    serverTransport = transports[1];
     await Promise.all([
       server.connect(serverTransport),
       client.connect(clientTransport),
@@ -462,7 +469,7 @@ describe("MCP server tools and prompts", () => {
     fs.rmSync(testMainRepo, { recursive: true, force: true });
   });
 
-  it("should register all 18 tools", async () => {
+  it("should register every MCP tool", async () => {
     const tools = await client.listTools();
 
     expect(tools.tools).toHaveLength(MCP_TOOL_NAMES.length);
@@ -913,7 +920,12 @@ describe("MCP server tools and prompts", () => {
     const content = result.content as Array<{ type: string; text?: string }>;
     expect(content[0].text).toContain("Path (2 hops)");
     const indexer = indexerMockState.instances.at(-1);
-    expect(indexer?.findCallPathBySymbolIds).toHaveBeenCalledWith("from-node-id", "to-node-id", 7);
+    expect(indexer?.findCallPathBySymbolIds).toHaveBeenCalledWith(
+      "from-node-id",
+      "to-node-id",
+      7,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 
   it("should keep conceptual and graph responses within the minimum token budget", async () => {
@@ -1030,6 +1042,108 @@ describe("MCP server tools and prompts", () => {
     expect(content[0].text).toContain("Indexed chunks");
     expect(content[0].text).toContain("50");
     expect(content[0].text).toContain("Compatibility: Index is compatible");
+    expect(result.structuredContent).toMatchObject({
+      mcpDiagnostics: {
+        schemaVersion: 1,
+        activeOperations: [],
+      },
+    });
+  });
+
+  it("emits monotone in-memory progress with the exact caller token", async () => {
+    const send = vi.spyOn(serverTransport, "send");
+    const indexer = (await import("../src/tools/operations.js"))
+      .getIndexerForProject("/tmp/test-project", "opencode");
+    vi.mocked(indexer.index).mockImplementationOnce(async (onProgress) => {
+      onProgress?.({
+        phase: "scanning",
+        filesProcessed: 0,
+        totalFiles: 1,
+        chunksProcessed: 0,
+        totalChunks: 1,
+      });
+      onProgress?.({
+        phase: "embedding",
+        filesProcessed: 1,
+        totalFiles: 1,
+        chunksProcessed: 0,
+        totalChunks: 1,
+      });
+      onProgress?.({
+        phase: "complete",
+        filesProcessed: 1,
+        totalFiles: 1,
+        chunksProcessed: 1,
+        totalChunks: 1,
+      });
+      return mockIndexResult;
+    });
+
+    const result = await client.callTool({
+      name: "index_codebase",
+      arguments: {},
+      _meta: { progressToken: "caller-token" },
+    });
+
+    expect(result.isError).not.toBe(true);
+    const progress = send.mock.calls
+      .map(([message]) => message)
+      .filter((message) => "method" in message && message.method === "notifications/progress")
+      .map((message) => "params" in message ? message.params : undefined);
+    expect(progress).toEqual([
+      { progressToken: "caller-token", progress: 0, total: 100 },
+      { progressToken: "caller-token", progress: 20, total: 100 },
+      { progressToken: "caller-token", progress: 100, total: 100 },
+    ]);
+  });
+
+  it("propagates in-memory client cancellation to the handler and clears its diagnostic", async () => {
+    const indexer = (await import("../src/tools/operations.js"))
+      .getIndexerForProject("/tmp/test-project", "opencode");
+    let handlerSignal: AbortSignal | undefined;
+    let markHandlerStarted: (() => void) | undefined;
+    const handlerStarted = new Promise<void>((resolve) => {
+      markHandlerStarted = resolve;
+    });
+    vi.mocked(indexer.index).mockImplementationOnce(async (_onProgress, options) => {
+      handlerSignal = options?.signal;
+      markHandlerStarted?.();
+      await new Promise<void>((_resolve, reject) => {
+        if (!options?.signal) {
+          reject(new Error("Expected the MCP operation signal."));
+          return;
+        }
+        const rejectCancellation = (): void => reject(new OperationCancelledError());
+        if (options.signal.aborted) rejectCancellation();
+        else options.signal.addEventListener("abort", rejectCancellation, { once: true });
+      });
+      return mockIndexResult;
+    });
+
+    const controller = new AbortController();
+    const call = client.callTool(
+      { name: "index_codebase", arguments: {} },
+      undefined,
+      { signal: controller.signal },
+    );
+    await handlerStarted;
+
+    const activeStatus = await client.callTool({ name: "index_status", arguments: {} });
+    expect(activeStatus.structuredContent).toMatchObject({
+      mcpDiagnostics: {
+        activeOperations: [expect.objectContaining({ operation: "index_codebase", status: "active" })],
+      },
+    });
+
+    controller.abort(new Error("client cancellation test"));
+    await expect(call).rejects.toThrow("client cancellation test");
+    await vi.waitFor(() => expect(handlerSignal?.aborted).toBe(true));
+    await vi.waitFor(async () => {
+      const settledStatus = await client.callTool({ name: "index_status", arguments: {} });
+      expect(settledStatus.structuredContent).toMatchObject({
+        mcpDiagnostics: { activeOperations: [] },
+      });
+    });
   });
 
   it("should surface failed batch diagnostics in index_codebase output", async () => {
@@ -1055,6 +1169,37 @@ describe("MCP server tools and prompts", () => {
     const content = result.content as Array<{ type: string; text?: string }>;
     expect(content[0].text).toContain("INDEXING WARNING");
     expect(content[0].text).toContain("failed-batches.json");
+  });
+
+  it("returns a redacted structured provider error after preserving partial indexing work", async () => {
+    const providerError = new ProviderRequestError({
+      statusCode: 500,
+      message: "private provider URL=https://user:secret@example.invalid/body",
+    });
+    const indexer = (await import("../src/tools/operations.js"))
+      .getIndexerForProject("/tmp/test-project", "opencode");
+    vi.mocked(indexer.index).mockImplementationOnce(async (_onProgress, options) => {
+      options?.onProviderError?.(providerError);
+      return {
+        ...mockIndexResult,
+        indexedChunks: 4,
+        failedChunks: 1,
+        failedBatchesPath: "/private/index/failed-batches.json",
+      };
+    });
+
+    const result = await client.callTool({ name: "index_codebase", arguments: {} });
+
+    expect(result).toMatchObject({
+      isError: true,
+      structuredContent: {
+        error: { code: "PROVIDER_ERROR", retryable: true, operation: "index_codebase" },
+      },
+    });
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("example.invalid");
+    expect(serialized).not.toContain("failed-batches.json");
+    expect(serialized).not.toContain("secret");
   });
 
   it("keeps manual MCP indexing available when battery pausing is enabled", async () => {
@@ -1107,6 +1252,14 @@ describe("MCP server tools and prompts", () => {
     expect(content[0].text).toContain("PID 4242");
     expect(content[0].text).toContain("operation index");
     expect(content[0].text).toContain(owner.startedAt);
+    expect(result.structuredContent).toMatchObject({
+      error: {
+        schemaVersion: 1,
+        code: "INDEX_BUSY",
+        operation: "index_codebase",
+        retryable: true,
+      },
+    });
   });
 
   it("should explain when an unreadable lock requires manual verification", async () => {
@@ -1412,7 +1565,13 @@ describe("MCP server tools and prompts", () => {
     expect(content[0].type).toBe("text");
     expect(content[0].text).toContain("called by 1 function");
     const indexer = indexerMockState.instances[0];
-    expect(indexer.getCallersForSymbol).toHaveBeenCalledWith("sym_validate", "validateToken", true, undefined);
+    expect(indexer.getCallersForSymbol).toHaveBeenCalledWith(
+      "sym_validate",
+      "validateToken",
+      true,
+      undefined,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 
   it("should report bounded candidate locations instead of unioning duplicate names", async () => {
@@ -1444,7 +1603,11 @@ describe("MCP server tools and prompts", () => {
     });
     const text = (result.content as Array<{ text?: string }>)[0]?.text ?? "";
     expect(text).toContain('"run" at src/nested/b.ts:1 calls 1 function');
-    expect(indexer.getCallees).toHaveBeenCalledWith("sym_run_b", undefined);
+    expect(indexer.getCallees).toHaveBeenCalledWith(
+      "sym_run_b",
+      undefined,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 
   it("should return a concise missing-name result", async () => {
@@ -1465,7 +1628,11 @@ describe("MCP server tools and prompts", () => {
       name: "call_graph",
       arguments: { name: "run", direction: "callees", symbolId: " sym_run_b " },
     });
-    expect(indexer.getCallees).toHaveBeenCalledWith("sym_run_b", undefined);
+    expect(indexer.getCallees).toHaveBeenCalledWith(
+      "sym_run_b",
+      undefined,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 
   it("should disambiguate both path endpoints with normalized file paths", async () => {
@@ -1485,7 +1652,12 @@ describe("MCP server tools and prompts", () => {
         toFilePath: " ./src/nested//finish.ts ",
       },
     });
-    expect(indexer.findCallPathBySymbolIds).toHaveBeenCalledWith("sym_start_b", "sym_finish_b", 10);
+    expect(indexer.findCallPathBySymbolIds).toHaveBeenCalledWith(
+      "sym_start_b",
+      "sym_finish_b",
+      10,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 
   it("should get search prompt", async () => {

--- a/tests/multiprocess-indexing.test.ts
+++ b/tests/multiprocess-indexing.test.ts
@@ -306,15 +306,22 @@ describe("multiprocess indexing", () => {
   async function createMcpClient(
     configPath: string,
     host: "claude" | "codex" | "jcode" | "opencode" | "pi" = "opencode",
-    options: { environment?: Record<string, string>; preloads?: string[] } = {},
+    options: {
+      builtCli?: boolean;
+      environment?: Record<string, string>;
+      preloads?: string[];
+    } = {},
   ): Promise<{
     client: Client;
     transport: StdioClientTransport;
     stderr: string[];
   }> {
     const stderr: string[] = [];
-    const cliPath = fileURLToPath(new URL("../src/cli.ts", import.meta.url));
-    const args = ["--import", "tsx"];
+    const cliPath = fileURLToPath(new URL(
+      options.builtCli ? "../dist/cli.js" : "../src/cli.ts",
+      import.meta.url,
+    ));
+    const args = options.builtCli ? [] : ["--import", "tsx"];
     for (const preload of options.preloads ?? []) args.push("--import", preload);
     args.push(cliPath, "--project", projectRoot, "--config", configPath, "--host", host);
     const transport = new StdioClientTransport({
@@ -406,6 +413,34 @@ describe("multiprocess indexing", () => {
     };
     fs.writeFileSync(configPath, JSON.stringify(rawConfig));
     return parseConfig(rawConfig);
+  }
+
+  function writeForegroundMcpConfig(configPath: string): void {
+    fs.writeFileSync(configPath, JSON.stringify({
+      embeddingProvider: "custom",
+      scope: "project",
+      customProvider: {
+        baseUrl: embeddingServer.baseUrl,
+        model: "multiprocess-test",
+        dimensions: 8,
+        timeoutMs: 30_000,
+        maxBatchSize: 64,
+        concurrency: 1,
+        requestIntervalMs: 0,
+      },
+      include: ["**/*.ts"],
+      exclude: ["**/.opencode/**", "**/.git/**", "**/node_modules/**"],
+      indexing: {
+        autoIndex: false,
+        watchFiles: false,
+        autoGc: false,
+        retries: 0,
+        retryDelayMs: 1,
+        gitBlame: { enabled: false },
+      },
+      mcp: { stallTimeoutMs: 1000 },
+      debug: { enabled: false },
+    }));
   }
 
   function createLocalIndexer(
@@ -1187,30 +1222,7 @@ describe("multiprocess indexing", () => {
 
   it("allows only one of two real MCP stdio servers to index", async () => {
     const configPath = path.join(tempDir, "mcp-config.json");
-    fs.writeFileSync(configPath, JSON.stringify({
-      embeddingProvider: "custom",
-      scope: "project",
-      customProvider: {
-        baseUrl: embeddingServer.baseUrl,
-        model: "multiprocess-test",
-        dimensions: 8,
-        timeoutMs: 5000,
-        maxBatchSize: 64,
-        concurrency: 1,
-        requestIntervalMs: 0,
-      },
-      include: ["**/*.ts"],
-      exclude: ["**/.opencode/**", "**/.git/**", "**/node_modules/**"],
-      indexing: {
-        autoIndex: false,
-        watchFiles: false,
-        autoGc: false,
-        retries: 0,
-        retryDelayMs: 1,
-        gitBlame: { enabled: false },
-      },
-      debug: { enabled: false },
-    }));
+    writeForegroundMcpConfig(configPath);
 
     const first = await createMcpClient(configPath);
     const second = await createMcpClient(configPath);
@@ -1239,6 +1251,129 @@ describe("multiprocess indexing", () => {
     await Promise.all([first.client.close(), second.client.close()]);
     mcpClients = [];
     assertIndexIntegrity();
+  });
+
+  it("does not report a clean stdio EOF as an interrupted operation", async () => {
+    const configPath = path.join(tempDir, "mcp-clean-eof.json");
+    writeForegroundMcpConfig(configPath);
+    const first = await createMcpClient(configPath);
+    const firstPid = first.transport.pid;
+    if (firstPid === null) throw new Error("Expected an MCP stdio process");
+
+    await first.client.close();
+    mcpClients = mcpClients.filter((client) => client !== first.client);
+    await waitForProcessExit(firstPid);
+
+    const observer = await createMcpClient(configPath);
+    const status = await observer.client.callTool({ name: "index_status", arguments: {} });
+    const diagnostics = (status.structuredContent as {
+      mcpDiagnostics?: {
+        activeOperations?: unknown[];
+        latestInterruptedOperation?: unknown;
+      };
+    } | undefined)?.mcpDiagnostics;
+    expect(status.isError).not.toBe(true);
+    expect(diagnostics?.activeOperations).toEqual([]);
+    expect(diagnostics?.latestInterruptedOperation).toBeUndefined();
+
+    await observer.client.close();
+    mcpClients = mcpClients.filter((client) => client !== observer.client);
+  });
+
+  it("persists SIGKILL diagnostics and lets the next stdio server recover", async () => {
+    await seedIndex();
+    embeddingServer.reset();
+    fs.writeFileSync(sourcePath, "export function recovered() { return 'after-mcp-crash'; }\n");
+    const configPath = path.join(tempDir, "mcp-sigkill.json");
+    writeForegroundMcpConfig(configPath);
+    const crashed = await createMcpClient(configPath, "opencode", { builtCli: true });
+    const crashedPid = crashed.transport.pid;
+    if (crashedPid === null) throw new Error("Expected an MCP stdio process");
+    const runtimeDirectory = path.join(projectRoot, ".opencode", "index", "mcp-runtime");
+
+    embeddingServer.block();
+    const interruptedCall = crashed.client.callTool({ name: "index_codebase", arguments: {} });
+    let interruptedCallSettled = false;
+    void interruptedCall.finally(() => {
+      interruptedCallSettled = true;
+    }).catch(() => undefined);
+    void interruptedCall.catch(() => undefined);
+    await embeddingServer.waitForRequestCount(1);
+    await waitForCondition(() => {
+      if (!fs.existsSync(runtimeDirectory)) return false;
+      return fs.readdirSync(runtimeDirectory)
+        .filter((name) => name.endsWith(".json"))
+        .some((name) => {
+          try {
+            const state = JSON.parse(fs.readFileSync(path.join(runtimeDirectory, name), "utf8")) as {
+              pid?: number;
+              activeOperations?: Array<{ operation?: string; phase?: string }>;
+            };
+            return state.pid === crashedPid && state.activeOperations?.some(
+              (operation) => operation.operation === "index_codebase" && operation.phase === "embedding",
+            ) === true;
+          } catch {
+            return false;
+          }
+        });
+    }, "persisted MCP embedding phase");
+    expect(interruptedCallSettled).toBe(false);
+
+    process.kill(crashedPid, "SIGKILL");
+    await waitForProcessExit(crashedPid);
+    await interruptedCall.catch(() => undefined);
+    mcpClients = mcpClients.filter((client) => client !== crashed.client);
+    embeddingServer.release();
+    await embeddingServer.waitForIdle();
+    embeddingServer.reset();
+
+    const recovery = await createMcpClient(configPath, "opencode", { builtCli: true });
+    const status = await recovery.client.callTool({ name: "index_status", arguments: {} });
+    const diagnostics = (status.structuredContent as {
+      mcpDiagnostics?: {
+        activeOperations?: unknown[];
+        latestInterruptedOperation?: {
+          operation?: string;
+          phase?: string;
+          cause?: string;
+        };
+      };
+    } | undefined)?.mcpDiagnostics;
+    expect(status.isError).not.toBe(true);
+    expect(diagnostics?.activeOperations).toEqual([]);
+    expect(diagnostics?.latestInterruptedOperation).toMatchObject({
+      operation: "index_codebase",
+      phase: "embedding",
+      cause: "process_exit",
+    });
+
+    const progress: Array<{ progress: number; total?: number }> = [];
+    const recovered = await recovery.client.callTool(
+      { name: "index_codebase", arguments: {} },
+      undefined,
+      {
+        maxTotalTimeout: 30_000,
+        onprogress: (update) => progress.push(update),
+        resetTimeoutOnProgress: true,
+      },
+    );
+    expect(recovered.isError, JSON.stringify(recovered.content)).not.toBe(true);
+    expect(embeddingServer.inputs.some((input) => input.includes("after-mcp-crash"))).toBe(true);
+    expect(progress[0]).toEqual(expect.objectContaining({ progress: 0, total: 100 }));
+    expect(progress.at(-1)).toEqual(expect.objectContaining({ progress: 100, total: 100 }));
+    expect(progress.every((update, index) => index === 0 || update.progress > progress[index - 1]!.progress)).toBe(true);
+    await embeddingServer.waitForIdle();
+    const context = await recovery.client.callTool({
+      name: "codebase_context",
+      arguments: { query: "recovered function", tokenBudget: 1000 },
+    });
+    expect(context.isError, JSON.stringify(context.content)).not.toBe(true);
+    expect(JSON.stringify(context.content)).toMatch(/after-mcp-crash|recovered/);
+    expect(fs.readdirSync(runtimeDirectory).some((name) => name.endsWith(".tmp"))).toBe(false);
+    assertIndexIntegrity();
+
+    await recovery.client.close();
+    mcpClients = mcpClients.filter((client) => client !== recovery.client);
   });
 
   it("elects one Codex background worker, blocks a stale snapshot, and promotes a follower", async () => {
@@ -1300,7 +1435,14 @@ describe("multiprocess indexing", () => {
     });
     const searchText = (searchResult.content as Array<{ text?: string }>).map(({ text }) => text ?? "").join("\n");
     expect(searchResult.isError).toBe(true);
-    expect(searchText).toMatch(/Automatic indexing is (?:idle|indexing)/i);
+    expect(searchText).toContain("INDEX_UNAVAILABLE");
+    expect(searchResult.structuredContent).toMatchObject({
+      error: {
+        code: "INDEX_UNAVAILABLE",
+        operation: "codebase_search",
+        retryable: true,
+      },
+    });
     expect(searchText).not.toContain("INDEX_BUSY");
     expect(embeddingServer.inputs.filter((input) => input.includes("stale"))).toHaveLength(1);
 
@@ -1441,7 +1583,7 @@ describe("multiprocess indexing", () => {
     mcpClients = mcpClients.filter((client) => client !== first.client && client !== second.client);
   });
 
-  it("exits a busy Codex leader without releasing its lease before follower recovery", async () => {
+  it("releases a busy Codex leader lease before follower recovery", async () => {
     const configPath = path.join(tempDir, "codex-busy-shutdown.json");
     const parsedConfig = writeBackgroundMcpConfig(configPath);
     const seededIndexer = new Indexer(projectRoot, parsedConfig, "codex");
@@ -1469,9 +1611,15 @@ describe("multiprocess indexing", () => {
     mcpClients = mcpClients.filter((client) => client !== leader.client);
     await waitForProcessExit(leaderPid);
 
-    expect(fs.existsSync(leasePath)).toBe(true);
-    const retainedOwner = JSON.parse(fs.readFileSync(path.join(leasePath, "owner.json"), "utf-8")) as { pid: number };
-    expect(retainedOwner.pid).toBe(leaderPid);
+    await waitForCondition(() => {
+      if (!fs.existsSync(leasePath)) return true;
+      try {
+        const currentOwner = JSON.parse(fs.readFileSync(path.join(leasePath, "owner.json"), "utf-8")) as { pid: number };
+        return currentOwner.pid !== leaderPid;
+      } catch {
+        return true;
+      }
+    }, "busy leader lease release");
     embeddingServer.release();
     await embeddingServer.waitForIdle();
 
@@ -1585,7 +1733,14 @@ describe("multiprocess indexing", () => {
     });
     const searchText = (search.content as Array<{ text?: string }>).map(({ text }) => text ?? "").join("\n");
     expect(search.isError).toBe(true);
-    expect(searchText).toMatch(/Automatic indexing is (?:idle|indexing)/i);
+    expect(searchText).toContain("INDEX_UNAVAILABLE");
+    expect(search.structuredContent).toMatchObject({
+      error: {
+        code: "INDEX_UNAVAILABLE",
+        operation: "codebase_search",
+        retryable: true,
+      },
+    });
     expect(searchText).not.toContain("INDEX_BUSY");
     await waitForCondition(
       () => embeddingServer.inputs.some((input) => input.includes("follower-refresh")),

--- a/tests/ollama-embed.test.ts
+++ b/tests/ollama-embed.test.ts
@@ -189,7 +189,9 @@ describe("OllamaEmbeddingProvider.embedBatch", () => {
       throw new Error(`Unexpected request: ${url}`);
     });
 
-    await expect(makeProvider().embedBatch(["aaa", "bbb"])).rejects.toThrow("Ollama embedding API error: 500");
+    await expect(makeProvider().embedBatch(["aaa", "bbb"])).rejects.toThrow(
+      "Ollama embedding provider returned HTTP 500.",
+    );
   });
 
   it("falls back to per-text /api/embeddings when /api/embed returns a non-JSON 200 body", async () => {

--- a/tests/operations-progress.test.ts
+++ b/tests/operations-progress.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { Indexer, IndexStats } from "../src/indexer/index.js";
+import {
+  defaultProjectRoots,
+  getIndexerCacheKey,
+  indexerCache,
+} from "../src/tools/operation-runtime.js";
+import { implementationLookup, runIndexCodebase } from "../src/tools/operations.js";
+import { OperationCancelledError, ProviderRequestError } from "../src/utils/operation-control.js";
+
+function stats(): IndexStats {
+  return {
+    totalFiles: 1,
+    totalChunks: 1,
+    indexedChunks: 1,
+    failedChunks: 0,
+    existingChunks: 0,
+    removedChunks: 0,
+    tokensUsed: 10,
+    durationMs: 5,
+    skippedFiles: [],
+    parseFailures: [],
+  };
+}
+
+describe("direct index operation progress", () => {
+  const projectRoot = "/tmp/direct-index-progress";
+  const key = getIndexerCacheKey(projectRoot, "jcode");
+
+  afterEach(() => {
+    defaultProjectRoots.delete("jcode");
+    indexerCache.delete(key);
+  });
+
+  it("forwards progress when no coordinator is registered", async () => {
+    const index = vi.fn(async (onProgress?: Parameters<Indexer["index"]>[0]) => {
+      onProgress?.({
+        phase: "embedding",
+        filesProcessed: 1,
+        totalFiles: 1,
+        chunksProcessed: 0,
+        totalChunks: 1,
+      });
+      return stats();
+    });
+    defaultProjectRoots.set("jcode", projectRoot);
+    indexerCache.set(key, { index } as unknown as Indexer);
+    const onProgress = vi.fn();
+    const reportProgress = vi.fn();
+
+    await expect(runIndexCodebase(undefined, "jcode", {}, onProgress, { reportProgress }))
+      .resolves.toMatchObject({ kind: "stats" });
+
+    expect(index).toHaveBeenCalledOnce();
+    expect(onProgress).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
+      phase: "embedding",
+      percentage: 20,
+    }));
+    expect(reportProgress).toHaveBeenCalledWith(20, "embedding");
+  });
+
+  it("forwards phase control through the direct indexer path", async () => {
+    const setPhase = vi.fn(async () => undefined);
+    const index = vi.fn(async (
+      _onProgress?: Parameters<Indexer["index"]>[0],
+      options?: Parameters<Indexer["index"]>[1],
+    ) => {
+      await options?.setPhase?.("embedding");
+      return stats();
+    });
+    defaultProjectRoots.set("jcode", projectRoot);
+    indexerCache.set(key, { index } as unknown as Indexer);
+
+    await expect(runIndexCodebase(undefined, "jcode", {}, undefined, { setPhase }))
+      .resolves.toMatchObject({ kind: "stats" });
+
+    expect(setPhase).toHaveBeenCalledWith("embedding");
+  });
+
+  it("retains a typed provider failure after direct partial indexing completes", async () => {
+    const providerError = new ProviderRequestError({ statusCode: 429 });
+    const index = vi.fn(async (
+      _onProgress?: Parameters<Indexer["index"]>[0],
+      options?: Parameters<Indexer["index"]>[1],
+    ) => {
+      options?.onProviderError?.(providerError);
+      return stats();
+    });
+    defaultProjectRoots.set("jcode", projectRoot);
+    indexerCache.set(key, { index } as unknown as Indexer);
+
+    await expect(runIndexCodebase(undefined, "jcode", {})).resolves.toMatchObject({
+      kind: "stats",
+      providerError,
+    });
+  });
+
+  it("stops exact-symbol resolution when its shared operation is cancelled", async () => {
+    const controller = new AbortController();
+    const getCallGraphSymbols = vi.fn(async () => {
+      controller.abort();
+      return [{
+        id: "target",
+        name: "target",
+        filePath: "/tmp/target.ts",
+        kind: "function",
+        startLine: 1,
+        startCol: 0,
+        endLine: 1,
+        endCol: 10,
+        language: "typescript",
+      }];
+    });
+    defaultProjectRoots.set("jcode", projectRoot);
+    indexerCache.set(key, { getCallGraphSymbols } as unknown as Indexer);
+
+    await expect(implementationLookup(
+      undefined,
+      "jcode",
+      "target",
+      { exactSymbol: true },
+      { signal: controller.signal },
+    )).rejects.toBeInstanceOf(OperationCancelledError);
+  });
+});

--- a/tests/pr-impact.test.ts
+++ b/tests/pr-impact.test.ts
@@ -7,6 +7,7 @@ import { Indexer } from "../src/indexer/index.js";
 import { pr_impact, call_graph, initializeTools } from "../src/tools/index.js";
 import { getChangedFiles } from "../src/tools/changed-files.js";
 import { hashContent, type Database } from "../src/native/index.js";
+import { OperationCancelledError } from "../src/utils/operation-control.js";
 vi.mock("child_process", () => ({
   execFile: vi.fn(),
 }));
@@ -579,6 +580,69 @@ describe("pr_impact tool", () => {
       expect.arrayContaining([expect.stringContaining("b.ts")]),
       "other-branch",
     );
+  });
+
+  it("propagates cancellation while scanning conflicting PRs", async () => {
+    const controller = new AbortController();
+    (getChangedFiles as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (args: { pr?: number; signal?: AbortSignal }) => {
+        if (args.pr === 1) {
+          return {
+            files: ["src/a.ts"],
+            baseBranch: "main",
+            source: "git",
+            catalogIdentity: "feature-branch",
+            headRefName: "feature-branch",
+            headRef: "1111111111111111111111111111111111111111",
+          };
+        }
+        controller.abort();
+        expect(args.signal).toBe(controller.signal);
+        throw new OperationCancelledError();
+      },
+    );
+    (execFile as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (
+        cmd: string,
+        args: string[],
+        options: { signal?: AbortSignal },
+        callback: (error: Error | null, result?: { stdout: string }) => void,
+      ) => {
+        expect(options.signal).toBe(controller.signal);
+        if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
+          callback(null, { stdout: '[{"number":2,"headRefName":"other-branch"}]\n' });
+          return;
+        }
+        callback(new Error(`Unexpected command: ${cmd} ${args.join(" ")}`));
+      },
+    );
+
+    const indexer = await createIndexer();
+    const db = await getDatabase(indexer);
+    setBranchMigrationMetadataCurrent(db, "feature-branch");
+    db.setMetadata(
+      branchCommitMetadataKey("feature-branch"),
+      "1111111111111111111111111111111111111111",
+    );
+    db.upsertSymbol({
+      id: "sym_a",
+      filePath: "src/a.ts",
+      name: "funcA",
+      kind: "function",
+      startLine: 1,
+      startCol: 0,
+      endLine: 10,
+      endCol: 0,
+      language: "typescript",
+    });
+    db.addSymbolsToBranch("feature-branch", ["sym_a"]);
+
+    await expect(indexer.getPrImpact(
+      { pr: 1, checkConflicts: true },
+      undefined,
+      { signal: controller.signal },
+    )).rejects.toBeInstanceOf(OperationCancelledError);
+    expect(getChangedFiles).toHaveBeenCalledTimes(2);
   });
 
   it("regression: checkConflicts detects overlapping PRs despite cross-branch line drift", async () => {

--- a/tests/retrieval-ranking.test.ts
+++ b/tests/retrieval-ranking.test.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { ChunkMetadata } from "../src/native/index.js";
 import {
@@ -19,6 +19,7 @@ import {
   rerankResults,
 } from "../src/indexer/index.js";
 import { parseConfig } from "../src/config/schema.js";
+import { OperationCancelledError } from "../src/utils/operation-control.js";
 
 type Candidate = { id: string; score: number; metadata: ChunkMetadata };
 
@@ -632,6 +633,67 @@ describe("retrieval ranking", () => {
     globalThis.fetch = fetchSpy;
   });
 
+  it("cancels a blocked external reranker request without falling back", async () => {
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "mock-embed",
+        dimensions: 8,
+      },
+      reranker: {
+        enabled: true,
+        provider: "custom",
+        model: "mock-reranker",
+        baseUrl: "https://rerank.example/v1",
+        topN: 2,
+      },
+    });
+    const indexer = new Indexer("/repo", config, "opencode");
+    const candidates: Candidate[] = [
+      { id: "first", score: 0.9, metadata: meta({ filePath: "/repo/src/first.ts", name: "firstThing", chunkType: "function" }) },
+      { id: "second", score: 0.89, metadata: meta({ filePath: "/repo/src/second.ts", name: "secondThing", chunkType: "function" }) },
+    ];
+    const originalFetch = globalThis.fetch;
+    let requestSignal: AbortSignal | undefined;
+    let markRequestStarted: (() => void) | undefined;
+    const requestStarted = new Promise<void>((resolve) => {
+      markRequestStarted = resolve;
+    });
+    globalThis.fetch = vi.fn(async (_input, init) => {
+      requestSignal = init?.signal ?? undefined;
+      markRequestStarted?.();
+      return new Promise<Response>((_resolve, reject) => {
+        if (!requestSignal) {
+          reject(new Error("Expected a reranker request signal."));
+          return;
+        }
+        const rejectCancellation = (): void => reject(requestSignal?.reason ?? new Error("cancelled"));
+        if (requestSignal.aborted) rejectCancellation();
+        else requestSignal.addEventListener("abort", rejectCancellation, { once: true });
+      });
+    }) as typeof fetch;
+
+    try {
+      const controller = new AbortController();
+      const reranking = (indexer as unknown as {
+        rerankCandidatesWithApi(
+          query: string,
+          items: Candidate[],
+          options?: { signal?: AbortSignal },
+        ): Promise<Candidate[]>;
+      }).rerankCandidatesWithApi("find first thing", candidates, { signal: controller.signal });
+      await requestStarted;
+      controller.abort();
+
+      await expect(reranking).rejects.toBeInstanceOf(OperationCancelledError);
+      expect(requestSignal?.aborted).toBe(true);
+      expect(globalThis.fetch).toHaveBeenCalledOnce();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("skips external reranker for definition-intent queries with identifier hints", async () => {
     const config = parseConfig({
       embeddingProvider: "custom",
@@ -727,15 +789,21 @@ describe("retrieval ranking", () => {
       { id: "docs-readme", score: 0.89, metadata: meta({ filePath: "/repo/README.md", name: "retrieval documentation", chunkType: "other", startLine: 1, endLine: 3 }) },
       { id: "docs-guide", score: 0.88, metadata: meta({ filePath: "/repo/docs/guide.md", name: "rankHybridResults guide", chunkType: "other", startLine: 1, endLine: 3 }) },
     ];
+    const setPhase = vi.fn(async () => undefined);
 
     const reranked = await (indexer as unknown as {
       rerankCandidatesWithApi(
         query: string,
         items: Candidate[],
-        options?: { definitionIntent?: boolean; hasIdentifierHints?: boolean }
+        options?: {
+          definitionIntent?: boolean;
+          hasIdentifierHints?: boolean;
+          setPhase?: (phase: string) => void | Promise<void>;
+        }
       ): Promise<Candidate[]>;
     }).rerankCandidatesWithApi("rankHybridResults documentation guide", candidates, {
       hasIdentifierHints: true,
+      setPhase,
     });
 
     expect(rerankCalled).toBe(true);
@@ -743,6 +811,7 @@ describe("retrieval ranking", () => {
     expect(rerankDocuments?.length).toBe(2);
     expect(rerankDocuments?.[0]).toContain("path: /repo/README.md");
     expect(rerankDocuments?.[1]).toContain("path: /repo/docs/guide.md");
+    expect(setPhase).toHaveBeenCalledWith("reranking");
     globalThis.fetch = fetchSpy;
   });
 

--- a/tests/search-integration.test.ts
+++ b/tests/search-integration.test.ts
@@ -1127,7 +1127,7 @@ ${Array.from({ length: 120 }, (_, index) => `  public int Value${index} { get; s
     expect(warningLog).toHaveBeenCalledWith(
       "Query embedding failed; falling back to keyword-only search",
       expect.objectContaining({
-        error: "embedding endpoint unavailable",
+        error: "Custom embedding provider request failed.",
         action: expect.stringContaining("embedding provider"),
       })
     );

--- a/tests/worktree-fallback.test.ts
+++ b/tests/worktree-fallback.test.ts
@@ -97,6 +97,14 @@ describe("worktree fallback (issue #60)", () => {
     expect(() => loadMergedConfig(worktreeDir, "opencode")).toThrow(/field 'knowledgeBases' must be an array of strings/);
   });
 
+  it("rejects a non-object MCP configuration section", () => {
+    const configPath = path.join(mainRepoDir, ".opencode", "codebase-index.json");
+    fs.writeFileSync(configPath, JSON.stringify({ mcp: 300_000 }, null, 2), "utf-8");
+
+    expect(() => loadMergedConfig(worktreeDir, "opencode"))
+      .toThrow(/field 'mcp' must be an object/);
+  });
+
   it("throws a file-specific error when the global config is malformed", () => {
     const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "worktree-fallback-home-"));
 


### PR DESCRIPTION
## Summary

Hi! This came out of reproducing intermittent `Transport closed` failures during long-running indexing. The goal is to give users and maintainers enough evidence to distinguish a server-side interruption from a client reconnection problem, without changing the existing public tool contracts.

Long-running MCP operations can currently end as a generic `Transport closed`, leaving no reliable way to tell whether the request was cancelled, the embedding provider stalled, the index was busy, or the server process exited.

This PR hardens the server side of that failure mode. It makes MCP work cooperatively cancellable, reports monotonic progress when requested, returns structured and redacted errors, and preserves enough process-level state for a later `index_status` call to explain an interrupted operation.

It deliberately does not claim to reconnect a Codex client that is already attached to a dead transport. That remains a client-side concern tracked in openai/codex#35486 and openai/codex#16899; openai/codex#34957 only covers a narrower recovery path.

## Changes

- Route all 19 existing MCP tools through one execution wrapper for cancellation, inactivity detection, phase tracking, progress serialization, and safe error classification.
- Propagate cooperative cancellation and activity through indexing, embedding providers, reranking, Git/branch work, graph operations, leases, and transaction rollback paths.
- Keep shared indexing alive for remaining consumers while detaching a cancelled caller; stop exclusive work when its caller leaves.
- Add durable per-process diagnostics under the index root and expose additive `mcpDiagnostics` data through `index_status`.
- Add `mcp.stallTimeoutMs` with a five-minute default, `0` to disable detection, and a one-second minimum for positive values.
- Handle ordered stdio shutdown without reporting a false crash, and retain evidence after abrupt process termination.
- Document configuration, structured errors, troubleshooting, and the remaining Codex reconnection limitation.

Compatibility is preserved: MCP SDK remains at 1.29.0, tool names and request contracts are unchanged, diagnostics are additive, and the persisted index format is unchanged.

`cancellable` here means cooperative cancellation. Synchronous native calls are checked before and after execution but cannot be preempted in the middle. Likewise, `suspected_stall` is an inactivity signal, not proof that a process died.

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

Validation included:

- 108 Vitest files and 1,762 tests passing in the normal parallel run.
- The same 1,762 tests passing in a serialized run after identifying an unrelated existing race between temporary-directory cleanup and repository-copy tests.
- An isolated install using the tracked MCP SDK 1.29.0 lockfile.
- In-memory MCP cancellation, redacted structured errors, absent/present progress tokens, and monotonic progress.
- Real built stdio processes covering clean EOF, SIGKILL during embedding, persistent diagnostics, subsequent recovery, and no orphaned indexing lock.

## Release Labels

The fork account cannot apply labels in the upstream repository. Maintainer action requested:

- [ ] `bug`
- [ ] `semver:patch`

## Related Issues

- Relates to openai/codex#35486
- Relates to openai/codex#16899
- Partial client-side recovery: openai/codex#34957
