### PR TITLE
fix: prevent duplicate chunk IDs in vector batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Cancellable and diagnosable MCP operations**: Added inactivity-based cancellation, exact-token monotone progress, redacted structured handler errors, and durable per-process phase diagnostics exposed by `index_status`. Shared indexing detaches cancelled callers without stopping work still awaited by another consumer, while exclusively owned cancelled work rolls back and releases its index lease. MCP SDK `1.29.0`, public tool names, package identities, and index formats remain unchanged.
 
+### Fixed
+
+- **Swift indexing stability**: Deduplicated identical Swift chunk windows before embedding, rejected duplicate native vector-store batch keys atomically, and bumped the Swift parser cache version so existing indexes are reparsed.
+
 ## [0.26.0] - 2026-08-29
 
 ### Added

--- a/native/src/parser.rs
+++ b/native/src/parser.rs
@@ -225,8 +225,33 @@ fn extract_chunks(
     }
 
     merge_small_chunks(&mut chunks);
+    if *language == Language::Swift {
+        deduplicate_chunks_by_span_and_content(&mut chunks);
+    }
 
     Ok(chunks)
+}
+
+fn deduplicate_chunks_by_span_and_content(chunks: &mut Vec<CodeChunk>) {
+    let keep = {
+        let mut seen = HashSet::with_capacity(chunks.len());
+        let mut keep = vec![false; chunks.len()];
+
+        for (index, chunk) in chunks.iter().enumerate().rev() {
+            if seen.insert((chunk.start_line, chunk.end_line, chunk.content.as_str())) {
+                keep[index] = true;
+            }
+        }
+
+        keep
+    };
+
+    let mut index = 0;
+    chunks.retain(|_| {
+        let retain = keep[index];
+        index += 1;
+        retain
+    });
 }
 
 fn extract_semantic_nodes(

--- a/native/src/store.rs
+++ b/native/src/store.rs
@@ -182,6 +182,22 @@ impl VectorStoreInner {
             return Ok(());
         }
 
+        let mut duplicate_keys = HashSet::new();
+        let mut unique_keys = HashSet::with_capacity(batch_size);
+        for key in keys {
+            if !unique_keys.insert(key.as_str()) {
+                duplicate_keys.insert(key.as_str());
+            }
+        }
+        if !duplicate_keys.is_empty() {
+            let mut duplicate_keys = duplicate_keys.into_iter().collect::<Vec<_>>();
+            duplicate_keys.sort_unstable();
+            return Err(anyhow!(
+                "Duplicate vector store keys in batch: {}",
+                duplicate_keys.join(", ")
+            ));
+        }
+
         for (i, vector) in vectors.iter().enumerate() {
             if vector.len() != self.dimensions {
                 return Err(anyhow!(

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -577,6 +577,15 @@ interface PendingChunkBatchResult {
   failedChunkIds: Set<string>;
 }
 
+function deduplicateLastById<T extends { id: string }>(items: T[]): T[] {
+  const lastIndexById = new Map<string, number>();
+  for (let index = 0; index < items.length; index++) {
+    lastIndexById.set(items[index]!.id, index);
+  }
+
+  return items.filter((item, index) => lastIndexById.get(item.id) === index);
+}
+
 function getFailedBatchGroupKey(record: Pick<SerializedFailedBatch, "error" | "attemptCount" | "lastAttempt">): string {
   return `${record.attemptCount}:${record.lastAttempt}:${record.error}`;
 }
@@ -688,7 +697,7 @@ const INDEX_METADATA_VERSION = "1";
 const PROJECT_PATH_STORAGE_VERSION = "2";
 const GLOBAL_PATH_STORAGE_VERSION = "1";
 const EMBEDDING_STRATEGY_VERSION = "2";
-const SWIFT_PARSER_VERSION = "1";
+const SWIFT_PARSER_VERSION = "2";
 const METAL_PARSER_VERSION = "1";
 const SYMBOL_EXTRACTOR_VERSION = "1";
 
@@ -2639,6 +2648,7 @@ export class Indexer {
       onProviderError?: (error: ProviderRequestError) => void;
     },
   ): Promise<PendingChunkBatchResult> {
+    chunks = deduplicateLastById(chunks);
     const result: PendingChunkBatchResult = {
       indexedChunks: 0,
       failedChunks: 0,
@@ -4875,8 +4885,12 @@ export class Indexer {
             this.config.indexing.semanticOnly,
           );
 
-          for (const chunk of chunksToProcess) {
-            const id = this.getPreparedChunkId(generateChunkId(parsed.path, chunk));
+          const chunksWithIds = deduplicateLastById(chunksToProcess.map((chunk) => ({
+            id: this.getPreparedChunkId(generateChunkId(parsed.path, chunk)),
+            chunk,
+          })));
+
+          for (const { id, chunk } of chunksWithIds) {
             const contentHash = generateChunkHash(chunk);
             const existingContentHash = existingChunks.get(id);
             const existingChunk = gitBlameEnabled ? database.getChunk(id) : null;

--- a/tests/automatic-branch-index.test.ts
+++ b/tests/automatic-branch-index.test.ts
@@ -319,7 +319,7 @@ function changed(): number {
     ).toBe(true);
     for (const [prefix, version] of [
       ["index.callGraphResolutionVersion", "9"],
-      [swiftPrefix, "1"],
+      [swiftPrefix, "2"],
       ["index.parser.metalVersion", "1"],
     ] as const) {
       expect(migratedDb.getMetadata(migrationMetadataKey(prefix, "main"))).toBe(version);

--- a/tests/fixtures/swift/DuplicateSemanticWindow.swift
+++ b/tests/fixtures/swift/DuplicateSemanticWindow.swift
@@ -1,0 +1,43 @@
+enum LargeContainer {
+    static let padding0 = 0
+    static let padding1 = 1
+    static let padding2 = 2
+    static let padding3 = 3
+    static let padding4 = 4
+    static let padding5 = 5
+    static let padding6 = 6
+    static let padding7 = 7
+    static func nestedMethod() -> Int {
+        let value0 = 0 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value1 = 1 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value2 = 2 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value3 = 3 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value4 = 4 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value5 = 5 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value6 = 6 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value7 = 7 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value8 = 8 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value9 = 9 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value10 = 10 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value11 = 11 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value12 = 12 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value13 = 13 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value14 = 14 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value15 = 15 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value16 = 16 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value17 = 17 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value18 = 18 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value19 = 19 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value20 = 20 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value21 = 21 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value22 = 22 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value23 = 23 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value24 = 24 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value25 = 25 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value26 = 26 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value27 = 27 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value28 = 28 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        let value29 = 29 // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        return value29
+    }
+}

--- a/tests/indexer-duplicate-chunk-ids.test.ts
+++ b/tests/indexer-duplicate-chunk-ids.test.ts
@@ -1,0 +1,142 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import PQueue from "p-queue";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { parseConfig } from "../src/config/schema.js";
+import type { ConfiguredProviderInfo } from "../src/embeddings/detector.js";
+import type { EmbeddingProviderInterface } from "../src/embeddings/provider.js";
+import { createFailedBatchWriter } from "../src/indexer/failed-state-persistence.js";
+import type { PendingChunk } from "../src/indexer/embedding-batches.js";
+import { Indexer } from "../src/indexer/index.js";
+import { Database, InvertedIndex, VectorStore } from "../src/native/index.js";
+
+describe("duplicate chunk ID indexing", () => {
+  let tempDir: string;
+  let database: Database;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "duplicate-chunk-ids-"));
+    database = new Database(path.join(tempDir, "codebase.db"));
+  });
+
+  afterEach(() => {
+    database.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("publishes only the last duplicate occurrence", async () => {
+    const config = parseConfig({
+      embeddingProvider: "custom",
+      customProvider: {
+        baseUrl: "http://localhost:11434/v1",
+        model: "duplicate-id-test-model",
+        dimensions: 3,
+        concurrency: 1,
+        requestIntervalMs: 0,
+      },
+      indexing: {
+        watchFiles: false,
+        retries: 0,
+        retryDelayMs: 1,
+      },
+    });
+    const indexer = new Indexer(tempDir, config, "opencode", {
+      indexPath: path.join(tempDir, "index"),
+    });
+    const storePath = path.join(tempDir, "vectors");
+    const store = new VectorStore(storePath, 3);
+    const addBatch = vi.spyOn(store, "addBatch");
+    const invertedIndex = new InvertedIndex(path.join(tempDir, "inverted.json"));
+    const embedBatch = vi.fn(async (texts: string[]) => ({
+      embeddings: texts.map(() => [0.1, 0.2, 0.3]),
+      totalTokensUsed: texts.length,
+    }));
+    const provider: EmbeddingProviderInterface = {
+      embedQuery: async () => ({ embedding: [0.1, 0.2, 0.3], tokensUsed: 1 }),
+      embedDocument: async () => ({ embedding: [0.1, 0.2, 0.3], tokensUsed: 1 }),
+      embedBatch,
+      getModelInfo: () => ({
+        model: "duplicate-id-test-model",
+        dimensions: 3,
+        maxTokens: 8192,
+        costPer1MTokens: 0,
+      }),
+    };
+    const configuredProviderInfo = {
+      provider: "custom",
+      credentials: { provider: "custom", baseUrl: "http://localhost:11434/v1" },
+      modelInfo: {
+        provider: "custom",
+        model: "duplicate-id-test-model",
+        dimensions: 3,
+        maxTokens: 8192,
+        costPer1MTokens: 0,
+        timeoutMs: 1_000,
+      },
+    } satisfies ConfiguredProviderInfo;
+    const pendingChunk = (chunkType: string, name: string): PendingChunk => ({
+      id: "duplicate-id",
+      texts: [{ text: `embedding for ${name}`, tokenCount: 3 }],
+      storageText: `embedding for ${name}`,
+      content: "same source content",
+      contentHash: "same-content-hash",
+      metadata: {
+        filePath: "src/Duplicate.swift",
+        startLine: 90,
+        endLine: 101,
+        chunkType,
+        name,
+        language: "swift",
+        hash: "same-content-hash",
+      },
+    });
+    const failedWriter = createFailedBatchWriter(path.join(tempDir, "failed-batches.json"));
+    const processPendingChunkBatch = indexer as unknown as {
+      processPendingChunkBatch(
+        chunks: PendingChunk[],
+        options: Record<string, unknown>,
+      ): Promise<{ indexedChunks: number; failedChunks: number }>;
+    };
+
+    try {
+      const result = await processPendingChunkBatch.processPendingChunkBatch([
+        pendingChunk("enum_declaration", "LargeContainer"),
+        pendingChunk("method_declaration", "nestedMethod"),
+      ], {
+        store,
+        provider,
+        invertedIndex,
+        database,
+        configuredProviderInfo,
+        queue: new PQueue({ concurrency: 1 }),
+        providerRateLimits: { concurrency: 1, intervalMs: 0, minRetryMs: 1, maxRetryMs: 1 },
+        rateLimitState: { backoffMs: 0 },
+        failedState: { writer: failedWriter, recordsWritten: 0 },
+        attemptCounts: new Map<string, number>(),
+        forceReembed: false,
+        reuseCachedEmbeddings: false,
+        incrementRepeatedFailures: true,
+      });
+
+      expect(embedBatch).toHaveBeenCalledTimes(1);
+      expect(embedBatch.mock.calls[0]?.[0]).toEqual(["embedding for nestedMethod"]);
+      expect(addBatch).toHaveBeenCalledTimes(1);
+      expect(addBatch.mock.calls[0]?.[0]).toHaveLength(1);
+      expect(result).toMatchObject({ indexedChunks: 1, failedChunks: 0 });
+      expect(store.count()).toBe(1);
+      expect(store.getMetadata("duplicate-id")?.name).toBe("nestedMethod");
+
+      store.save();
+      const reloadedStore = new VectorStore(storePath, 3);
+      reloadedStore.load();
+      expect(reloadedStore.count()).toBe(1);
+      expect(reloadedStore.getMetadata("duplicate-id")?.chunkType).toBe("method_declaration");
+    } finally {
+      failedWriter.cleanup();
+      await indexer.close();
+    }
+  });
+});

--- a/tests/native.test.ts
+++ b/tests/native.test.ts
@@ -413,6 +413,36 @@ public class AccountService {
       expect(methods.map((chunk) => chunk.name)).toEqual(["a", "b"]);
     });
 
+    it("should prefer nested Swift chunks when large declaration windows overlap exactly", () => {
+      const fixturePath = path.join(
+        process.cwd(),
+        "tests",
+        "fixtures",
+        "swift",
+        "DuplicateSemanticWindow.swift",
+      );
+      const content = fs.readFileSync(fixturePath, "utf-8");
+
+      const chunks = parseFile("LargeContainer.swift", content);
+      const duplicateKeys = new Set<string>();
+      const seenKeys = new Set<string>();
+      for (const chunk of chunks) {
+        const key = `${chunk.startLine}:${chunk.endLine}:${chunk.content}`;
+        if (seenKeys.has(key)) {
+          duplicateKeys.add(key);
+        }
+        seenKeys.add(key);
+      }
+
+      expect(duplicateKeys).toEqual(new Set());
+      expect(chunks.some(
+        (chunk) => chunk.chunkType === "method_declaration" && chunk.name === "nestedMethod",
+      )).toBe(true);
+      expect(chunks.find(
+        (chunk) => chunk.startLine === 19 && chunk.endLine === 30,
+      )).toMatchObject({ chunkType: "method_declaration", name: "nestedMethod" });
+    });
+
     it("should attach Swift line and block comments to declarations", () => {
       const chunks = parseFile(
         "Comments.swift",
@@ -1176,6 +1206,57 @@ const values = [1, 2].map(item => item * 2);
       expect(metadataMap.size).toBe(2);
       expect(metadataMap.get("chunk1")?.filePath).toBe("a.ts");
       expect(metadataMap.get("chunk3")?.chunkType).toBe("method");
+    });
+
+    it("should reject duplicate batch keys before mutating the store", () => {
+      const duplicateBatch = [
+        {
+          id: "duplicate",
+          vector: [1, 0, 0],
+          metadata: {
+            filePath: "container.swift",
+            startLine: 1,
+            endLine: 10,
+            chunkType: "enum_declaration",
+            language: "swift",
+            hash: "same-hash",
+          },
+        },
+        {
+          id: "duplicate",
+          vector: [0, 1, 0],
+          metadata: {
+            filePath: "container.swift",
+            startLine: 1,
+            endLine: 10,
+            chunkType: "method_declaration",
+            language: "swift",
+            hash: "same-hash",
+          },
+        },
+      ];
+
+      store.add("existing", [0, 0, 1], {
+        filePath: "existing.swift",
+        startLine: 1,
+        endLine: 1,
+        chunkType: "property_declaration",
+        language: "swift",
+        hash: "existing-hash",
+      });
+
+      expect(() => store.addBatch(duplicateBatch)).toThrow(/duplicate vector store keys/i);
+      expect(store.count()).toBe(1);
+      expect(store.getMetadata("existing")?.filePath).toBe("existing.swift");
+
+      store.addBatch([duplicateBatch[1]!]);
+      store.save();
+
+      const reloadedStore = new VectorStore(path.join(tempDir, "vectors"), 3);
+      reloadedStore.load();
+      expect(reloadedStore.count()).toBe(2);
+      expect(reloadedStore.getMetadata("existing")?.filePath).toBe("existing.swift");
+      expect(reloadedStore.getMetadata("duplicate")?.chunkType).toBe("method_declaration");
     });
 
     it("should replace existing keys when updating via batch", () => {

--- a/tests/pr-impact.test.ts
+++ b/tests/pr-impact.test.ts
@@ -30,7 +30,7 @@ function symbolExtractorMetadataKey(catalogIdentity: string): string {
 function setBranchMigrationMetadataCurrent(database: Database, catalogIdentity: string): void {
   const suffix = hashContent(catalogIdentity).slice(0, 24);
   database.setMetadata(`index.callGraphResolutionVersion.${suffix}`, "9");
-  database.setMetadata(`index.parser.swiftVersion.${suffix}`, "1");
+  database.setMetadata(`index.parser.swiftVersion.${suffix}`, "2");
   database.setMetadata(`index.parser.metalVersion.${suffix}`, "1");
   database.setMetadata(symbolExtractorMetadataKey(catalogIdentity), "1");
 }


### PR DESCRIPTION
## Summary

Prevent Swift semantic chunk collisions from corrupting vector-store structure during indexing.

The failure surfaced at final publication as errors such as `Vector store structure mismatch: vectors=2772, ids=2772, keys=2768, metadata=2768`. Swift parsing could emit a large declaration window and a more precise nested declaration with the same file span and content. Because chunk IDs hash only the file path, span, and content, both chunks received the same ID. The vector store inserted both positional vectors while its key and metadata maps overwrote the repeated key, so validation rejected the index and search remained unavailable.

## Changes

- Deduplicate Swift semantic chunks by `(startLine, endLine, content)` after semantic splitting, keeping the later nested chunk, and bump `SWIFT_PARSER_VERSION` to `2` so existing Swift files are reparsed.
- Deduplicate indexer batches last-wins by chunk ID before statistics, pending work, embeddings, retries/recovery, and `VectorStore.addBatch`.
- Reject duplicate keys atomically inside the native vector store before mutation while preserving normal replacement of keys already stored.
- Add regression coverage for the synthetic Swift overlap, indexer batching, atomic native-store rejection, persistence/reload, and parser-version migration.
- Document the fix under `Unreleased > Fixed`.

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run`)
- [x] Lint passes (`npm run lint`)

Full gate: `npm run build && npm run typecheck && npm run lint && npm run test:run` with 106 test files and 1,677 tests passing.

The rebuilt native parser was also run against the four reported Swift files. Duplicate tuple counts dropped from `4`, `233`, `42`, and `25` to zero.

Two independent review-loop passes returned `No findings.` on worktree fingerprint `3bdd64e96f04a130f9119821c6f1391dfd697ad9710eaee77810d5e469e6591e`.

## Release Labels

- [ ] `bug` requested
- [ ] `semver:patch` requested

The connected GitHub App cannot apply labels to the canonical repository (`403 Resource not accessible by integration`), so a maintainer must apply these two requested labels.

## Related Issues

No linked issue.