### PR TITLE
release: v1.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "codebase-index",
       "description": "Semantic code search and codebase graph tools for Claude Code",
       "source": "./",
-      "version": "0.26.0"
+      "version": "1.0.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.26.0",
+  "version": "1.0.0",
   "description": "Semantic code search and codebase graph tools for Claude Code",
   "displayName": "Codebase Index",
   "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.26.0",
+  "version": "1.0.0",
   "description": "Semantic code search and codebase graph tools for Codex",
   "author": {
     "name": "Kenneth",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- **Node.js runtime requirement**: Raised the minimum supported Node.js version from 20 to 22.13 in preparation for planned PDF text indexing. CI tests Node.js 22 and 24, with packed-package smoke checks on 22.13. Node.js 24 LTS remains recommended and is used for release packaging. PDF indexing is not included in this release.
+## [1.0.0] - 2026-09-08
 
 ### Added
 
-- **Cancellable and diagnosable MCP operations**: Added inactivity-based cancellation, exact-token monotone progress, redacted structured handler errors, and durable per-process phase diagnostics exposed by `index_status`. Shared indexing detaches cancelled callers without stopping work still awaited by another consumer, while exclusively owned cancelled work rolls back and releases its index lease. MCP SDK `1.29.0`, public tool names, package identities, and index formats remain unchanged.
+- **Cancellable and diagnosable MCP operations**: All MCP tools now support cooperative cancellation, exact-token monotone progress, and inactivity detection through `mcp.stallTimeoutMs`, which defaults to five minutes and can be disabled with `0`. Failures consistently return `isError: true` with a redacted `structuredContent.error`, while seven-day runtime records under `<indexRoot>/mcp-runtime/` are summarized by `index_status.mcpDiagnostics`. Shared indexing detaches cancelled callers without stopping work still awaited by another consumer, while exclusively owned cancelled work rolls back and releases its index lease. MCP SDK `1.29.0`, public tool names, request schemas, package identities, and index formats remain unchanged.
+
+### Changed
+
+- **Breaking Node.js runtime requirement**: Raised the minimum supported Node.js version from 20 to 22.13 in preparation for planned PDF text indexing. CI tests Node.js 22 and 24, with packed-package smoke checks on 22.13. Node.js 24 LTS remains recommended and is used for release packaging. The bundled `@opencode-ai/plugin` dependency is pinned to `1.3.13` to preserve the Node.js 22.13 runtime floor, while its peer compatibility range remains `^1.0.0`. PDF indexing is not included in this release.
 
 ### Fixed
 
 - **Context retrieval quality**: Code-focused `codebase_context` searches now honor source-path prioritization, and explicit definition lookups retry without invalid directory or file-type hints before reporting a miss while remaining definition-only.
-- **Swift indexing stability**: Deduplicated identical Swift chunk windows before embedding, rejected duplicate native vector-store batch keys atomically, and bumped the Swift parser cache version so existing indexes are reparsed.
+- **Swift indexing stability**: Deduplicated identical Swift chunk windows, applied deterministic last-wins chunk-ID deduplication before embedding and publication, rejected duplicate native vector-store batch keys atomically, and bumped the Swift parser cache version so existing indexes receive a one-time reparse.
 - **Transitive dependency security**: Pinned `fast-uri` to 3.1.6 and `qs` to 6.16.0 through npm overrides, resolving the current URI parsing and query-string parsing Dependabot advisories in the MCP runtime dependency tree.
 
 ## [0.26.0] - 2026-08-29

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.26.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.26.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.26.0",
+  "version": "1.0.0",
   "description": "Host-neutral semantic codebase search with embeddings, symbol discovery, and call-graph tooling",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v1.0.0

### Included

- Cancellable and diagnosable MCP operations with cooperative cancellation, inactivity detection, progress, redacted structured errors, and durable `index_status` diagnostics.
- Deterministic Swift and vector-batch duplicate chunk-key hardening with automatic Swift reparse.
- Restored representative retrieval quality with source-aware context ranking and scoped explicit-definition recovery.
- Patched runtime dependency advisories for `fast-uri` and `qs`.
- Raised the public Node.js minimum to 22.13, with Node.js 24 recommended and Node.js 22/24 CI coverage.

### Release metadata

- Bumps package, lockfile, Claude, and Codex metadata to `1.0.0`.
- Moves the reconciled Unreleased notes into the dated `1.0.0` changelog section.

### Validation

- `npm run build && npm run typecheck && npm run lint && npm run test:run`
- 109 test files and 1,774 tests passed.
- `npm run smoke:package`
- `npm audit --omit=dev --audit-level=high` reported zero production vulnerabilities.
- Hosted full representative evaluation passed on merged main: Hit@5 75.00%, MRR@10 0.6354.
