### PR TITLE
fix: restore representative retrieval quality gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Context retrieval quality**: Code-focused `codebase_context` searches now honor source-path prioritization, and explicit definition lookups retry without invalid directory or file-type hints before reporting a miss while remaining definition-only.
 - **Swift indexing stability**: Deduplicated identical Swift chunk windows before embedding, rejected duplicate native vector-store batch keys atomically, and bumped the Swift parser cache version so existing indexes are reparsed.
 - **Transitive dependency security**: Pinned `fast-uri` to 3.1.6 and `qs` to 6.16.0 through npm overrides, resolving the current URI parsing and query-string parsing Dependabot advisories in the MCP runtime dependency tree.
 

--- a/src/indexer/index.ts
+++ b/src/indexer/index.ts
@@ -5688,7 +5688,10 @@ export class Indexer {
     const rrfK = this.config.search.rrfK;
     const rerankTopN = this.config.search.rerankTopN;
     const filterByBranch = options?.filterByBranch ?? true;
-    const sourceIntent = options?.definitionIntent === true || classifyQueryIntentRaw(query) === "source";
+    const sourceIntent =
+      options?.definitionIntent === true ||
+      options?.prioritizeSourcePaths === true ||
+      classifyQueryIntentRaw(query) === "source";
     const prioritizeSourcePaths = sourceIntent || options?.prioritizeSourcePaths === true;
     const identifierHints = extractIdentifierHints(query);
     const candidateLimit = maxResults * (prioritizeSourcePaths ? 12 : 4);

--- a/src/tools/context-search.ts
+++ b/src/tools/context-search.ts
@@ -494,6 +494,37 @@ export async function resolveSearchContext(
       );
     }
 
