### PR TITLE
release: v0.28.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "codebase-index",
       "description": "Semantic code search and codebase graph tools for Claude Code",
       "source": "./",
-      "version": "0.27.0"
+      "version": "0.28.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "Semantic code search and codebase graph tools for Claude Code",
   "displayName": "Codebase Index",
   "author": {

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codebase-index",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "Semantic code search and codebase graph tools for Codex",
   "author": {
     "name": "Kenneth",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.0] - 2026-09-10
+
 ### Added
 
 - **Semantic XML and SVG indexing**: Added native, opt-in XML element extraction and accessible SVG text extraction. SVG geometry, style, class, and layer metadata are excluded from embeddings, search and similarity results, and external reranker documents, including when a file exceeds the semantic chunk cap. Markup retrieval reconstructs the indexed semantic chunk without raw context lines and reports unavailable content when the source no longer matches.
 - **Opt-in PDF text indexing**: Explicit PDF include patterns now use a shared binary-aware ingestion path across CLI, MCP, OpenCode, and Pi. Text is extracted locally into deterministic page-aware chunks, persisted for vector and keyword retrieval, retries, branch indexes, snippets, and reranking, and returned with truthful physical-page citations. Incremental updates, invalid replacements, renames, and deletions remove stale passages without blocking valid files. PDF discovery remains disabled by default; OCR and password entry are not supported.
 
+### Changed
+
+- **Test tooling**: Upgraded Vitest and its V8 coverage provider together to 5.0.0, keeping test and coverage tooling aligned.
+
 ### Fixed
 
+- **PDF page preservation in search**: Evidence deduplication now distinguishes physical PDF page ranges, so passages on different pages are not collapsed merely because they share page-local line numbers or identical text. Same-page and ordinary code deduplication remain unchanged.
 - **Transitive dependency security**: Updated dependency overrides for `hono` to `4.13.5` and `js-yaml` to `4.3.2`, with a lockfile-only bump of `nanoid` to `3.3.18`, addressing the current security advisories in these packages.
 - **PDF definition exclusion**: Definition-oriented retrieval now excludes PDF passages before ranking and external reranking, while ordinary document search retains page-aware results.
 
@@ -754,7 +761,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - File watcher for automatic re-indexing
 - OpenCode tools: `codebase_search`, `index_codebase`, `index_status`, `index_health_check`
 
-[Unreleased]: https://github.com/Helweg/open-codebase-index/compare/v0.22.2...HEAD
+[Unreleased]: https://github.com/Helweg/open-codebase-index/compare/v0.28.0...HEAD
+[0.28.0]: https://github.com/Helweg/open-codebase-index/compare/v0.27.0...v0.28.0
 [0.22.2]: https://github.com/Helweg/open-codebase-index/compare/v0.22.1...v0.22.2
 [0.22.1]: https://github.com/Helweg/open-codebase-index/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/Helweg/open-codebase-index/compare/v0.21.0...v0.22.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-codebase-index",
-      "version": "0.27.0",
+      "version": "0.28.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-codebase-index",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "Host-neutral semantic codebase search with embeddings, symbol discovery, and call-graph tooling",
   "type": "module",
   "main": "dist/index.js",

--- a/src/indexer/intent-aware-ranking.ts
+++ b/src/indexer/intent-aware-ranking.ts
@@ -409,6 +409,13 @@ function containsRange(outer: ChunkMetadata, inner: ChunkMetadata): boolean {
 
 function areDuplicateEvidence(a: RankedCandidate, b: RankedCandidate): boolean {
   if (normalizePath(a.metadata.filePath) !== normalizePath(b.metadata.filePath)) return false;
+  const aLocation = a.metadata.documentLocation;
+  const bLocation = b.metadata.documentLocation;
+  if (aLocation?.kind === "pdf" || bLocation?.kind === "pdf") {
+    if (aLocation?.kind !== bLocation?.kind
+      || aLocation?.pageStart !== bLocation?.pageStart
+      || aLocation?.pageEnd !== bLocation?.pageEnd) return false;
+  }
   const aName = normalizeRankingText(a.metadata.name ?? "");
   const bName = normalizeRankingText(b.metadata.name ?? "");
   const sameNamedSymbol = aName.length > 0 && aName === bName;

--- a/tests/mcp-operation-execution.test.ts
+++ b/tests/mcp-operation-execution.test.ts
@@ -68,6 +68,8 @@ describe("MCP operation execution", () => {
 
   afterEach(async () => {
     await resetAutoIndexCoordinatorsForTests();
+    // Failed operations return before diagnostic completion finishes persisting.
+    await runtime.diagnostics.markOrderedShutdown();
     vi.useRealTimers();
     configCache.delete(getIndexerCacheKey(projectRoot, "jcode"));
     fs.rmSync(projectRoot, { recursive: true, force: true });

--- a/tests/mcp-runtime-diagnostics.test.ts
+++ b/tests/mcp-runtime-diagnostics.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { McpRuntimeDiagnostics } from "../src/adapters/mcp/runtime-diagnostics.js";
 
@@ -38,6 +38,39 @@ describe("MCP runtime diagnostics", () => {
       schemaVersion: 1,
       activeOperations: [],
     });
+  });
+
+  it("drains pending completion persistence during ordered shutdown", async () => {
+    const diagnostics = new McpRuntimeDiagnostics(indexRoot);
+    const operation = await diagnostics.begin("index_codebase");
+    let releaseWrite!: () => void;
+    let markWriteStarted!: () => void;
+    const writeGate = new Promise<void>((resolve) => { releaseWrite = resolve; });
+    const writeStarted = new Promise<void>((resolve) => { markWriteStarted = resolve; });
+    const mkdir = fs.promises.mkdir.bind(fs.promises);
+    const mkdirSpy = vi.spyOn(fs.promises, "mkdir").mockImplementationOnce(async (...args) => {
+      markWriteStarted();
+      await writeGate;
+      return mkdir(...args);
+    });
+    const completion = operation.complete();
+    let shutdown: Promise<void> | undefined;
+    let shutdownSettled = false;
+    try {
+      await writeStarted;
+      // complete() has removed the active entry, but its disk write is still blocked.
+      shutdown = diagnostics.markOrderedShutdown().then(() => { shutdownSettled = true; });
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(shutdownSettled).toBe(false);
+      releaseWrite();
+      await shutdown;
+      expect(fs.readdirSync(path.join(indexRoot, "mcp-runtime"))).toEqual([]);
+    } finally {
+      releaseWrite();
+      await completion;
+      await shutdown;
+      mkdirSpy.mockRestore();
+    }
   });
 
   it("corrects permissions on an existing runtime directory", async () => {

--- a/tests/pdf-indexer.test.ts
+++ b/tests/pdf-indexer.test.ts
@@ -115,6 +115,31 @@ describe("PDF Indexer integration", () => {
       .some((item) => item.filePath.endsWith("guide.pdf"))).toBe(false);
   });
 
+  it("returns both physical PDF pages across a blank middle page before and after restart", async () => {
+    fs.writeFileSync(path.join(tempDir, "guide.pdf"), buildPdfFixture([
+      { lines: ["Repeated searchable page marker"] },
+      { empty: true },
+      { lines: ["Repeated searchable page marker"] },
+    ]));
+    const indexer = createIndexer();
+    await indexer.forceIndex();
+    const assertPages = async (active: Indexer): Promise<void> => {
+      const results = (await active.search("Repeated searchable page marker", 10))
+        .filter((result) => result.filePath.endsWith("guide.pdf"));
+      expect(results).toHaveLength(2);
+      expect(results.map((result) => result.documentLocation?.pageStart).sort()).toEqual([1, 3]);
+      for (const result of results) {
+        expect(result.content).toBe("Repeated searchable page marker");
+        expect(result.documentLocation).toEqual({
+          kind: "pdf", pageStart: result.documentLocation?.pageStart, pageEnd: result.documentLocation?.pageStart,
+        });
+      }
+    };
+    await assertPages(indexer);
+    await indexer.close();
+    await assertPages(createIndexer());
+  });
+
   it("excludes PDF passages from definition intent while retaining code definitions", async () => {
     const indexer = createIndexer();
     await indexer.forceIndex();

--- a/tests/retrieval-ranking.test.ts
+++ b/tests/retrieval-ranking.test.ts
@@ -56,6 +56,29 @@ describe("retrieval ranking", () => {
     }
   });
 
+  it.each([
+    { label: "different pages with equal lines", aPage: 1, bPage: 3, bEnd: 3, bLine: 1, bHash: "different", count: 2 },
+    { label: "different pages with equal hashes", aPage: 1, bPage: 3, bEnd: 3, bLine: 20, bHash: "hash", count: 2 },
+    { label: "different page ends", aPage: 1, bPage: 1, bEnd: 3, bLine: 1, bHash: "hash", count: 2 },
+    { label: "PDF versus non-PDF", aPage: 1, bPage: undefined, bEnd: undefined, bLine: 1, bHash: "hash", count: 2 },
+    { label: "non-PDF versus PDF", aPage: undefined, bPage: 1, bEnd: 1, bLine: 1, bHash: "hash", count: 2 },
+    { label: "same-page equal lines", aPage: 1, bPage: 1, bEnd: 1, bLine: 1, bHash: "different", count: 1 },
+    { label: "same-page equal hashes", aPage: 1, bPage: 1, bEnd: 1, bLine: 20, bHash: "hash", count: 1 },
+    { label: "code equal lines", aPage: undefined, bPage: undefined, bEnd: undefined, bLine: 1, bHash: "different", count: 1 },
+    { label: "code equal hashes", aPage: undefined, bPage: undefined, bEnd: undefined, bLine: 20, bHash: "hash", count: 1 },
+  ])("preserves deduplication boundaries: $label", ({ aPage, bPage, bEnd, bLine, bHash, count }) => {
+    const candidates: Candidate[] = [
+      { id: "a", score: 0.9, metadata: meta({
+        documentLocation: aPage === undefined ? undefined : { kind: "pdf", pageStart: aPage, pageEnd: aPage },
+      }) },
+      { id: "b", score: 0.8, metadata: meta({
+        startLine: bLine, endLine: bLine + 9, hash: bHash,
+        documentLocation: bPage === undefined ? undefined : { kind: "pdf", pageStart: bPage, pageEnd: bEnd! },
+      }) },
+    ];
+    expect(rankSemanticOnlyResults("page marker", candidates, { rerankTopN: 10, limit: 10 })).toHaveLength(count);
+  });
+
   it("fuses hybrid results using RRF rank ordering", () => {
     const semantic: Candidate[] = [
       { id: "a", score: 0.91, metadata: meta({ filePath: "/repo/src/auth.ts", name: "validateAuth", chunkType: "function" }) },


### PR DESCRIPTION
## Summary

Prepare **v0.28.0** from the changes already merged into `main` through `4393a3bd8e79afcf41ffb819f1ce287c6348e218`. The full delta since v0.27.0 includes opt-in PDF indexing (#343), semantic XML/SVG indexing (#342), dependency security fixes (#345), and aligned Vitest/V8 coverage upgrades (#344), so a minor release is appropriate.

The separate `feat/reliable-change-context` branch is explicitly **not included**. Clean installed-package validation also exposed a PDF cross-page deduplication blocker, corrected here before publication.

## Changes

- Bump package and lockfile root versions to 0.28.0 for synchronized publication of both npm identities.
- Synchronize Claude, Codex and Claude marketplace versions.
- Preserve distinct physical PDF pages before line/hash deduplication. Add regression coverage for same-line/same-hash pages, mixed metadata, ordinary code, and index/search/restart with a blank middle page.
- Reconcile CHANGELOG against the complete v0.27.0-to-main delta, include the tooling update, and update the release comparison link.

## Testing

Clean isolated checkout, verified Node.js 22.21.1 on macOS ARM64. Native build was bootstrapped before the built-CLI smoke because a clean checkout has no native artifact.

- [x] Unit tests added/updated: page-aware deduplication and PDF search/restart regressions; existing version-contract tests executed.
- [x] Manual testing performed: staged clean-package CLI smoke for both package identities.
- [x] Build passes (`npm run build`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Tests pass (`npm run test:run -- --maxWorkers=1`): **1,865 tests, 114 files**
- [x] Lint passes (`npm run lint`)

Additional checks: `npm ci`, full and production-only npm audits report **0 vulnerabilities**, and `npm run smoke:package` passes. Exact current-main CI and evaluation workflows are green. Independent clean installs of both staged tarballs passed live local-Ollama PDF page-1/page-3 search and restart, SVG sanitization under chunk caps/context expansion, ESM/CJS imports, MCP initialization through all aliases, and full/production consumer audits (0 vulnerabilities). This PR's exact-head CI remains required before merge/publication.

## Release Labels

- [x] Added a release category label: `feature` (same convention as release PR #341).
- [x] Added one semver label: `semver:minor`.

## Related Issues

Releases merged PRs #342, #343, #344 and #345. No new issue is closed by this metadata PR.
