### PR TITLE
fix(deps): patch Hono, js-yaml, and nanoid security advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Transitive dependency security**: Updated dependency overrides for `hono` to `4.13.5` and `js-yaml` to `4.3.2`, with a lockfile-only bump of `nanoid` to `3.3.18`, addressing the current security advisories in these packages.
 - **PDF definition exclusion**: Definition-oriented retrieval now excludes PDF passages before ranking and external reranking, while ordinary document search retains page-aware results.
 
 ## [0.27.0] - 2026-09-08

--- a/package-lock.json
+++ b/package-lock.json
@@ -7093,9 +7093,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.34",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
-      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
+      "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -7271,9 +7271,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -7820,9 +7820,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -127,14 +127,14 @@
     "brace-expansion": "5.0.9",
     "express-rate-limit": "8.5.2",
     "fast-uri": "3.1.6",
-    "hono": "4.12.34",
+    "hono": "4.13.5",
     "ip-address": "10.4.0",
     "postcss": "8.5.26",
     "qs": "6.16.0",
     "vite": "8.0.16",
     "esbuild": "0.28.1",
     "body-parser": "2.3.0",
-    "js-yaml": "4.3.1",
+    "js-yaml": "4.3.2",
     "undici": "8.10.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary

Patch the dependencies behind the four current GitHub Dependabot alerts and the additional nanoid advisory reported by npm audit. Full and production-only npm audits on this branch both report zero vulnerabilities.

## Changes

- Update the existing Hono override from `4.12.34` to `4.13.5`, addressing the three runtime dependency advisories.
- Update the existing js-yaml override from `4.3.1` to `4.3.2`, addressing the development dependency CPU-exhaustion advisory.
- Update locked nanoid from `3.3.17` to `3.3.18` within PostCSS's existing compatible range. No new override or direct dependency is introduced.
- Add an Unreleased changelog entry. Only these three package records change in the lockfile. No application code, test assertions, runtime floor, or package version changes.

## Testing

Validation on the dependency changes committed as `415f5a6`, locally on macOS ARM64 / Node.js 26.6.0:

- `npm ci`: passed, 492 packages installed, zero audit findings.
- `npm audit --json` and `npm audit --omit=dev --json`: both zero vulnerabilities. Before remediation the audit reported seven affected-package entries, including transitive parents and nanoid.
- `npm ls hono js-yaml nanoid --depth=4`: confirms patched versions in the MCP SDK, build, and lint dependency paths.
- `npm run build && npm run typecheck && npm run lint`: passed. Build includes native compilation and real built CLI/MCP initialization/shutdown and CJS smoke checks.
- `npx vitest run --coverage --no-file-parallelism`: all **1,818 tests in 114 files** passed with V8 coverage. Native code was rebuilt first. No tests, assertions, or coverage configuration were weakened.
- `npm run smoke:package`: passed clean packed-install checks for both package identities.

Hosted validation on `415f5a6` is complete: all 14 checks pass, including the full Node.js 22/24 jobs, all six OS/runtime path-and-watcher jobs, CodeQL, and release-label validation. Audit results are point-in-time dependency checks, not a claim that every vulnerable function was reachable or that all security risks are eliminated. GitHub alerts remain on default-branch dependencies until this PR is merged and rescanned.

- [ ] Unit tests added/updated (not applicable: dependency-only changes, existing full suite exercised)
- [x] Manual testing performed
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run` suite, executed with coverage as documented above)
- [x] Lint passes (`npm run lint`)

## Release Labels

- [x] Added at least one release category label (`dependencies`)
- [x] Added at most one semver label (`semver:patch`)

## Related Issues

Addresses Dependabot alerts [47](https://github.com/Helweg/open-codebase-index/security/dependabot/47), [48](https://github.com/Helweg/open-codebase-index/security/dependabot/48), [49](https://github.com/Helweg/open-codebase-index/security/dependabot/49), and [50](https://github.com/Helweg/open-codebase-index/security/dependabot/50).

Also addresses nanoid advisory [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8), observed in npm audit.