+    if (explicitSymbol && hasFilters) {
+      const relaxedDefinitionResults = await tryDefinitionLookup(
+        definitionSymbol,
+        Boolean(explicitSymbol),
+        unscopedScope,
+        relaxedFields,
+      );
+      if (relaxedDefinitionResults.length > 0) {
+        const heading = buildPackHeading("definition", decisions);
+        return toResult(
+          "definition",
+          definitionSymbol,
+          buildContextPack(relaxedDefinitionResults, {
+            tokenBudget,
+            maxResults: limit,
+            heading,
+            preserveInputOrder: true,
+            ...(input.diagnostic ? {
+              trace: (trace) => {
+                const attemptState = findSuccessfulAttemptState("definition");
+                if (attemptState) {
+                  attemptState.contextPackTrace = trace;
+                }
+              },
+            } : undefined),
+          }),
+          findSuccessfulAttemptState("definition"),
+        );
+      }
+    }
+
     if (explicitSymbol) {
       const heading = buildRecoveryFallbackText(
         attempts,

--- a/tests/tools-context.test.ts
+++ b/tests/tools-context.test.ts
@@ -674,6 +674,52 @@ describe("native OpenCode codebase_context", () => {
     expect(result.details?.recovery?.successfulAttemptIndex).toBeUndefined();
   });
 
+  it("relaxes invalid scope filters for explicit-symbol definition lookup", async () => {
+    const lookup = vi.fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{
+        filePath: "src/indexer/index.ts",
+        startLine: 100,
+        endLine: 110,
+        name: "getStatus",
+        chunkType: "method",
+        content: "source",
+        score: 0.99,
+      }]);
+
+    const result = await resolveSearchContext({
+      query: "find the getStatus method definition",
+      symbol: "getStatus",
+      limit: 10,
+      tokenBudget: 128,
+      fileType: undefined,
+      directory: "does/not/exist",
+      diagnostic: true,
+    }, {
+      lookup,
+      search: vi.fn(),
+    });
+
+    expect(lookup).toHaveBeenNthCalledWith(1, "getStatus", 100, {
+      fileType: undefined,
+      directory: "does/not/exist",
+    }, true, expect.any(Function));
+    expect(lookup).toHaveBeenNthCalledWith(2, "getStatus", 100, {}, true, expect.any(Function));
+    expect(result.text).toContain("src/indexer/index.ts:100-110");
+    expect(result.text).toContain("Recovery: directory filter removed.");
+    expect(result.details?.recovery?.successfulAttemptIndex).toBe(1);
+    expect(result.details?.diagnostic?.contextPackTrace).toMatchObject({
+      selectedCandidates: [{
+        filePath: "src/indexer/index.ts",
+        startLine: 100,
+        endLine: 110,
+        score: 0.99,
+        chunkType: "method",
+        name: "getStatus",
+      }],
+    });
+  });
+
   it("does not duplicate identical conceptual attempts", async () => {
     const search = vi.fn()
       .mockResolvedValueOnce([])
@@ -703,6 +749,10 @@ describe("native OpenCode codebase_context", () => {
   });
 
   it("fits all-failure output to the provided token budget", async () => {
+    const search = vi.fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
     const result = await resolveSearchContext(
       {
         query: "where is neverFound defined",
@@ -714,19 +764,33 @@ describe("native OpenCode codebase_context", () => {
       },
       {
         lookup: vi.fn().mockResolvedValue([]),
-        search: vi.fn()
-          .mockResolvedValueOnce([])
-          .mockResolvedValueOnce([]),
+        search,
       },
     );
 
     expect(countContextTokens(result.text)).toBeLessThanOrEqual(128);
     expect(result.details?.tokenEstimate).toBe(countContextTokens(result.text));
     expect(result.details?.route).toBe("definition");
-    expect(result.details?.recovery?.attempts).toHaveLength(1);
+    expect(result.details?.recovery?.attempts).toEqual([
+      {
+        kind: "definition",
+        scope: "scoped",
+        resultCount: 0,
+        relaxedFields: [],
+      },
+      {
+        kind: "definition",
+        scope: "unscoped",
+        resultCount: 0,
+        relaxedFields: ["directory", "fileType"],
+      },
+    ]);
+    expect(result.text).toContain("No definition found.");
+    expect(result.text).toContain("Recovery: directory filter removed; file-type filter removed.");
+    expect(search).not.toHaveBeenCalled();
   });
 
-  it("keeps explicit symbols definition-only within their normalized scope", async () => {
+  it("keeps explicit symbols definition-only while relaxing their normalized scope", async () => {
     const lookup = vi.fn()
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([{
@@ -749,10 +813,14 @@ describe("native OpenCode codebase_context", () => {
       directory: " ./src\\tools/ ",
     }, { lookup, search });
 
-    expect(lookup).toHaveBeenCalledOnce();
+    expect(lookup).toHaveBeenCalledTimes(2);
     expect(lookup).toHaveBeenNthCalledWith(1, "resolveSearchContext", 100, {
       fileType: "ts",
       directory: "src/tools",
+    }, true, undefined);
+    expect(lookup).toHaveBeenNthCalledWith(2, "resolveSearchContext", 100, {
+      fileType: undefined,
+      directory: undefined,
     }, true, undefined);
     expect(search).not.toHaveBeenCalled();
     expect(result.details).toMatchObject({
@@ -760,7 +828,8 @@ describe("native OpenCode codebase_context", () => {
       routedQuery: "resolveSearchContext",
       truncated: expect.any(Boolean),
     });
-    expect(result.text).toContain("No definition found.");
+    expect(result.text).toContain("src/tools/context.ts:1-4");
+    expect(result.text).not.toContain("No definition found.");
     expect(result.text).not.toContain("resolveSearchContext  ");
     expect(result.details?.tokenEstimate).toBe(countContextTokens(result.text));
   });


### PR DESCRIPTION
## Summary

- honor contextual source-path prioritization for code-focused searches
- retry explicit definition lookup without invalid directory or file-type hints while keeping the route definition-only
- preserve recovery diagnostics and document the behavior

Fixes #338.

## Validation

- Exact representative-retrieval v2.2.0 full evaluation: Hit@5 **75.00%**, MRR@10 **0.6354**, p95 **411.042 ms**
- Scoped recovery query: route, outcome, and recovery all matched; `getStatus` ranked first
- `npm run build && npm run typecheck && npm run lint && npm run test:run`
- 109 test files and 1,774 tests passed
